### PR TITLE
Error out instead of panic

### DIFF
--- a/disk/src/lib.rs
+++ b/disk/src/lib.rs
@@ -123,7 +123,7 @@ impl Storage {
         let mut file = OpenOptions::new().read(true).open(&next_file_path)?;
 
         // Load file into memory and delete it
-        let metadata = fs::metadata(&next_file_path).expect("unable to read metadata");
+        let metadata = fs::metadata(&next_file_path)?;
         self.prepare_current_read_buffer(metadata.len() as usize);
         file.read_exact(&mut self.current_read_file[..])?;
         self.remove(id)?;

--- a/uplink/src/base/actions/mod.rs
+++ b/uplink/src/base/actions/mod.rs
@@ -236,8 +236,8 @@ impl Package for Buffer<ActionResponse> {
         return self.topic.clone();
     }
 
-    fn serialize(&self) -> Vec<u8> {
-        serde_json::to_vec(&self.buffer).unwrap()
+    fn serialize(&self) -> serde_json::Result<Vec<u8>> {
+        serde_json::to_vec(&self.buffer)
     }
 
     fn anomalies(&self) -> Option<(String, usize)> {

--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -75,6 +75,8 @@ pub trait Point: Send + Debug {
 
 pub trait Package: Send + Debug {
     fn topic(&self) -> Arc<String>;
+    // TODO: Implement a generic Return type that can wrap
+    // around custom serialization error types.
     fn serialize(&self) -> serde_json::Result<Vec<u8>>;
     fn anomalies(&self) -> Option<(String, usize)>;
 }

--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -15,8 +15,6 @@ pub mod serializer;
 pub enum Error {
     #[error("Send error {0}")]
     Send(#[from] SendError<Box<dyn Package>>),
-    #[error("Serde error {0}")]
-    Serde(#[from] serde_json::Error),
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -15,6 +15,8 @@ pub mod serializer;
 pub enum Error {
     #[error("Send error {0}")]
     Send(#[from] SendError<Box<dyn Package>>),
+    #[error("Serde error {0}")]
+    Serde(#[from] serde_json::Error),
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -75,7 +77,7 @@ pub trait Point: Send + Debug {
 
 pub trait Package: Send + Debug {
     fn topic(&self) -> Arc<String>;
-    fn serialize(&self) -> Vec<u8>;
+    fn serialize(&self) -> serde_json::Result<Vec<u8>>;
     fn anomalies(&self) -> Option<(String, usize)>;
 }
 

--- a/uplink/src/base/serializer.rs
+++ b/uplink/src/base/serializer.rs
@@ -26,8 +26,6 @@ pub enum Error {
     UnexpectedPacket(Packet),
     #[error("Storage is disabled/missing")]
     MissingPersistence,
-    #[error("Stream to push Serializer Metrics is missing")]
-    MissingMetricsStream,
 }
 
 enum Status {
@@ -81,7 +79,7 @@ impl Serializer {
         collector_rx: Receiver<Box<dyn Package>>,
         client: AsyncClient,
     ) -> Result<Serializer, Error> {
-        let metrics_config = config.streams.get("metrics").ok_or(Error::MissingMetricsStream)?;
+        let metrics_config = config.streams.get("metrics").expect("Missing metrics Stream in config");
         let metrics = Metrics::new(&metrics_config.topic);
 
         let storage = match &config.persistence {

--- a/uplink/src/base/serializer.rs
+++ b/uplink/src/base/serializer.rs
@@ -24,8 +24,6 @@ pub enum Error {
     Client(#[from] ClientError),
     #[error("Packet was not expected {0:?}")]
     UnexpectedPacket(Packet),
-    #[error("Request was not expected {0:?}")]
-    UnexpectedRequest(Request),
     #[error("Storage is disabled/missing")]
     MissingPersistence,
     #[error("Stream to push Serializer Metrics is missing")]
@@ -261,7 +259,7 @@ impl Serializer {
                         Ok(c) => c,
                         Err(ClientError::Request(request)) => match request.into_inner() {
                             Request::Publish(publish) => return Ok(Status::EventLoopCrash(publish)),
-                            request => return Err(Error::UnexpectedRequest(request)),
+                            request => unreachable!("{:?}", request),
                         },
                         Err(e) => return Err(e.into()),
                     };
@@ -339,7 +337,7 @@ impl Serializer {
 
             match failed.into_inner() {
                 Request::Publish(publish) => return Ok(Status::SlowEventloop(publish)),
-                request => return Err(Error::UnexpectedRequest(request)),
+                request => unreachable!("{:?}", request),
             };
         }
     }

--- a/uplink/src/collector/systemstats.rs
+++ b/uplink/src/collector/systemstats.rs
@@ -77,8 +77,8 @@ impl Package for Buffer<System> {
         self.topic.clone()
     }
 
-    fn serialize(&self) -> Vec<u8> {
-        serde_json::to_vec(&self.buffer).unwrap()
+    fn serialize(&self) -> serde_json::Result<Vec<u8>> {
+        serde_json::to_vec(&self.buffer)
     }
 
     fn anomalies(&self) -> Option<(String, usize)> {
@@ -146,8 +146,8 @@ impl Package for Buffer<Network> {
         self.topic.clone()
     }
 
-    fn serialize(&self) -> Vec<u8> {
-        serde_json::to_vec(&self.buffer).unwrap()
+    fn serialize(&self) -> serde_json::Result<Vec<u8>> {
+        serde_json::to_vec(&self.buffer)
     }
 
     fn anomalies(&self) -> Option<(String, usize)> {
@@ -218,8 +218,8 @@ impl Package for Buffer<Disk> {
         self.topic.clone()
     }
 
-    fn serialize(&self) -> Vec<u8> {
-        serde_json::to_vec(&self.buffer).unwrap()
+    fn serialize(&self) -> serde_json::Result<Vec<u8>> {
+        serde_json::to_vec(&self.buffer)
     }
 
     fn anomalies(&self) -> Option<(String, usize)> {
@@ -281,8 +281,8 @@ impl Package for Buffer<Processor> {
         self.topic.clone()
     }
 
-    fn serialize(&self) -> Vec<u8> {
-        serde_json::to_vec(&self.buffer).unwrap()
+    fn serialize(&self) -> serde_json::Result<Vec<u8>> {
+        serde_json::to_vec(&self.buffer)
     }
 
     fn anomalies(&self) -> Option<(String, usize)> {
@@ -356,8 +356,8 @@ impl Package for Buffer<Process> {
         self.topic.clone()
     }
 
-    fn serialize(&self) -> Vec<u8> {
-        serde_json::to_vec(&self.buffer).unwrap()
+    fn serialize(&self) -> serde_json::Result<Vec<u8>> {
+        serde_json::to_vec(&self.buffer)
     }
 
     fn anomalies(&self) -> Option<(String, usize)> {
@@ -480,7 +480,7 @@ impl StatCollector {
         );
         let system = SystemStats { stat: System::init(&sys), stream };
 
-        let timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis() as u64;
+        let timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_millis() as u64;
 
         StatCollector { sys, system, config, processes, disks, networks, processors, timestamp }
     }

--- a/uplink/src/collector/tcpjson.rs
+++ b/uplink/src/collector/tcpjson.rs
@@ -71,7 +71,7 @@ impl Bridge {
                         }
                     }
                     action = self.actions_rx.recv_async() => {
-                        let action = action.unwrap();
+                        let action = action?;
                         error!("Bridge down!! Action ID = {}", action.action_id);
                         let status = ActionResponse::failure(&action.action_id, "Bridge down");
                         if let Err(e) = action_status.fill(status).await {
@@ -215,8 +215,8 @@ impl Package for Buffer<Payload> {
         return self.topic.clone();
     }
 
-    fn serialize(&self) -> Vec<u8> {
-        serde_json::to_vec(&self.buffer).unwrap()
+    fn serialize(&self) -> serde_json::Result<Vec<u8>> {
+        serde_json::to_vec(&self.buffer)
     }
 
     fn anomalies(&self) -> Option<(String, usize)> {


### PR DESCRIPTION
Remove calls to `unwrap()` and `expect()` and instead return Errors