### PR TITLE
feat: refactor as `FileDownloader` to handle non OTA actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,12 +138,10 @@ An example success response to an action with the id `"123"`, would look like:
 }
 ```
 
-#### Downloading OTA updates
-uplink has a built-in feature that enables it to download OTA firmware updates, this can be enabled by setting the following fields in the `config.toml` and using the `-c` option while starting uplink:
+#### Downloading OTA updates and other files
+uplink has a built-in feature that enables it to download OTA firmware updates, this can be enabled by setting the following field in the `config.toml` and using the `-c` option while starting uplink:
 ```toml
-[ota]
-enabled = true
-path = "/path/to/directory" # Where you want the update file to be downloaded
+download_path = "/path/to/directory" # Where you want the update file to be downloaded
 ```
 ```sh
 uplink -c config.toml -a auth.json
@@ -169,7 +167,7 @@ Once downloded, the payload JSON is updated with the file's on device path, as s
     "name": "update_firmware",
     "payload": "{
         \"url\": \"https://example.com/file\",
-        \"ota_path\": \"/path/to/directory\",
+        \"download_path\": \"/path/to/directory\",
         \"version\":\"1.0\"
     }"
 }

--- a/README.md
+++ b/README.md
@@ -141,7 +141,9 @@ An example success response to an action with the id `"123"`, would look like:
 #### Downloading OTA updates and other files
 uplink has a built-in feature that enables it to download OTA firmware updates, this can be enabled by setting the following field in the `config.toml` and using the `-c` option while starting uplink:
 ```toml
-download_path = "/path/to/directory" # Where you want the update file to be downloaded
+[downloader]
+actions = ["firmware_update"]
+path = "/path/to/directory" # Where you want the update file to be downloaded
 ```
 ```sh
 uplink -c config.toml -a auth.json

--- a/configs/config.toml
+++ b/configs/config.toml
@@ -63,17 +63,10 @@ flush_period = 30
 topic = "/tenants/{tenant_id}/devices/{device_id}/action/status"
 buf_size = 1
 
-# Configurations associated with the OTA module of uplink, if enabled Actions
-# with `name: "update_firmware"` can trigger the OtaDownloader to download the
-# OTA package.
-#
-# Required Parameters
-# - enabled: A boolean to determine if the feature must be enabled
-# - path: The location in file system where uplink will download and store
-#         OTA update files into.
-[ota]
-enabled = true
-path = "/var/tmp/ota-file"
+# The location in file system where uplink will download and store files from the URLs
+# mentioned in the "send_file" or "update_firmware" actions, over HTTP(S). If left
+# unconfigured, downloader will be disabled.
+download_path = "/var/tmp/ota-file"
 
 # Configurations associated with the system stats module of uplink, if enabled
 # system stats such as memory in use and CPU usage will be published onto special.

--- a/configs/config.toml
+++ b/configs/config.toml
@@ -63,17 +63,24 @@ flush_period = 30
 topic = "/tenants/{tenant_id}/devices/{device_id}/action/status"
 buf_size = 1
 
-# The location in file system where uplink will download and store files from the URLs
-# mentioned in the "send_file" or "update_firmware" actions, over HTTP(S). If left
-# unconfigured, downloader will be disabled.
-download_path = "/var/tmp/ota-file"
+# Configurations for uplink's built-in file downloader, including the actions that can trigger
+# a download, the location in file system where uplink will download and store files from the
+# provided URL in the payload of download file actions, over HTTP(S). 
+# If left unconfigured, downloader will be disabled.
+#
+# Required Parameters
+# - actions: List of actions names that can trigger the downloader
+# - path: Location in fs where the files are downloaded into
+[downloader]
+actions ["firmware_update", "send_file"]
+path = "/var/tmp/ota-file"
 
 # Configurations associated with the system stats module of uplink, if enabled
 # system stats such as memory in use and CPU usage will be published onto special.
 #
 # Required Parameters
 # - enabled: A boolean to determine if the feature must be enabled
-# - process_names: List of processes which are to be tracked in system stats
+# - process_names: List of process names that are to be tracked with system stats
 # - update_period: Time in seconds between each collection/publish of system stats
 [stats]
 enabled = false

--- a/examples/demo.py
+++ b/examples/demo.py
@@ -33,7 +33,7 @@ def action_complete(id):
 def update_firmware(action):
     payload = json.loads(action['payload'])
     print(payload)
-    shutil.move(payload["ota_path"], "/tmp/foobar")
+    shutil.move(payload["download_path"], "/tmp/foobar")
     os.chmod("/tmp/foobar", 0o755)
 
 def recv_actions():

--- a/tools/actions/main.go
+++ b/tools/actions/main.go
@@ -74,7 +74,7 @@ func createAction(name string) *Action {
 	id := generateID(10)
 	fmt.Println("action =", name, "id =", id)
 	switch name {
-	case "ota":
+	case "update_firmware":
 		kind := "process"
 		command := "tools/ota"
 		payload := `{"hello": "world"}`

--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -42,15 +42,9 @@ pub struct Persistence {
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct Authentication {
-    ca_certificate: String,
-    device_certificate: String,
-    device_private_key: String,
-}
-
-#[derive(Debug, Clone, Deserialize, Default)]
-pub struct Ota {
-    pub enabled: bool,
-    pub path: String,
+    pub ca_certificate: String,
+    pub device_certificate: String,
+    pub device_private_key: String,
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]
@@ -92,7 +86,7 @@ pub struct Config {
     pub streams: HashMap<String, StreamConfig>,
     pub action_status: StreamConfig,
     pub serializer_metrics: Option<StreamConfig>,
-    pub ota: Ota,
+    pub download_path: Option<String>,
     pub stats: Stats,
     pub simulator: Option<SimulatorConfig>,
     #[cfg(target_os = "linux")]

--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -67,7 +67,13 @@ pub struct SimulatorConfig {
 pub struct JournalctlConfig {
     pub tags: Vec<String>,
     pub priority: u8,
-    pub stream_size: Option<usize>
+    pub stream_size: Option<usize>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct Downloader {
+    pub actions: Vec<String>,
+    pub path: String,
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]
@@ -86,7 +92,7 @@ pub struct Config {
     pub streams: HashMap<String, StreamConfig>,
     pub action_status: StreamConfig,
     pub serializer_metrics: Option<StreamConfig>,
-    pub download_path: Option<String>,
+    pub downloader: Option<Downloader>,
     pub stats: Stats,
     pub simulator: Option<SimulatorConfig>,
     #[cfg(target_os = "linux")]

--- a/uplink/src/collector/downloader.rs
+++ b/uplink/src/collector/downloader.rs
@@ -1,10 +1,10 @@
-//! Contains definitions necessary to download files such as OTA updates, as notified by a download [`Action`], i.e. with `name` `"update_firmware"` or `"send_file"`
+//! Contains definitions necessary to download files such as OTA updates, as notified by a download file [`Action`]
 //!
 //! The thread running [`Actions`] forwards the appropriate `Action`s to the [`FileDownloader`] with a _rendezvous channel_(A channel bounded to 0).
 //! The `Action` is sent only when a receiver is awaiting on the otherside and fails otherwise. This allows us to instantly recognize that another
 //! download is currently being performed.
 //!
-//! OTA `Action`s contain JSON formatted [`payload`] which can be deserialized into an object of type [`DownloadFile`].
+//! Download file `Action`s contain JSON formatted [`payload`] which can be deserialized into an object of type [`DownloadFile`].
 //! This object contains information such as the `url` where the download file is accessible from, the `version` number associated
 //! with the downloaded file and a field which must be updated with the location in file-system where the file is stored into.
 //!
@@ -83,7 +83,7 @@ impl From<flume::TrySendError<Action>> for Error {
     }
 }
 
-/// This struct contains the necessary components to download and store file as notified by a download
+/// This struct contains the necessary components to download and store file as notified by a download file
 /// [`Action`], while also sending periodic [`ActionResponse`]s to update progress and finally forwarding
 /// the download [`Action`], updated with information regarding where the file is stored in the file-system
 /// to the connected bridge application.
@@ -265,7 +265,7 @@ impl FileDownloader {
     }
 }
 
-/// Expected JSON format of data contained in the [`payload`] of a download [`Action`]
+/// Expected JSON format of data contained in the [`payload`] of a download file [`Action`]
 ///
 /// [`payload`]: Action#structfield.payload
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]

--- a/uplink/src/collector/downloader.rs
+++ b/uplink/src/collector/downloader.rs
@@ -292,14 +292,14 @@ mod test {
         // Ensure path exists
         std::fs::create_dir_all(DOWNLOAD_DIR).unwrap();
         // Prepare config
-        let download_path = format!("{}/download", DOWNLOAD_DIR);
+        let downloader_cfg = Downloader { actions: vec!["firmware_update".to_string()], path : format!("{}/download", DOWNLOAD_DIR) };
 
         // Create channels to forward and push action_status on
         let (stx, srx) = flume::bounded(1);
         let (btx, brx) = flume::bounded(1);
         let action_status = Stream::dynamic_with_size("actions_status", "", "", 1, stx);
         let (download_tx, downloader) =
-            FileDownloader::new(download_path.clone(), None, action_status, btx).unwrap();
+            FileDownloader::new(downloader_cfg.clone(), None, action_status, btx).unwrap();
 
         // Start FileDownloader in separate thread
         std::thread::spawn(|| downloader.start().unwrap());
@@ -311,7 +311,7 @@ mod test {
             download_path: None,
         };
         let mut expected_forward = download_update.clone();
-        expected_forward.download_path = Some(download_path + "/1.0/logo.png");
+        expected_forward.download_path = Some(downloader_cfg.path + "/update_firmware/1.0/logo.png");
         let download_action = Action {
             device_id: Default::default(),
             action_id: "1".to_string(),
@@ -340,14 +340,14 @@ mod test {
         // Ensure path exists
         std::fs::create_dir_all(DOWNLOAD_DIR).unwrap();
         // Prepare config
-        let download_path = format!("{}/download", DOWNLOAD_DIR);
+        let downloader_cfg = Downloader { actions: vec!["firmware_update".to_string()], path : format!("{}/download", DOWNLOAD_DIR) };
 
         // Create channels to forward and push action_status on
         let (stx, _) = flume::bounded(1);
         let (btx, _) = flume::bounded(1);
         let action_status = Stream::dynamic_with_size("actions_status", "", "", 1, stx);
         let (download_tx, downloader) =
-            FileDownloader::new(download_path.clone(), None, action_status, btx).unwrap();
+            FileDownloader::new(downloader_cfg.clone(), None, action_status, btx).unwrap();
 
         // Start FileDownloader in separate thread
         std::thread::spawn(|| downloader.start().unwrap());
@@ -359,7 +359,7 @@ mod test {
             download_path: None,
         };
         let mut expected_forward = download_update.clone();
-        expected_forward.download_path = Some(download_path + "/1.0/logo.png");
+        expected_forward.download_path = Some(downloader_cfg.path + "/update_firmware/1.0/logo.png");
         let download_action = Action {
             device_id: Default::default(),
             action_id: "1".to_string(),

--- a/uplink/src/collector/downloader.rs
+++ b/uplink/src/collector/downloader.rs
@@ -311,7 +311,7 @@ mod test {
             download_path: None,
         };
         let mut expected_forward = download_update.clone();
-        expected_forward.download_path = Some(downloader_cfg.path + "/update_firmware/1.0/logo.png");
+        expected_forward.download_path = Some(downloader_cfg.path + "/firmware_update/1.0/logo.png");
         let download_action = Action {
             device_id: Default::default(),
             action_id: "1".to_string(),
@@ -359,7 +359,7 @@ mod test {
             download_path: None,
         };
         let mut expected_forward = download_update.clone();
-        expected_forward.download_path = Some(downloader_cfg.path + "/update_firmware/1.0/logo.png");
+        expected_forward.download_path = Some(downloader_cfg.path + "/firmware_update/1.0/logo.png");
         let download_action = Action {
             device_id: Default::default(),
             action_id: "1".to_string(),

--- a/uplink/src/collector/mod.rs
+++ b/uplink/src/collector/mod.rs
@@ -1,3 +1,4 @@
+pub mod downloader;
 pub mod logging;
 pub mod simulator;
 pub mod systemstats;

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -173,9 +173,9 @@ impl Uplink {
         thread::spawn(move || tunshell_session.start());
 
         // Launch a thread to handle file downloads
-        let download_tx = if let Some(download_path) = self.config.download_path.clone() {
+        let download_tx = if let Some(downloader_cfg) = self.config.downloader.clone() {
             let (download_tx, file_downloader) = FileDownloader::new(
-                download_path,
+                downloader_cfg,
                 self.config.authentication.clone(),
                 self.action_status.clone(),
                 self.action_tx.clone(),

--- a/uplink/src/main.rs
+++ b/uplink/src/main.rs
@@ -100,8 +100,8 @@ fn banner(commandline: &CommandLine, config: &Arc<Config>) {
         println!("    persistence_max_segment_size: {}", persistence.max_file_size);
         println!("    persistence_max_segment_count: {}", persistence.max_file_count);
     }
-    if let Some(download_path) = &config.download_path {
-        println!("    download_path: {}", download_path);
+    if let Some(downloader_cfg) = &config.downloader {
+        println!("    download_path: {}", downloader_cfg.path);
     }
     if config.stats.enabled {
         println!("    processes: {:?}", config.stats.process_names);

--- a/uplink/src/main.rs
+++ b/uplink/src/main.rs
@@ -1,41 +1,41 @@
 //! uplink is a utility/library to interact with the Bytebeam platform. It's internal architecture is described in the diagram below.
 //! We use [`rumqttc`], which implements the MQTT protocol, to communicate with the platform. Communication is handled separately as ingress and egress
-//! by [`Mqtt`] and [`Serializer`] respectively. [`Action`]s are received and forwarded by Mqtt to the [`Actions`] module, where it is handled depending
-//! on it's type and purpose, forwarding it to either the [`Bridge`](collector::tcpjson::Bridge), [`Process`](base::actions::process::Process),
-//! [`OtaDownloader`](base::actions::ota::OtaDownloader) or [`TunshellSession`](base::actions::tunshell::TunshellSession). Bridge forwards received Actions
-//! to devices connected to it through the `bridge_port` and collects response data from these devices, to forward to the platform.
+//! by [`Mqtt`](uplink::Mqtt) and [`Serializer`](uplink::Serializer) respectively. [`Action`](uplink::Action)s are received and forwarded by Mqtt to the
+//! [`Middleware`](uplink::Middleware) module, where it is handled depending on its type and purpose, forwarding it to either the [`Bridge`](uplink::Bridge),
+//! `Process`, [`FileDownloader`](uplink::FileDownloader) or [`TunshellSession`](uplink::TunshellSession). Bridge forwards received Actions to the devices
+//! connected to it through the `bridge_port` and collects response data from these devices, to forward to the platform.
 //!
-//! Response data can be of multiple types, of interest to us are [`ActionResponse`](base::actions::response::ActionResponse)s, which are forwarded to Actions
+//! Response data can be of multiple types, of interest to us are [`ActionResponse`](uplink::ActionResponse)s, which are forwarded to Actions
 //! and then to Serializer where depending on the network, it may be stored onto disk with [`Storage`](disk::Storage) to ensure packets aren't lost.
 //!
 //!```text
-//!                                                                                 ┌────────────┐
-//!                                                                                 │MQTT backend│
-//!                                                                                 └─────┐▲─────┘
-//!                                                                                       ││
-//!                                                                                Action ││ ActionResponse
-//!                                                                                       ││ / Data
-//!                                                                           Action    ┌─▼└─┐
-//!                                                                       ┌─────────────┤Mqtt◄───────────┐
-//!                                                                       │             └────┘           │ ActionResponse
-//!                                                                       │                              │ / Data
-//!                                                                       │                              │
-//!                                                                   ┌───▼───┐   ActionResponse    ┌────┴─────┐
-//!                                                  ┌────────────────►Actions├─────────────────────►Serializer│
-//!                                                  │                └┬─┬─┬─┬┘                     └────▲─────┘
-//!                                                  │                 │ │ │ │                           │
-//!                                                  │                 │ │ │ └───────────────────┐       │Data
-//!                                                  │     Tunshell Key│ │ │ Action              │    ┌──┴───┐   Action       ┌───────────┐
-//!                                                  │        ┌────────┘ │ └───────────┐         ├────►Bridge◄────────────────►Application│
-//!                                                  │  ------│----------│-------------│-------- │    └──┬───┘ ActionResponse │ / Device  │
-//!                                                  │  '     │          │             │       ' │       │       / Data       └───────────┘
-//!                                                  │  '┌────▼───┐  ┌───▼───┐  ┌──────▼──────┐' │       │
-//!                                                  │  '│Tunshell│  │Process│  │OtaDownloader├──┘       │
-//!                                                  │  '└────┬───┘  └───┬───┘  └──────┬──────┘'         │
-//!                                                  │  '     │          │             │       '         │
-//!                                                  │  ------│----------│-------------│--------         │
-//!                                                  │        │          │             │                 │
-//!                                                  └────────┴──────────┴─────────────┴─────────────────┘
+//!                                                                                  ┌────────────┐
+//!                                                                                  │MQTT backend│
+//!                                                                                  └─────┐▲─────┘
+//!                                                                                        ││
+//!                                                                                 Action ││ ActionResponse
+//!                                                                                        ││ / Data
+//!                                                                            Action    ┌─▼└─┐
+//!                                                                        ┌─────────────┤Mqtt◄──────────────┐
+//!                                                                        │             └────┘              │ ActionResponse
+//!                                                                        │                                 │ / Data
+//!                                                                        │                                 │
+//!                                                                   ┌────▼─────┐   ActionResponse     ┌────┴─────┐
+//!                                                  ┌────────────────►Middleware├──────────────────────►Serializer│
+//!                                                  │                └┬──┬──┬──┬┘                      └────▲─────┘
+//!                                                  │                 │  │  │  │                            │
+//!                                                  │                 │  │  │  └────────────────────┐       │Data
+//!                                                  │     Tunshell Key│  │  │ Action                │    ┌──┴───┐   Action       ┌───────────┐
+//!                                                  │        ┌────────┘  │  └───────────┐           ├────►Bridge◄────────────────►Application│
+//!                                                  │  ------│-----------│--------------│---------- │    └──┬───┘ ActionResponse │ / Device  │
+//!                                                  │  '     │           │              │         ' │       │       / Data       └───────────┘
+//!                                                  │  '┌────▼───┐   ┌───▼───┐   ┌──────▼───────┐ ' │       │
+//!                                                  │  '│Tunshell│   │Process│   │FileDownloader├───┘       │
+//!                                                  │  '└────┬───┘   └───┬───┘   └──────┬───────┘ '         │
+//!                                                  │  '     │           │              │         '         │
+//!                                                  │  ------│-----------│--------------│----------         │
+//!                                                  │        │           │              │                   │
+//!                                                  └────────┴───────────┴──────────────┴───────────────────┘
 //!                                                                      ActionResponse
 //!```
 

--- a/uplink/src/main.rs
+++ b/uplink/src/main.rs
@@ -100,8 +100,8 @@ fn banner(commandline: &CommandLine, config: &Arc<Config>) {
         println!("    persistence_max_segment_size: {}", persistence.max_file_size);
         println!("    persistence_max_segment_count: {}", persistence.max_file_count);
     }
-    if config.ota.enabled {
-        println!("    ota_path: {}", config.ota.path);
+    if let Some(download_path) = &config.download_path {
+        println!("    download_path: {}", download_path);
     }
     if config.stats.enabled {
         println!("    processes: {:?}", config.stats.process_names);
@@ -134,7 +134,6 @@ async fn main() -> Result<(), Error> {
         let _err_guard = stdio_override::StderrOverride::override_file(err_path).unwrap();
         (_out_guard, _err_guard)
     });
-
     banner(&commandline, &config);
 
     let mut uplink = Uplink::new(config.clone())?;


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->
Rename and generalize working of `OtaDownloader`

### Changes
<!--Detailed description of changes made-->
Allow user to customize downloader and allow triggering file downloads for multiple types of actions as follows:
```
[downloader]
actions = ["firmware_update", "send_file"]
path = "/path/to/downloads"
```

### Why?
<!--Detailed description of why the changes had to be made-->
This will simplify the download feature and enable downloads for non-OTA tasks as well.

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->