### PR TITLE
fix: runit new command

### DIFF
--- a/runit/uplink/run
+++ b/runit/uplink/run
@@ -3,4 +3,4 @@
 cd /usr/share/bytebeam/uplink
 
 export RUST_LOG=debug
-exec ./target/debug/uplink -c config/uplink.toml -i 2 -a certs/
+exec ./target/debug/uplink -c configs/config.toml -a configs/noauth.json


### PR DESCRIPTION
@tekjar set `BROKER` env variable according to the environment in which it is to be run