### PR TITLE
doc: fix action name for OTA

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ An example success response to an action with the id `"123"`, would look like:
 uplink has a built-in feature that enables it to download OTA firmware updates, this can be enabled by setting the following field in the `config.toml` and using the `-c` option while starting uplink:
 ```toml
 [downloader]
-actions = ["firmware_update"]
+actions = ["update_firmware"]
 path = "/path/to/directory" # Where you want the update file to be downloaded
 ```
 ```sh

--- a/configs/config.toml
+++ b/configs/config.toml
@@ -72,7 +72,7 @@ buf_size = 1
 # - actions: List of actions names that can trigger the downloader
 # - path: Location in fs where the files are downloaded into
 [downloader]
-actions = ["firmware_update", "send_file"]
+actions = ["update_firmware", "send_file"]
 path = "/var/tmp/ota-file"
 
 # Configurations associated with the system stats module of uplink, if enabled

--- a/docs/apps.md
+++ b/docs/apps.md
@@ -2,7 +2,7 @@
 uplink handles device data, `Action`s and `ActionResponse`s. An action is received from the broker and sent to user apps that can also send either user data or action responses, containing status of actions in execution.
 
 ## Action
-An `Action` is the term used to refer to messages that carry commands and other information that can be used by uplink or apps connected to it. Some common Actions include the `firmware_update` and `config_update` actions which when executed by the target device will lead to the initiation of an OTA update. A firmware update `Action` messages in JSON would be structured as follows:
+An `Action` is the term used to refer to messages that carry commands and other information that can be used by uplink or apps connected to it. Some common Actions include the `update_firmware` and `config_update` actions which when executed by the target device will lead to the initiation of an OTA update. A firmware update `Action` messages in JSON would be structured as follows:
 ```js
 {
     "action_id": "...", // An integer value that can be used to maintain indempotence


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
"firmware_update" ~> "update_firmware" in example configs and docs

### Why?
The platform sends actions with name "update_firmware", not "firmware_update"

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->