### PR TITLE
update rumqttc to v0.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,17 +40,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
 
 [[package]]
-name = "async-channel"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2114d64672151c0c5eaa5e131ec84a74f06e1e559830dabba01ca30605d66319"
-dependencies = [
- "concurrent-queue",
- "event-listener",
- "futures-core",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,12 +166,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0b3de4a0c5e67e16066a0715723abd91edc2f9001d09c46e1dca929351e130e"
 
 [[package]]
-name = "cache-padded"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
-
-[[package]]
 name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -229,15 +212,6 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
-]
-
-[[package]]
-name = "concurrent-queue"
-version = "1.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af4780a44ab5696ea9e28294517f1fffb421a83a25af521333c838635509db9c"
-dependencies = [
- "cache-padded",
 ]
 
 [[package]]
@@ -464,12 +438,6 @@ dependencies = [
  "cc",
  "libc",
 ]
-
-[[package]]
-name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "fastrand"
@@ -856,7 +824,7 @@ dependencies = [
  "hyper",
  "rustls 0.20.6",
  "tokio 1.20.1",
- "tokio-rustls 0.23.4",
+ "tokio-rustls 0.23.3",
 ]
 
 [[package]]
@@ -1692,7 +1660,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio 1.20.1",
- "tokio-rustls 0.23.4",
+ "tokio-rustls 0.23.3",
  "tokio-util 0.7.3",
  "tower-service",
  "url",
@@ -1720,20 +1688,19 @@ dependencies = [
 
 [[package]]
 name = "rumqttc"
-version = "0.11.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29fa50cc13f4c9c4962d925c3f99f822fb19995cc527ec1d556ee7635dfa2e3d"
+checksum = "59d0bc9f169b15197e527c6784e7e7687683f503bfd0040d180422c9b2551eb8"
 dependencies = [
- "async-channel",
  "bytes 1.2.0",
+ "flume",
  "http",
  "log",
  "pollster",
  "rustls-pemfile 0.3.0",
  "thiserror",
  "tokio 1.20.1",
- "tokio-rustls 0.23.4",
- "webpki 0.22.0",
+ "tokio-rustls 0.23.3",
 ]
 
 [[package]]
@@ -2372,9 +2339,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.23.4"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+checksum = "4151fda0cf2798550ad0b34bcfc9b9dcc2a9d2471c895c68f3a8818e54f2389e"
 dependencies = [
  "rustls 0.20.6",
  "tokio 1.20.1",

--- a/uplink/Cargo.toml
+++ b/uplink/Cargo.toml
@@ -15,7 +15,7 @@ tokio-util = { version = "0.7.2", features = ["codec", "time"] }
 tokio-stream = "0.1"
 tokio-compat-02 = "0.2.0"
 flume = "0.10"
-rumqttc = "0.11"
+rumqttc = "0.14"
 bytes = "1"
 serde = { version = "1", features = ["derive"] }
 thiserror = "1"

--- a/uplink/src/base/serializer.rs
+++ b/uplink/src/base/serializer.rs
@@ -14,8 +14,6 @@ use tokio::{select, time};
 
 #[derive(thiserror::Error, Debug)]
 pub enum MqttError {
-    #[error("Client error {0}")]
-    Client(ClientError),
     #[error("SendError(..)")]
     Send(Request),
     #[error("TrySendError(..)")]
@@ -25,9 +23,8 @@ pub enum MqttError {
 impl From<ClientError> for MqttError {
     fn from(e: ClientError) -> Self {
         match e {
-            ClientError::Request(e) => MqttError::Send(e.into_inner()),
-            ClientError::TryRequest(e) => MqttError::TrySend(e.into_inner()),
-            e => MqttError::Client(e),
+            ClientError::Request(r) => MqttError::Send(r),
+            ClientError::TryRequest(r) => MqttError::TrySend(r),
         }
     }
 }


### PR DESCRIPTION
<!--Brief description of the purpose behind opening the PR-->
Brings changes associated with new rumqttc version into uplink, including the following error log entry when trying to connect to the wrong port.

### Changes
- 1-to-1 mapping between `ClientError` and `MqttError` variants
<!--Detailed description of changes made-->
Error log now contains entry when unable to connect to broker due to improper port config.
```
******* [ERROR] (21) uplink::base::mqtt: Connection error = "Timeout"
```

### Why?
<!--Detailed description of why the changes had to be made-->
To keep dependencies updated.

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
Checked operations against regular uplink instance. Similar behavior observed.