### PR TITLE
fix: Forward server errors as `ActionResponse`

### DIFF
--- a/uplink/src/base/actions/ota.rs
+++ b/uplink/src/base/actions/ota.rs
@@ -170,7 +170,8 @@ impl OtaDownloader {
         let (file, file_path) = self.create_file(&url, &update.version)?;
 
         // Create handler to perform download from URL
-        let resp = self.client.get(&url).send().await?;
+        // TODO: Error out for 1XX/3XX responses
+        let resp = self.client.get(&url).send().await?.error_for_status()?;
         info!("Downloading from {} into {}", url, file_path);
         self.download(resp, file).await?;
 

--- a/uplink/src/base/actions/ota.rs
+++ b/uplink/src/base/actions/ota.rs
@@ -114,7 +114,7 @@ impl OtaDownloader {
             // None if config.simulator.is_some() => {},
             None => client_builder,
         }
-            .build()?;
+        .build()?;
 
         // Create rendezvous channel with flume
         let (ota_tx, ota_rx) = flume::bounded(0);


### PR DESCRIPTION
Closes #<!--Issue Number-->

Currently server errors are being written to file even though they should be reported as failures to platform

### Changes
Server errors on reqwest reported to platform

### Why?
<!--Detailed description of why the changes had to be made-->

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->