### PR TITLE
feat: optionalize serializer metrics

### DIFF
--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -180,15 +180,17 @@ impl Uplink {
 
         let (raw_action_tx, raw_action_rx) = bounded(10);
         let mut mqtt = Mqtt::new(self.config.clone(), raw_action_tx);
-        let metrics_config =
-            self.config.streams.get("metrics").expect("Missing metrics Stream in config");
-        let metrics_stream = Stream::with_config(
-            &"metrics".to_owned(),
-            &self.config.project_id,
-            &self.config.device_id,
-            metrics_config,
-            self.bridge_data_tx(),
-        );
+
+        let metrics_config = self.config.streams.get("metrics");
+        let metrics_stream = metrics_config.map(|metrics_config| {
+            Stream::with_config(
+                &"metrics".to_owned(),
+                &self.config.project_id,
+                &self.config.device_id,
+                metrics_config,
+                self.bridge_data_tx(),
+            )
+        });
         let serializer = Serializer::new(
             self.config.clone(),
             self.data_rx.clone(),


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
Forward serializer metrics only if metrics stream is configured

### Why?
serializer metrics might be unnecessary for certain usecases and hence leaving it unconfigured should cause the serializer to stop sending this information to the platform.

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->