### PR TITLE
Fix `Serializer` bugs and documentation

### DIFF
--- a/uplink/src/base/serializer.rs
+++ b/uplink/src/base/serializer.rs
@@ -187,13 +187,8 @@ impl Serializer {
                       }
                 }
                 o = &mut publish => {
-                    match o {
-                        Ok(_) => return Ok(Status::EventLoopReady),
-                        Err(ClientError::Request(SendError(Request::Publish(publish)))) =>{
-                            return Ok(Status::EventLoopCrash(publish))
-                        },
-                        Err(e) => unreachable!("Unexpected error: {}", e),
-                    }
+                    o?;
+                    return Ok(Status::EventLoopReady);
                 }
             }
         }


### PR DESCRIPTION
Fix bugs and documentation in `Serializer` state-machine implementation.

### Changes
<!--Detailed description of changes made-->
- Write initial failed publish packet to disk in `crash()`.
- rename `disk()` to `slow()` and handle network publish error as `EventLoopCrash`
- Better document code

### Why?
<!--Detailed description of why the changes had to be made-->
To ensure code works as expected.

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
These issues in code were discovered in #7 