### PR TITLE
fix: disable journalctl by default

### DIFF
--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -58,11 +58,6 @@ pub mod config {
     # triggered from cloud.
     actions = ["tunshell"]
 
-    [journalctl]
-    enabled = false
-    tags = ["kernel"]
-    priority = 6
-
     [persistence]
     path = "/tmp/uplink"
     max_file_size = 104857600 # 100MB


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->
journalctl is left disabled by default. To enable, add the following to `config.yaml`:
```
[journalctl]
tags = ["kernel"]
priority = 6
```

### Why?
<!--Detailed description of why the changes had to be made-->
This is expected behaviour

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
regular usage