### PR TITLE
fix: parse timestamp for journalctl log entries into millis

### DIFF
--- a/uplink/src/collector/logging/journalctl.rs
+++ b/uplink/src/collector/logging/journalctl.rs
@@ -68,17 +68,17 @@ impl LogEntry {
         let entry: JournaldEntry = serde_json::from_str(line)?;
 
         Ok(Self {
-                level: LogLevel::from_syslog_level(&entry.priority),
-                log_timestamp: entry.log_timestamp,
-                tag: entry.tag,
-                message: entry.message,
+            level: LogLevel::from_syslog_level(&entry.priority),
+            log_timestamp: entry.log_timestamp,
+            tag: entry.tag,
+            message: entry.message,
             line: line.to_owned(),
         })
     }
 
     pub fn to_payload(&self, sequence: u32) -> anyhow::Result<Payload> {
         let payload = serde_json::to_value(self)?;
-        let timestamp = self.log_timestamp.parse::<u64>()?;
+        let timestamp = self.log_timestamp.parse::<u64>()? / 1000;
 
         Ok(Payload { stream: "logs".to_string(), sequence, timestamp, payload })
     }

--- a/uplink/src/collector/logging/journalctl.rs
+++ b/uplink/src/collector/logging/journalctl.rs
@@ -78,6 +78,7 @@ impl LogEntry {
 
     pub fn to_payload(&self, sequence: u32) -> anyhow::Result<Payload> {
         let payload = serde_json::to_value(self)?;
+        // Convert from microseconds to milliseconds
         let timestamp = self.log_timestamp.parse::<u64>()? / 1000;
 
         Ok(Payload { stream: "logs".to_string(), sequence, timestamp, payload })

--- a/uplink/src/collector/logging/mod.rs
+++ b/uplink/src/collector/logging/mod.rs
@@ -144,9 +144,9 @@ impl LoggerInstance {
 
                 let next_line = next_line.trim();
                 let entry = match LogEntry::from_string(next_line) {
-                    Some(entry) => entry,
-                    _ => {
-                        log::warn!("log line in unknown format: {:?}", next_line);
+                    Ok(entry) => entry,
+                    Err(e) => {
+                        log::warn!("log line: {} couldn't be parsed due to: {}", next_line, e);
                         continue;
                     }
                 };


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
Convert `log_timestamp` value collected by journalctl into millis from micros

### Why?
Platform expects millis

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->