### PR TITLE
fix: `ActionResponse` from `Payload`

### DIFF
--- a/uplink/src/collector/tcpjson.rs
+++ b/uplink/src/collector/tcpjson.rs
@@ -1,8 +1,6 @@
 use flume::{Receiver, RecvError, Sender};
 use futures_util::SinkExt;
 use log::{debug, error, info};
-use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use thiserror::Error;
 use tokio::net::{TcpListener, TcpStream};
 use tokio::time::{Duration, Sleep};
@@ -10,12 +8,13 @@ use tokio::{select, time};
 use tokio_stream::StreamExt;
 use tokio_util::codec::{Framed, LinesCodec, LinesCodecError};
 
-use std::{collections::HashMap, io, sync::Arc};
 use std::pin::Pin;
+use std::{collections::HashMap, io, sync::Arc};
 
 use super::util::DelayMap;
 use crate::base::actions::{Action, ActionResponse, Error as ActionsError};
-use crate::base::{Buffer, Config, Package, Point, Stream, StreamStatus};
+use crate::base::{Config, Package, Stream, StreamStatus};
+use crate::Payload;
 
 #[derive(Error, Debug)]
 pub enum Error {
@@ -236,47 +235,5 @@ impl Bridge {
 
             }
         }
-    }
-}
-
-// TODO Don't do any deserialization on payload. Read it a Vec<u8> which is in turn a json
-// TODO which cloud will double deserialize (Batch 1st and messages next)
-#[derive(Debug, Serialize, Deserialize)]
-pub struct Payload {
-    #[serde(skip_serializing)]
-    pub stream: String,
-    pub sequence: u32,
-    pub timestamp: u64,
-    #[serde(flatten)]
-    pub payload: Value,
-}
-
-impl Payload {
-    pub fn from_string<S: Into<String>>(input: S) -> Result<Self, Error> {
-        Ok(serde_json::from_str(&input.into())?)
-    }
-}
-
-impl Point for Payload {
-    fn sequence(&self) -> u32 {
-        self.sequence
-    }
-
-    fn timestamp(&self) -> u64 {
-        self.timestamp
-    }
-}
-
-impl Package for Buffer<Payload> {
-    fn topic(&self) -> Arc<String> {
-        self.topic.clone()
-    }
-
-    fn serialize(&self) -> serde_json::Result<Vec<u8>> {
-        serde_json::to_vec(&self.buffer)
-    }
-
-    fn anomalies(&self) -> Option<(String, usize)> {
-        self.anomalies()
     }
 }

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -135,10 +135,9 @@ use base::actions::Actions;
 pub use base::actions::{Action, ActionResponse};
 use base::mqtt::Mqtt;
 use base::serializer::Serializer;
-pub use base::{Config, Package, Point, Stream};
-pub use collector::simulator;
-pub use collector::tcpjson::{Bridge, Payload};
+pub use base::{Config, Package, Payload, Point, Stream};
 use collector::{logging::LoggerInstance, systemstats::StatCollector};
+pub use collector::{simulator, tcpjson::Bridge};
 pub use disk::Storage;
 
 pub struct Uplink {


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->
Current `ActionResponse` parsing from `Payload` is faulty, and can fail on use of `"id"` as key instead of `"action_id"`, which should be allowed.

### Changes
`ActionResponse` <=> `Payload`

### Why?
<!--Detailed description of why the changes had to be made-->
For use when checking `CurrentAction`

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->