### PR TITLE
feat: make stream topic field optional

### DIFF
--- a/configs/config.toml
+++ b/configs/config.toml
@@ -33,26 +33,27 @@ max_file_count = 3
 # Table of pre-configured data streams
 #
 # Required Parameters
-# - topic: Topic-filter to which data shall be published
 # - buf-size: Number of data points that shall be included in each Publish
-# - flush-period: Duration in seconds after a data point enters the stream
+# - topic(optional): topic-filter to which data shall be published. If left
+#   unconfigured, stream will be created dynamically.
+# - flush-period(optional): Duration in seconds after a data point enters the stream
 #   and WILL be flushed by collector. Defaults to 60s in case not configured.
 #
 # NOTE: The metrics stream is one to which the Serializer Metrics module
 # publishes associated data onto, to keep track of serializer performance.
 [streams.metrics]
-topic = "/tenants/{tenant_id}/devices/{device_id}/events/metrics/jsonarray"
 buf_size = 10
 flush_period = 30
 
 # The action_status stream is used to push progress of Actions in execution
+#
+# NOTE: Action statuses are expected on a specifc topic as configured below.
 [streams.action_status]
 topic = "/tenants/{tenant_id}/devices/{device_id}/action/status"
 buf_size = 1
 
 # Set buf_size to 1 for the device_shadow stream
 [streams.device_shadow]
-topic = "/tenants/{tenant_id}/devices/{device_id}/events/device_shadow/jsonarray"
 buf_size = 1
 
 # Configurations associated with the OTA module of uplink, if enabled Actions

--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -23,7 +23,7 @@ fn default_timeout() -> u64 {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct StreamConfig {
-    pub topic: String,
+    pub topic: Option<String>,
     pub buf_size: usize,
     #[serde(default = "default_timeout")]
     /// Duration(in seconds) that bridge collector waits from
@@ -148,10 +148,16 @@ where
 
     pub fn with_config(
         name: &String,
+        project_id: &String,
+        device_id: &String,
         config: &StreamConfig,
         tx: Sender<Box<dyn Package>>,
     ) -> Stream<T> {
-        let mut stream = Stream::new(name, &config.topic, config.buf_size, tx);
+        let mut stream = if let Some(topic) = &config.topic {
+            Stream::new(name, topic, config.buf_size, tx)
+        } else {
+            Stream::dynamic_with_size(name, project_id, device_id, config.buf_size, tx)
+        };
         stream.flush_period = Duration::from_secs(config.flush_period);
 
         stream

--- a/uplink/src/base/serializer.rs
+++ b/uplink/src/base/serializer.rs
@@ -643,7 +643,7 @@ mod test {
         streams.insert(
             "metrics".to_owned(),
             StreamConfig {
-                topic: Default::default(),
+                topic: Some("metrics/topic".to_string()),
                 buf_size: 100,
                 flush_period: DEFAULT_TIMEOUT,
             },

--- a/uplink/src/base/serializer.rs
+++ b/uplink/src/base/serializer.rs
@@ -173,7 +173,7 @@ impl<C: MqttClient> Serializer<C> {
     ) -> Result<Serializer<C>, Error> {
         let metrics_config =
             config.streams.get("metrics").expect("Missing metrics Stream in config");
-        let metrics = Metrics::new(&metrics_config.topic);
+        let metrics = Metrics::new(metrics_config.topic.as_ref().unwrap());
 
         let storage = match &config.persistence {
             Some(persistence) => {

--- a/uplink/src/collector/tcpjson.rs
+++ b/uplink/src/collector/tcpjson.rs
@@ -95,7 +95,13 @@ impl Bridge {
     ) -> Result<(), Error> {
         let mut bridge_partitions = HashMap::new();
         for (name, config) in &self.config.streams {
-            let stream = Stream::with_config(name, config, self.data_tx.clone());
+            let stream = Stream::with_config(
+                name,
+                &self.config.project_id,
+                &self.config.device_id,
+                config,
+                self.data_tx.clone(),
+            );
             bridge_partitions.insert(name.to_owned(), stream);
         }
 

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -102,11 +102,11 @@ pub mod config {
         let tenant_id = config.project_id.trim();
         let device_id = config.device_id.trim();
         for config in config.streams.values_mut() {
-            let topic = str::replace(&config.topic, "{tenant_id}", tenant_id);
-            config.topic = topic;
-
-            let topic = str::replace(&config.topic, "{device_id}", device_id);
-            config.topic = topic;
+            if let Some(topic) = &config.topic {
+                let topic = str::replace(topic, "{tenant_id}", tenant_id);
+                let topic = str::replace(&topic, "{device_id}", device_id);
+                config.topic = Some(topic);
+            }
         }
 
         Ok(config)
@@ -144,7 +144,9 @@ impl Uplink {
             .streams
             .get("action_status")
             .ok_or_else(|| Error::msg("Action status topic missing from config"))?
-            .topic;
+            .topic
+            .as_ref()
+            .unwrap();
         let action_status = Stream::new("action_status", action_status_topic, 1, data_tx.clone());
 
         Ok(Uplink { config, action_rx, action_tx, data_rx, data_tx, action_status })

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -62,7 +62,6 @@ pub mod config {
     max_file_count = 3
 
     [streams.metrics]
-    topic = "/tenants/{tenant_id}/devices/{device_id}/events/metrics/jsonarray"
     buf_size = 10
 
     # Action status stream from status messages from bridge

--- a/uplink/src/main.rs
+++ b/uplink/src/main.rs
@@ -130,12 +130,9 @@ async fn main() -> Result<(), Error> {
     uplink.spawn()?;
 
     if let Some(simulator_config) = &config.simulator {
-        if let Err(e) = simulator::start(
-            uplink.bridge_data_tx(),
-            uplink.bridge_action_rx(),
-            simulator_config
-        )
-        .await
+        if let Err(e) =
+            simulator::start(uplink.bridge_data_tx(), uplink.bridge_action_rx(), simulator_config)
+                .await
         {
             error!("Error while running simulator: {}", e)
         }


### PR DESCRIPTION
Closes BYT-496

Field to configure a stream's topic should be made optional to ensure the user doesn't have to deal with it when wanting to configure the buffer size.

### Changes
<!--Detailed description of changes made-->

### Why?
<!--Detailed description of why the changes had to be made-->

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->