### PR TITLE
feat: Streamize metrics

### DIFF
--- a/uplink/src/base/serializer.rs
+++ b/uplink/src/base/serializer.rs
@@ -1,4 +1,5 @@
-use crate::base::{Config, Package};
+use crate::base::{Buffer, Config, Package};
+use crate::{Point, Stream};
 
 use bytes::Bytes;
 use disk::Storage;
@@ -163,18 +164,16 @@ pub struct Serializer<C: MqttClient> {
     client: C,
     storage: Option<Storage>,
     metrics: Metrics,
+    metrics_stream: Stream<Metrics>,
 }
 
 impl<C: MqttClient> Serializer<C> {
     pub fn new(
         config: Arc<Config>,
         collector_rx: Receiver<Box<dyn Package>>,
+        metrics_stream: Stream<Metrics>,
         client: C,
     ) -> Result<Serializer<C>, Error> {
-        let metrics_config =
-            config.streams.get("metrics").expect("Missing metrics Stream in config");
-        let metrics = Metrics::new(&metrics_config.topic);
-
         let storage = match &config.persistence {
             Some(persistence) => {
                 let storage = Storage::new(
@@ -187,7 +186,14 @@ impl<C: MqttClient> Serializer<C> {
             None => None,
         };
 
-        Ok(Serializer { config, collector_rx, client, storage, metrics })
+        Ok(Serializer {
+            config,
+            collector_rx,
+            client,
+            storage,
+            metrics: Metrics::new(),
+            metrics_stream,
+        })
     }
 
     /// Write all data received, from here-on, to disk only.
@@ -420,16 +426,8 @@ impl<C: MqttClient> Serializer<C> {
 
                 }
                 _ = interval.tick() => {
-                    let (topic, payload) = self.metrics.next()?;
-                    let payload_size = payload.len();
-                    match self.client.try_publish(topic, QoS::AtLeastOnce, false, payload) {
-                        Ok(_) => {
-                            self.metrics.add_total_sent_size(payload_size);
-                            continue;
-                        }
-                        Err(MqttError::TrySend(Request::Publish(publish))) => return Ok(Status::SlowEventloop(publish)),
-                        Err(e) => unreachable!("Unexpected error: {}", e),
-                    }
+                    let metrics = self.metrics.next();
+                    self.metrics_stream.fill(metrics).await.unwrap();
                 }
             }
         }
@@ -473,10 +471,8 @@ async fn send_publish<C: MqttClient>(
     Ok(client)
 }
 
-#[derive(Debug, Default, Serialize)]
-struct Metrics {
-    #[serde(skip_serializing)]
-    topic: String,
+#[derive(Debug, Default, Serialize, Clone)]
+pub struct Metrics {
     sequence: u32,
     timestamp: u64,
     total_sent_size: usize,
@@ -487,8 +483,8 @@ struct Metrics {
 }
 
 impl Metrics {
-    pub fn new<T: Into<String>>(topic: T) -> Metrics {
-        Metrics { topic: topic.into(), errors: String::with_capacity(1024), ..Default::default() }
+    pub fn new() -> Metrics {
+        Metrics { errors: String::with_capacity(1024), ..Default::default() }
     }
 
     pub fn add_total_sent_size(&mut self, size: usize) {
@@ -527,16 +523,42 @@ impl Metrics {
         self.errors.push_str(" | ");
     }
 
-    pub fn next(&mut self) -> Result<(&str, Vec<u8>), Error> {
+    pub fn next(&mut self) -> Metrics {
         let timestamp =
             SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or(Duration::from_secs(0));
         self.timestamp = timestamp.as_millis() as u64;
         self.sequence += 1;
 
-        let payload = serde_json::to_vec(&vec![&self])?;
+        let metrics = self.clone();
+
         self.errors.clear();
         self.lost_segments = 0;
-        Ok((&self.topic, payload))
+
+        metrics
+    }
+}
+
+impl Point for Metrics {
+    fn sequence(&self) -> u32 {
+        self.sequence
+    }
+
+    fn timestamp(&self) -> u64 {
+        self.timestamp
+    }
+}
+
+impl Package for Buffer<Metrics> {
+    fn topic(&self) -> Arc<String> {
+        self.topic.clone()
+    }
+
+    fn serialize(&self) -> serde_json::Result<Vec<u8>> {
+        serde_json::to_vec(&self.buffer)
+    }
+
+    fn anomalies(&self) -> Option<(String, usize)> {
+        self.anomalies()
     }
 }
 
@@ -639,20 +661,11 @@ mod test {
     }
 
     fn default_config() -> Config {
-        let mut streams = HashMap::new();
-        streams.insert(
-            "metrics".to_owned(),
-            StreamConfig {
-                topic: Default::default(),
-                buf_size: 100,
-                flush_period: DEFAULT_TIMEOUT,
-            },
-        );
         Config {
             broker: "localhost".to_owned(),
             port: 1883,
             device_id: "123".to_owned(),
-            streams,
+            streams: HashMap::new(),
             max_packet_size: 1024 * 1024,
             ..Default::default()
         }
@@ -677,7 +690,15 @@ mod test {
         let (net_tx, net_rx) = flume::bounded(1);
         let client = MockClient { net_tx };
 
-        (Serializer::new(config, data_rx, client).unwrap(), data_tx, net_rx)
+        let metrics_config = StreamConfig {
+            topic: Default::default(),
+            buf_size: 100,
+            flush_period: DEFAULT_TIMEOUT,
+        };
+        let metrics_stream =
+            Stream::with_config(&"metrics".to_owned(), &metrics_config, data_tx.clone());
+
+        (Serializer::new(config, data_rx, metrics_stream, client).unwrap(), data_tx, net_rx)
     }
 
     #[derive(Error, Debug)]

--- a/uplink/src/base/serializer.rs
+++ b/uplink/src/base/serializer.rs
@@ -695,8 +695,13 @@ mod test {
             buf_size: 100,
             flush_period: DEFAULT_TIMEOUT,
         };
-        let metrics_stream =
-            Stream::with_config(&"metrics".to_owned(), &metrics_config, data_tx.clone());
+        let metrics_stream = Stream::with_config(
+            &"metrics".to_owned(),
+            &config.project_id,
+            &config.device_id,
+            &metrics_config,
+            data_tx.clone(),
+        );
 
         (Serializer::new(config, data_rx, metrics_stream, client).unwrap(), data_tx, net_rx)
     }

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -178,8 +178,13 @@ impl Uplink {
         let mut mqtt = Mqtt::new(self.config.clone(), raw_action_tx);
         let metrics_config =
             self.config.streams.get("metrics").expect("Missing metrics Stream in config");
-        let metrics_stream =
-            Stream::with_config(&"metrics".to_owned(), metrics_config, self.bridge_data_tx());
+        let metrics_stream = Stream::with_config(
+            &"metrics".to_owned(),
+            &self.config.project_id,
+            &self.config.device_id,
+            metrics_config,
+            self.bridge_data_tx(),
+        );
         let serializer = Serializer::new(
             self.config.clone(),
             self.data_rx.clone(),

--- a/uplink/src/main.rs
+++ b/uplink/src/main.rs
@@ -130,12 +130,9 @@ async fn main() -> Result<(), Error> {
     uplink.spawn()?;
 
     if let Some(simulator_config) = &config.simulator {
-        if let Err(e) = simulator::start(
-            uplink.bridge_data_tx(),
-            uplink.bridge_action_rx(),
-            simulator_config
-        )
-        .await
+        if let Err(e) =
+            simulator::start(uplink.bridge_data_tx(), uplink.bridge_action_rx(), simulator_config)
+                .await
         {
             error!("Error while running simulator: {}", e)
         }


### PR DESCRIPTION
Closes #<!--Issue Number-->

Serializer's `Metrics` currently doesn't construct a stream

### Changes
Push serializer metrics data onto stream configured from user provided details.

### Why?
Metrics is being sent as batch of size 1 even when configured otherwise.

### Trials Performed
Configured and sent over metrics data in batch of 10, data push frequency has significantly decreased