### PR TITLE
Add means to flush partially filled bridge partitions

### DIFF
--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -182,6 +182,7 @@ where
         }
     }
 
+    /// Method to force flush a Stream, triggers async channel send when called
     pub async fn flush(&mut self) -> Result<(), Error> {
         let name = self.name.clone();
         let topic = self.topic.clone();
@@ -191,6 +192,7 @@ where
         Ok(())
     }
 
+    /// Method to check if a Stream buffer is empty
     pub fn is_empty(&mut self) -> bool {
         self.buffer.buffer.is_empty()
     }

--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -139,6 +139,7 @@ where
         device_id: S,
         max_buffer_size: usize,
         tx: Sender<Box<dyn Package>>,
+        flush_period: Duration,
     ) -> Stream<T> {
         let stream = stream.into();
         let project_id = project_id.into();
@@ -152,8 +153,6 @@ where
             + &stream
             + "/jsonarray";
 
-        let flush_period = Duration::from_secs(10);
-
         Stream::new(stream, topic, max_buffer_size, tx, flush_period)
     }
 
@@ -162,8 +161,9 @@ where
         project_id: S,
         device_id: S,
         tx: Sender<Box<dyn Package>>,
+        flush_period: Duration,
     ) -> Stream<T> {
-        Stream::dynamic_with_size(stream, project_id, device_id, 100, tx)
+        Stream::dynamic_with_size(stream, project_id, device_id, 100, tx, flush_period)
     }
 
     fn add(&mut self, data: T) -> Result<Option<Buffer<T>>, Error> {

--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -5,7 +5,7 @@ use std::time::Instant;
 use std::{collections::HashMap, time::Duration};
 
 use flume::{SendError, Sender};
-use log::warn;
+use log::{warn, info};
 use serde::Deserialize;
 
 pub mod actions;
@@ -198,6 +198,8 @@ where
         {
             let name = self.name.clone();
             let topic = self.topic.clone();
+            info!("Flushing stream name: {}, topic: {}", name, topic);
+
             let buffer = mem::replace(&mut self.buffer, Buffer::new(name, topic));
             self.last_flushed = Instant::now();
             return Some(buffer);

--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -194,7 +194,7 @@ where
     // Pops buffer content if max_buffer_size is reached or timedout and not empty
     fn flush_buffer(&mut self) -> Option<Buffer<T>> {
         if self.buffer.buffer.len() >= self.max_buffer_size
-            || !self.is_empty() && self.last_flushed.elapsed() > self.flush_period
+            || (!self.is_empty() && self.last_flushed.elapsed() > self.flush_period)
         {
             let name = self.name.clone();
             let topic = self.topic.clone();

--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -306,8 +306,8 @@ impl<T> Clone for Stream<T> {
             max_buffer_size: self.max_buffer_size,
             buffer: Buffer::new(self.buffer.stream.clone(), self.buffer.topic.clone()),
             tx: self.tx.clone(),
-            flush_period: self.flush_period.clone(),
-            last_flushed: self.last_flushed.clone(),
+            flush_period: self.flush_period,
+            last_flushed: self.last_flushed,
         }
     }
 }

--- a/uplink/src/collector/simulator.rs
+++ b/uplink/src/collector/simulator.rs
@@ -26,7 +26,13 @@ impl Simulator {
         for (stream, config) in config.streams.clone() {
             partitions.insert(
                 stream.clone(),
-                Stream::new(stream, config.topic, config.buf_size, data_tx.clone()),
+                Stream::new(
+                    stream,
+                    config.topic,
+                    config.buf_size,
+                    data_tx.clone(),
+                    Duration::from_secs(10),
+                ),
             );
         }
 

--- a/uplink/src/collector/simulator.rs
+++ b/uplink/src/collector/simulator.rs
@@ -66,6 +66,7 @@ impl Simulator {
                         &self.config.project_id,
                         &self.config.device_id,
                         self.data_tx.clone(),
+                        Duration::from_secs(10),
                     );
                     self.partitions.entry(stream.to_owned()).or_insert(s)
                 }
@@ -82,6 +83,7 @@ impl Simulator {
                         &self.config.project_id,
                         &self.config.device_id,
                         self.data_tx.clone(),
+                        Duration::from_secs(10),
                     );
                     self.partitions.entry(stream.to_owned()).or_insert(s)
                 }

--- a/uplink/src/collector/systemstats.rs
+++ b/uplink/src/collector/systemstats.rs
@@ -417,6 +417,7 @@ impl StatCollector {
         sys.refresh_memory();
 
         let max_buf_size = config.stats.stream_size.unwrap_or(10);
+        let flush_period = Duration::from_secs(10);
 
         let mut map = HashMap::new();
         let stream = Stream::dynamic_with_size(
@@ -425,6 +426,7 @@ impl StatCollector {
             &config.device_id,
             max_buf_size,
             tx.clone(),
+            flush_period,
         );
         for disk_data in sys.disks() {
             let disk_name = disk_data.name().to_string_lossy().to_string();
@@ -439,6 +441,7 @@ impl StatCollector {
             &config.device_id,
             max_buf_size,
             tx.clone(),
+            flush_period,
         );
         for (net_name, _) in sys.networks() {
             map.insert(net_name.to_owned(), Network::init(net_name.to_owned()));
@@ -452,6 +455,7 @@ impl StatCollector {
             &config.device_id,
             max_buf_size,
             tx.clone(),
+            flush_period,
         );
         for proc in sys.processors().iter() {
             let proc_name = proc.name().to_owned();
@@ -465,6 +469,7 @@ impl StatCollector {
             &config.device_id,
             max_buf_size,
             tx.clone(),
+            flush_period,
         );
         let processes = ProcessStats { sequence: 0, map: HashMap::new(), stream };
 
@@ -474,10 +479,12 @@ impl StatCollector {
             &config.device_id,
             max_buf_size,
             tx.clone(),
+            flush_period,
         );
         let system = SystemStats { stat: System::init(&sys), stream };
 
-        let timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_millis() as u64;
+        let timestamp =
+            SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_millis() as u64;
 
         StatCollector { sys, system, config, processes, disks, networks, processors, timestamp }
     }

--- a/uplink/src/collector/tcpjson.rs
+++ b/uplink/src/collector/tcpjson.rs
@@ -152,7 +152,7 @@ impl Bridge {
                                 continue
                             }
 
-                            let stream = Stream::dynamic(&data.stream, &self.config.project_id, &self.config.device_id, self.data_tx.clone());
+                            let stream = Stream::dynamic(&data.stream, &self.config.project_id, &self.config.device_id, self.data_tx.clone(), flush_period);
                             bridge_partitions.entry(data.stream.clone()).or_insert(stream)
                         }
                     };

--- a/uplink/src/collector/tcpjson.rs
+++ b/uplink/src/collector/tcpjson.rs
@@ -196,6 +196,8 @@ impl Bridge {
                     for (_, partition) in bridge_partitions.iter_mut() {
                         partition.flush().await?;
                     }
+
+                    flush_timeout.as_mut().reset(Instant::now() + flush_period);
                 }
             }
         }

--- a/uplink/src/collector/tcpjson.rs
+++ b/uplink/src/collector/tcpjson.rs
@@ -95,11 +95,19 @@ impl Bridge {
         &mut self,
         mut framed: Framed<TcpStream, LinesCodec>,
     ) -> Result<(), Error> {
+        let flush_period = Duration::from_secs(self.config.flush_period.unwrap_or(10));
+
         let mut bridge_partitions = HashMap::new();
         for (stream, config) in self.config.streams.clone() {
             bridge_partitions.insert(
                 stream.clone(),
-                Stream::new(stream, config.topic, config.buf_size, self.data_tx.clone()),
+                Stream::new(
+                    stream,
+                    config.topic,
+                    config.buf_size,
+                    self.data_tx.clone(),
+                    flush_period,
+                ),
             );
         }
 
@@ -107,8 +115,7 @@ impl Bridge {
         let action_timeout = time::sleep(Duration::from_secs(100));
         tokio::pin!(action_timeout);
 
-        let flush_period = self.config.flush_period.unwrap_or(10);
-        let flush_timeout = time::sleep(Duration::from_secs(flush_period));
+        let flush_timeout = time::sleep(flush_period);
         tokio::pin!(flush_timeout);
 
         loop {
@@ -151,11 +158,8 @@ impl Bridge {
                     };
 
                     // If fill causes a flush, reset flush_timeout
-                    match partition.fill(data).await {
-                        Ok(flushed) => if flushed {
-                            flush_timeout.as_mut().reset(Instant::now() + Duration::from_secs(flush_period));
-                        }
-                        Err(e) => error!("Failed to send data. Error = {:?}", e.to_string());
+                    if let Err(e) = partition.fill(data).await {
+                        error!("Failed to send data. Error = {:?}", e.to_string());
                     }
                 }
 
@@ -187,7 +191,7 @@ impl Bridge {
                     }
                 }
 
-                // Manually flush all partitions on timeout
+                // Ask partitions to flush themselves if timedout
                 _ = &mut flush_timeout => {
                     for (_, partition) in bridge_partitions.iter_mut() {
                         partition.flush().await?;

--- a/uplink/src/collector/tcpjson.rs
+++ b/uplink/src/collector/tcpjson.rs
@@ -190,7 +190,7 @@ impl Bridge {
                 // Manually flush all partitions on timeout
                 _ = &mut flush_timeout => {
                     for (_, partition) in bridge_partitions.iter_mut() {
-                        partition.flush().await?;
+                        if !partition.is_empty() { partition.flush().await?; }
                     }
                 }
             }

--- a/uplink/src/collector/tcpjson.rs
+++ b/uplink/src/collector/tcpjson.rs
@@ -190,7 +190,7 @@ impl Bridge {
                 // Manually flush all partitions on timeout
                 _ = &mut flush_timeout => {
                     for (_, partition) in bridge_partitions.iter_mut() {
-                        if !partition.is_empty() { partition.flush().await?; }
+                        partition.flush().await?;
                     }
                 }
             }

--- a/uplink/src/collector/tcpjson.rs
+++ b/uplink/src/collector/tcpjson.rs
@@ -157,7 +157,6 @@ impl Bridge {
                         }
                     };
 
-                    // If fill causes a flush, reset flush_timeout
                     if let Err(e) = partition.fill(data).await {
                         error!("Failed to send data. Error = {:?}", e.to_string());
                     }
@@ -191,8 +190,9 @@ impl Bridge {
                     }
                 }
 
-                // Ask partitions to flush themselves if timedout
+                // Ask partitions to flush themselves on interval timeout
                 _ = &mut flush_timeout => {
+                    info!("Manually flushing streams");
                     for (_, partition) in bridge_partitions.iter_mut() {
                         partition.flush().await?;
                     }

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -2,6 +2,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::thread;
+use std::time::Duration;
 
 use anyhow::Error;
 
@@ -58,8 +59,13 @@ impl Uplink {
             .get("action_status")
             .ok_or_else(|| Error::msg("Action status topic missing from config"))?
             .topic;
-        let action_status =
-            Stream::new("action_status", action_status_topic, 1, data_channel.tx.clone());
+        let action_status = Stream::new(
+            "action_status",
+            action_status_topic,
+            1,
+            data_channel.tx.clone(),
+            Duration::from_secs(0),
+        );
 
         Ok(Uplink { config, action_channel, data_channel, action_status })
     }


### PR DESCRIPTION
Uses a "garbage-collector"-esque timeout to ensure partially filled buffers are sent flush commands at regular intervals. These flush commands only cause a flush when time difference between last flush and now is greater than the stream's flush period.

### Why?
At times a connected application may die off, after having pushed not enough data elements to fill a `Stream`'s designated `max_buffer_size`, leading to it's data being lost. By using a timeout we intend to ensure the application's data will eventually be flushed by a global `flush_timeout`, the time period for which is set optionally with the `flush_period` field in the `Config` or will be defaulted to 10s.

> NOTE: The global flush period should ideally never be too much greater than a stream's flush period as that may cause the flush to be triggered later than destined. The flush period of `ActionRespose` is set to 0 as ideally it will never need to be flushed as the stream essentially sends on being filled with one element.