### PR TITLE
fix: override configs for demo simulator

### DIFF
--- a/configs/demo.toml
+++ b/configs/demo.toml
@@ -1,0 +1,7 @@
+[ota]
+enabled = true
+path = "/var/tmp/ota-file"
+
+[simulator]
+num_devices = 10
+gps_paths = "./paths/"

--- a/configs/device_demo.json
+++ b/configs/device_demo.json
@@ -1,0 +1,6 @@
+{
+  "project_id": "demo",
+  "device_id":"1",
+  "broker": "beamd",
+  "port": 1883
+}

--- a/runit/uplink/run
+++ b/runit/uplink/run
@@ -3,4 +3,4 @@
 cd /usr/share/bytebeam/uplink
 
 export RUST_LOG=debug
-exec ./target/debug/uplink -c configs/config.toml -a configs/noauth.json
+exec ./target/debug/uplink -c configs/demo.toml -a configs/noauth.json


### PR DESCRIPTION
Closes BYT-511

Currently runit uses the wrong configs for running uplink as demo simulator.

### Changes
- Add `demo.toml` as uplink config
- Add `device_demo.json` as uplink auth

### Why?
<!--Detailed description of why the changes had to be made-->

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->