### PR TITLE
feat: rework config

### DIFF
--- a/configs/config.toml
+++ b/configs/config.toml
@@ -30,7 +30,8 @@ path = "/tmp/uplink"
 max_file_size = 104857600 # 100MB
 max_file_count = 3
 
-# Table of pre-configured data streams
+# Table of pre-configured data streams, specifies streams of data elements that are to
+# be collected, batched and forwarded to serializer to then be published onto platform.
 #
 # Required Parameters
 # - buf-size: Number of data points that shall be included in each Publish
@@ -39,21 +40,27 @@ max_file_count = 3
 # - flush-period(optional): Duration in seconds after a data point enters the stream
 #   and WILL be flushed by collector. Defaults to 60s in case not configured.
 #
-# NOTE: The metrics stream is one to which the Serializer Metrics module
-# publishes associated data onto, to keep track of serializer performance.
-[streams.metrics]
+# In the following config for the device_shadow stream we set buf_size to 1. streams is
+# internally constructed as a map of Name -> Config
+[streams.device_shadow]
+buf_size = 1
+
+# Built-in streams: Serializer metrics and action status are special cases and need to be
+# separately configured outside of the streams map. The metrics stream is one to which the
+# Serializer Metrics module publishes associated stats, to keep track of serializer performance.
+# If not configured, serializer metrics will not be forwarded to platform. In this example we
+# are enabling and publishing on reaching 10 elements or flushing on 30 seconds timeouts.
+[serializer_metrics]
 buf_size = 10
 flush_period = 30
 
-# The action_status stream is used to push progress of Actions in execution
+# The action_status stream is used to push progress of Actions in execution.
+# This configuration is required or will lead to fallback to default config.
 #
-# NOTE: Action statuses are expected on a specifc topic as configured below.
-[streams.action_status]
+# NOTE: Action statuses are expected on a specifc topic as configured in example below.
+# This also means that we require a topic to be configured or uplink will error out.
+[action_status]
 topic = "/tenants/{tenant_id}/devices/{device_id}/action/status"
-buf_size = 1
-
-# Set buf_size to 1 for the device_shadow stream
-[streams.device_shadow]
 buf_size = 1
 
 # Configurations associated with the OTA module of uplink, if enabled Actions

--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -21,7 +21,7 @@ fn default_timeout() -> u64 {
     DEFAULT_TIMEOUT
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct StreamConfig {
     pub topic: Option<String>,
     pub buf_size: usize,
@@ -80,6 +80,8 @@ pub struct Config {
     pub actions: Vec<String>,
     pub persistence: Option<Persistence>,
     pub streams: HashMap<String, StreamConfig>,
+    pub action_status: StreamConfig,
+    pub serializer_metrics: Option<StreamConfig>,
     pub ota: Ota,
     pub stats: Stats,
     pub simulator: Option<SimulatorConfig>,

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -12,6 +12,7 @@ pub mod base;
 pub mod collector;
 
 pub mod config {
+    use crate::base::StreamConfig;
     pub use crate::base::{Config, Ota, Persistence, Stats};
     use config::{Environment, File, FileFormat};
     use std::fs;
@@ -61,10 +62,9 @@ pub mod config {
     max_file_size = 104857600 # 100MB
     max_file_count = 3
 
-    [streams.metrics]
-    buf_size = 10
+    # [serializer_metrics] is left disabled by default
 
-    [streams.action_status]
+    [action_status]
     topic = "/tenants/{tenant_id}/devices/{device_id}/action/status"
     buf_size = 1
 
@@ -97,17 +97,30 @@ pub mod config {
         if let Some(persistence) = &config.persistence {
             fs::create_dir_all(&persistence.path)?;
         }
+
+        // replace placeholders with device/tenant ID
         let tenant_id = config.project_id.trim();
         let device_id = config.device_id.trim();
         for config in config.streams.values_mut() {
-            if let Some(topic) = &config.topic {
-                let topic = str::replace(topic, "{tenant_id}", tenant_id);
-                let topic = str::replace(&topic, "{device_id}", device_id);
-                config.topic = Some(topic);
-            }
+            replace_topic_placeholders(config, tenant_id, device_id);
+        }
+
+        replace_topic_placeholders(&mut config.action_status, tenant_id, device_id);
+
+        if let Some(config) = &mut config.serializer_metrics {
+            replace_topic_placeholders(config, tenant_id, device_id);
         }
 
         Ok(config)
+    }
+
+    // Replace placeholders in topic strings with configured values for tenant_id and device_id
+    fn replace_topic_placeholders(config: &mut StreamConfig, tenant_id: &str, device_id: &str) {
+        if let Some(topic) = &config.topic {
+            let topic = topic.replace("{tenant_id}", tenant_id);
+            let topic = topic.replace("{device_id}", device_id);
+            config.topic = Some(topic);
+        }
     }
 }
 
@@ -139,12 +152,10 @@ impl Uplink {
         let (data_tx, data_rx) = bounded(10);
 
         let action_status_topic = &config
-            .streams
-            .get("action_status")
-            .ok_or_else(|| Error::msg("Action status topic missing from config"))?
+            .action_status
             .topic
             .as_ref()
-            .unwrap();
+            .ok_or_else(|| Error::msg("Action status topic missing from config"))?;
         let action_status = Stream::new("action_status", action_status_topic, 1, data_tx.clone());
 
         Ok(Uplink { config, action_rx, action_tx, data_rx, data_tx, action_status })
@@ -181,8 +192,7 @@ impl Uplink {
         let (raw_action_tx, raw_action_rx) = bounded(10);
         let mut mqtt = Mqtt::new(self.config.clone(), raw_action_tx);
 
-        let metrics_config = self.config.streams.get("metrics");
-        let metrics_stream = metrics_config.map(|metrics_config| {
+        let metrics_stream = self.config.serializer_metrics.as_ref().map(|metrics_config| {
             Stream::with_config(
                 &"metrics".to_owned(),
                 &self.config.project_id,
@@ -191,6 +201,7 @@ impl Uplink {
                 self.bridge_data_tx(),
             )
         });
+
         let serializer = Serializer::new(
             self.config.clone(),
             self.data_rx.clone(),


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->
Rework config to allow for special cases `serializer_metrics` and `action_status`

### Changes
<!--Detailed description of changes made-->
Require configuration for `serializer_metrics` and `action_status` to be separate from `streams`

### Why?
<!--Detailed description of why the changes had to be made-->
Allows for consistent configuration of special streams

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->