### PR TITLE
Payload compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "afl"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -48,6 +54,21 @@ dependencies = [
  "concurrent-queue",
  "event-listener",
  "futures-core",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "345fd392ab01f746c717b1357165b76f0b67a60192007b234058c9045fdcf695"
+dependencies = [
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite 0.2.9",
+ "tokio 1.19.2",
+ "zstd",
+ "zstd-safe",
 ]
 
 [[package]]
@@ -286,6 +307,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -503,6 +533,16 @@ dependencies = [
  "anyhow",
  "libc",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1012,6 +1052,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lz4_flex"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74141c8af4bb8136dafb5705826bdd9dce823021db897c1129191804140ddf84"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1043,6 +1092,15 @@ name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
+dependencies = [
+ "adler",
+]
 
 [[package]]
 name = "mio"
@@ -2601,12 +2659,15 @@ name = "uplink"
 version = "1.2.0"
 dependencies = [
  "anyhow",
+ "async-compression",
+ "async-trait",
  "bytes 1.1.0",
  "disk",
  "figment",
  "flume",
  "futures-util",
  "log",
+ "lz4_flex",
  "rand 0.8.5",
  "reqwest",
  "rumqttc",
@@ -2950,4 +3011,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4583db5cbd4c4c0303df2d15af80f0539db703fa1c68802d4cbbd2dd0f88f6"
 dependencies = [
  "dirs",
+]
+
+[[package]]
+name = "zstd"
+version = "0.11.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "5.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.1+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fd07cbbc53846d9145dbffdf6dd09a7a0aa52be46741825f5c97bdd4f73f12b"
+dependencies = [
+ "cc",
+ "libc",
 ]

--- a/uplink/Cargo.toml
+++ b/uplink/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["tekjar <raviteja@bytebeam.io>"]
 edition = "2018"
 
 [dependencies]
+async-trait = "0.1"
 structopt = "0.3"
 figment = { version = "0.10.6", features = ["toml", "json"] }
 log = "0.4"
@@ -26,6 +27,9 @@ tunshell-client = { git = "https://github.com/TimeToogo/tunshell.git" }
 reqwest = { version = "0.11", default-features = false, features = ["stream", "rustls-tls"] }
 futures-util = "0.3"
 sysinfo = "0.23"
+# Compression
+async-compression = { version = "0.3", features = ["tokio", "zstd", "zlib"] }
+lz4_flex = "0.9.3"
 
 [build-dependencies]
 vergen = { version = "7", features = ["git", "build", "time"] }

--- a/uplink/src/base/compress.rs
+++ b/uplink/src/base/compress.rs
@@ -1,0 +1,118 @@
+use std::io::Write;
+
+use async_compression::tokio::write::{ZlibEncoder, ZstdEncoder};
+use lz4_flex::frame::FrameEncoder;
+use serde::Deserialize;
+use tokio::io::AsyncWriteExt;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Io error {0}")]
+    Io(#[from] std::io::Error),
+    #[error("LZ4 compression error: {0}")]
+    Lz4(#[from] lz4_flex::frame::Error),
+    #[error("Serde error {0}")]
+    Serde(#[from] serde_json::Error),
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub enum CompressionAlgo {
+    Lz4,
+    Zlib,
+    Zstd,
+}
+
+impl CompressionAlgo {
+    pub async fn compress(&self, payload: &mut Vec<u8>, topic: &mut String) -> Result<(), Error> {
+        match self {
+            Self::Lz4 => Self::lz4_compress(payload, topic),
+            Self::Zlib => Self::zlib_compress(payload, topic).await,
+            Self::Zstd => Self::zstd_compress(payload, topic).await,
+        }
+    }
+
+    fn lz4_compress(payload: &mut Vec<u8>, topic: &mut String) -> Result<(), Error> {
+        let mut compressor = FrameEncoder::new(vec![]);
+        compressor.write_all(payload)?;
+        *payload = compressor.finish()?;
+        topic.push_str("/lz4");
+
+        Ok(())
+    }
+
+    async fn zlib_compress(payload: &mut Vec<u8>, topic: &mut String) -> Result<(), Error> {
+        let mut compressor = ZlibEncoder::new(vec![]);
+        compressor.write_all(payload).await?;
+        compressor.shutdown().await?;
+        *payload = compressor.into_inner();
+        topic.push_str("/zlib");
+
+        Ok(())
+    }
+
+    async fn zstd_compress(payload: &mut Vec<u8>, topic: &mut String) -> Result<(), Error> {
+        let mut compressor = ZstdEncoder::new(vec![]);
+        compressor.write_all(payload).await?;
+        compressor.shutdown().await?;
+        *payload = compressor.into_inner();
+        topic.push_str("/zstd");
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Read;
+
+    use async_compression::tokio::bufread::{ZlibDecoder, ZstdDecoder};
+    use lz4_flex::frame::FrameDecoder;
+    use tokio::io::AsyncReadExt;
+
+    use super::CompressionAlgo;
+
+    #[tokio::test]
+    async fn compress_decompress_lz4() {
+        let mut payload = b"Hello World".to_vec();
+        let mut topic = "".to_string();
+
+        CompressionAlgo::Lz4.compress(&mut payload, &mut topic).await.unwrap();
+
+        let mut decompressor = FrameDecoder::new(payload.as_slice());
+
+        let mut decompressed = String::new();
+        decompressor.read_to_string(&mut decompressed).unwrap();
+
+        assert_eq!("Hello World", decompressed);
+    }
+
+    #[tokio::test]
+    async fn compress_decompress_zlib() {
+        let mut payload = b"Hello World".to_vec();
+        let mut topic = "".to_string();
+
+        CompressionAlgo::Zlib.compress(&mut payload, &mut topic).await.unwrap();
+
+        let mut decompressor = ZlibDecoder::new(payload.as_slice());
+
+        let mut decompressed = Vec::new();
+        decompressor.read_to_end(&mut decompressed).await.unwrap();
+
+        assert_eq!(b"Hello World".to_vec(), decompressed);
+    }
+
+    #[tokio::test]
+    async fn compress_decompress_zstd() {
+        let mut payload = b"Hello World".to_vec();
+        let mut topic = "".to_string();
+
+        CompressionAlgo::Zstd.compress(&mut payload, &mut topic).await.unwrap();
+
+        let mut decompressor = ZstdDecoder::new(payload.as_slice());
+
+        let mut decompressed = Vec::new();
+        decompressor.read_to_end(&mut decompressed).await.unwrap();
+
+        assert_eq!(b"Hello World".to_vec(), decompressed);
+    }
+}

--- a/uplink/src/base/compress.rs
+++ b/uplink/src/base/compress.rs
@@ -74,9 +74,11 @@ mod tests {
     #[tokio::test]
     async fn compress_decompress_lz4() {
         let mut payload = b"Hello World".to_vec();
-        let mut topic = "".to_string();
+        let mut topic = "hello/world".to_string();
 
         CompressionAlgo::Lz4.compress(&mut payload, &mut topic).await.unwrap();
+
+        assert_eq!(topic, "hello/world/lz4");
 
         let mut decompressor = FrameDecoder::new(payload.as_slice());
 
@@ -89,9 +91,11 @@ mod tests {
     #[tokio::test]
     async fn compress_decompress_zlib() {
         let mut payload = b"Hello World".to_vec();
-        let mut topic = "".to_string();
+        let mut topic = "hello/world".to_string();
 
         CompressionAlgo::Zlib.compress(&mut payload, &mut topic).await.unwrap();
+
+        assert_eq!(topic, "hello/world/zlib");
 
         let mut decompressor = ZlibDecoder::new(payload.as_slice());
 
@@ -104,9 +108,11 @@ mod tests {
     #[tokio::test]
     async fn compress_decompress_zstd() {
         let mut payload = b"Hello World".to_vec();
-        let mut topic = "".to_string();
+        let mut topic = "hello/world".to_string();
 
         CompressionAlgo::Zstd.compress(&mut payload, &mut topic).await.unwrap();
+
+        assert_eq!(topic, "hello/world/zstd");
 
         let mut decompressor = ZstdDecoder::new(payload.as_slice());
 

--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -1,8 +1,11 @@
-use std::{collections::HashMap, fmt::Debug, mem, sync::Arc, time::Duration};
+use std::{collections::HashMap, fmt::Debug, io::Write, mem, sync::Arc, time::Duration};
 
+use async_compression::tokio::write::{ZlibEncoder, ZstdEncoder};
 use flume::{SendError, Sender};
 use log::{info, warn};
+use lz4_flex::frame::FrameEncoder;
 use serde::{Deserialize, Serialize};
+use tokio::io::AsyncWriteExt;
 
 pub mod actions;
 pub mod mqtt;
@@ -10,8 +13,14 @@ pub mod serializer;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+    #[error("Io error {0}")]
+    Io(#[from] std::io::Error),
     #[error("Send error {0}")]
     Send(#[from] SendError<Box<dyn Package>>),
+    #[error("LZ4 compression error: {0}")]
+    Lz4(#[from] lz4_flex::frame::Error),
+    #[error("Serde error {0}")]
+    Serde(#[from] serde_json::Error),
 }
 
 pub const DEFAULT_TIMEOUT: u64 = 60;
@@ -74,6 +83,53 @@ pub struct Config {
     pub streams: HashMap<String, StreamConfig>,
     pub ota: Ota,
     pub stats: Stats,
+    pub compression: Option<CompressionAlgo>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub enum CompressionAlgo {
+    Lz4,
+    Zlib,
+    Zstd,
+}
+
+impl CompressionAlgo {
+    pub async fn compress(&self, payload: &mut Vec<u8>, topic: &mut String) -> Result<(), Error> {
+        match self {
+            Self::Lz4 => Self::lz4_compress(payload, topic),
+            Self::Zlib => Self::zlib_compress(payload, topic).await,
+            Self::Zstd => Self::zstd_compress(payload, topic).await,
+        }
+    }
+
+    fn lz4_compress(payload: &mut Vec<u8>, topic: &mut String) -> Result<(), Error> {
+        let mut compressor = FrameEncoder::new(vec![]);
+        compressor.write_all(payload)?;
+        *payload = compressor.finish()?;
+        topic.push_str("/lz4");
+
+        Ok(())
+    }
+
+    async fn zlib_compress(payload: &mut Vec<u8>, topic: &mut String) -> Result<(), Error> {
+        let mut compressor = ZlibEncoder::new(vec![]);
+        compressor.write_all(payload).await?;
+        compressor.shutdown().await?;
+        *payload = compressor.into_inner();
+        topic.push_str("/zlib");
+
+        Ok(())
+    }
+
+    async fn zstd_compress(payload: &mut Vec<u8>, topic: &mut String) -> Result<(), Error> {
+        let mut compressor = ZstdEncoder::new(vec![]);
+        compressor.write_all(payload).await?;
+        compressor.shutdown().await?;
+        *payload = compressor.into_inner();
+        topic.push_str("/zstd");
+
+        Ok(())
+    }
 }
 
 pub trait Point: Send + Debug {
@@ -81,12 +137,24 @@ pub trait Point: Send + Debug {
     fn timestamp(&self) -> u64;
 }
 
-pub trait Package: Send + Debug {
+#[async_trait::async_trait]
+pub trait Package: Send + Debug + Sync {
     fn topic(&self) -> Arc<String>;
     // TODO: Implement a generic Return type that can wrap
     // around custom serialization error types.
     fn serialize(&self) -> serde_json::Result<Vec<u8>>;
     fn anomalies(&self) -> Option<(String, usize)>;
+
+    async fn payload(&self, compression: &Option<CompressionAlgo>) -> Result<String, Error> {
+        let mut topic = self.topic().to_string();
+        let mut payload = self.serialize()?;
+
+        if let Some(algo) = compression {
+            algo.compress(&mut payload, &mut topic).await?;
+        }
+
+        Ok(topic)
+    }
 }
 
 /// Signal to modify the behaviour of collector

--- a/uplink/src/base/serializer.rs
+++ b/uplink/src/base/serializer.rs
@@ -111,10 +111,9 @@ impl Serializer {
 
         loop {
             let data = self.collector_rx.recv_async().await?;
-            let topic = data.topic();
-            let payload = data.payload(&self.config.compression).await?;
+            let (payload, topic) = data.extract(&self.config.compression).await?;
 
-            let mut publish = Publish::new(topic.as_ref(), QoS::AtLeastOnce, payload);
+            let mut publish = Publish::new(topic, QoS::AtLeastOnce, payload);
             publish.pkid = 1;
 
             if let Err(e) = publish.write(storage.writer()) {
@@ -157,10 +156,9 @@ impl Serializer {
                         self.metrics.add_errors(errors, count);
                       }
 
-                      let topic = data.topic();
-                      let payload = data.payload(&self.config.compression).await?;
+                      let (payload, topic) = data.extract(&self.config.compression).await?;
                       let payload_size = payload.len();
-                      let mut publish = Publish::new(topic.as_ref(), QoS::AtLeastOnce, payload);
+                      let mut publish = Publish::new(topic, QoS::AtLeastOnce, payload);
                       publish.pkid = 1;
 
                       match publish.write(storage.writer()) {
@@ -229,10 +227,9 @@ impl Serializer {
                         self.metrics.add_errors(errors, count);
                       }
 
-                      let topic = data.topic();
-                      let payload = data.payload(&self.config.compression).await?;
+                      let (payload, topic) = data.extract(&self.config.compression).await?;
                       let payload_size = payload.len();
-                      let mut publish = Publish::new(topic.as_ref(), QoS::AtLeastOnce, payload);
+                      let mut publish = Publish::new(topic, QoS::AtLeastOnce, payload);
                       publish.pkid = 1;
 
                       match publish.write(storage.writer()) {
@@ -309,10 +306,9 @@ impl Serializer {
                         self.metrics.add_errors(errors, count);
                     }
 
-                    let topic = data.topic();
-                    let payload = data.payload(&self.config.compression).await?;
+                    let (payload, topic) = data.extract(&self.config.compression).await?;
                     let payload_size = payload.len();
-                    match self.client.try_publish(topic.as_ref(), QoS::AtLeastOnce, false, payload) {
+                    match self.client.try_publish(topic, QoS::AtLeastOnce, false, payload) {
                         Ok(_) => {
                             self.metrics.add_total_sent_size(payload_size);
                             continue;

--- a/uplink/src/base/serializer.rs
+++ b/uplink/src/base/serializer.rs
@@ -18,8 +18,8 @@ pub enum Error {
     Collector(#[from] RecvError),
     #[error("Serde error {0}")]
     Serde(#[from] serde_json::Error),
-    #[error("Package error {0}")]
-    Package(#[from] crate::base::Error),
+    #[error("Compress error {0}")]
+    Compress(#[from] super::compress::Error),
     #[error("Io error {0}")]
     Io(#[from] io::Error),
     #[error("Mqtt client error {0}")]

--- a/uplink/src/collector/tcpjson.rs
+++ b/uplink/src/collector/tcpjson.rs
@@ -161,6 +161,7 @@ impl Bridge {
                         StreamStatus::Partial(l) => {
                             debug!("Stream contains {} elements", l);
                         }
+                        StreamStatus::Ignore => {}
                     }
                 }
 

--- a/uplink/src/collector/tcpjson.rs
+++ b/uplink/src/collector/tcpjson.rs
@@ -242,4 +242,8 @@ impl Package for Buffer<Payload> {
     fn anomalies(&self) -> Option<(String, usize)> {
         self.anomalies()
     }
+
+    fn is_compressible(&self) -> bool {
+        true
+    }
 }

--- a/uplink/src/main.rs
+++ b/uplink/src/main.rs
@@ -207,6 +207,9 @@ fn banner(commandline: &CommandLine, config: &Arc<Config>) {
     if config.stats.enabled {
         println!("    processes: {:?}", config.stats.process_names);
     }
+    if let Some(algo) = &config.compression {
+        println!("    compression: {:?}", algo);
+    }
     println!("\n");
 }
 


### PR DESCRIPTION
Continues #6 

<!--Brief description of the purpose behind opening the PR-->
Enables users to configure uplink so as to forward compressed data

### Changes
<!--Detailed description of changes made-->
- `CompressionAlgo` that can be configured by user
- `Package.is_compressible()` to configure if type is compressible.
- `Package.extract()` returns payload along with topic. Payload is compressed as specified by user in uplink config and the topic is also updated to contain the compression name. 

### Why?
<!--Detailed description of why the changes had to be made-->
Uplink is expected to handle heavy, uncompressed data payloads. Compression will enable users to save on network bandwidth and enable better resource utilization at a minor cost for compressive computations.

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
Tests included. Had also configured another client with de-compression abilities and run them successfully.