### PR TITLE
feat: multiple tcp collectors, broadcast actions

### DIFF
--- a/docs/apps.md
+++ b/docs/apps.md
@@ -61,7 +61,7 @@ An example success response to an action with the id `"123"`, would look like:
 }
 ```
 
-> **NOTE:** Uplink broadcasts actions to all connected applications and expects the applications to handle the action appropriately. There is a timeout mechanism which on being triggered will send a ***Failure*** response to platform and stop forwarding any *Progress* responses from the connected applications. In order to not trigger this timeout, an application must keep sending timely *Progress* responses(faster than once every 30 seconds) until a final ***Failure*** or ***Completion*** response is made to uplink.
+> **NOTE:** Uplink broadcasts actions to all connected applications and expects only one application to handle the action. There is a timeout mechanism which on being triggered will send a ***Failed*** response to platform and stop forwarding any *Progress* responses from the connected applications. In order to not trigger this timeout, an application must keep sending timely *Progress* responses(faster than once every 30 seconds) until a final ***Failed*** or ***Completed*** response is made to uplink.
 
 ## Demonstration
 We have provided examples written in python and golang to demonstrate how you can receive Actions and reply back with either data or responses. You can checkout the examples provided in the `demo/` directory and execute them as such:

--- a/docs/apps.md
+++ b/docs/apps.md
@@ -61,6 +61,8 @@ An example success response to an action with the id `"123"`, would look like:
 }
 ```
 
+> **NOTE:** Uplink broadcasts actions to all connected applications and expects the applications to handle the action appropriately. There is a timeout mechanism which on being triggered will send a ***Failure*** response to platform and stop forwarding any *Progress* responses from the connected applications. In order to not trigger this timeout, an application must keep sending timely *Progress* responses(faster than once every 30 seconds) until a final ***Failure*** or ***Completion*** response is made to uplink.
+
 ## Demonstration
 We have provided examples written in python and golang to demonstrate how you can receive Actions and reply back with either data or responses. You can checkout the examples provided in the `demo/` directory and execute them as such:
 1. Ensure uplink is running on device and connected to relevant broker.

--- a/uplink/src/base/middleware/mod.rs
+++ b/uplink/src/base/middleware/mod.rs
@@ -74,12 +74,9 @@ impl Middleware {
 
             let action_id = action.action_id.clone();
             let action_name = action.name.clone();
-            let error = match self.handle(action).await {
-                Ok(_) => continue,
-                Err(e) => e,
-            };
-
-            self.forward_action_error(&action_id, &action_name, error).await;
+            if let Err(error) = self.handle(action).await {
+                self.forward_action_error(&action_id, &action_name, error).await;
+            }
         }
     }
 

--- a/uplink/src/collector/downloader.rs
+++ b/uplink/src/collector/downloader.rs
@@ -50,8 +50,8 @@ use reqwest::{Certificate, Client, ClientBuilder, Identity, Response};
 use serde::{Deserialize, Serialize};
 
 use std::fs::{create_dir_all, File};
-use std::{io::Write, path::PathBuf};
 use std::time::Duration;
+use std::{io::Write, path::PathBuf};
 
 use crate::base::{Authentication, Downloader};
 use crate::{Action, ActionResponse, Stream};
@@ -120,7 +120,7 @@ impl FileDownloader {
             }
             None => client_builder,
         }
-            .build()?;
+        .build()?;
 
         // Create rendezvous channel with flume
         let (download_tx, download_rx) = flume::bounded(0);
@@ -164,13 +164,10 @@ impl FileDownloader {
                 }
                 tokio::time::sleep(Duration::from_secs(30)).await;
             }
-            match error {
-                None => {}
-                Some(e) => {
-                    let status = ActionResponse::failure(&self.action_id, e.to_string())
-                        .set_sequence(self.sequence());
-                    self.send_status(status).await;
-                }
+            if let Some(e) = error {
+                let status = ActionResponse::failure(&self.action_id, e.to_string())
+                    .set_sequence(self.sequence());
+                self.send_status(status).await;
             }
         }
     }
@@ -310,7 +307,10 @@ mod test {
         // Ensure path exists
         std::fs::create_dir_all(DOWNLOAD_DIR).unwrap();
         // Prepare config
-        let downloader_cfg = Downloader { actions: vec!["firmware_update".to_string()], path : format!("{}/download", DOWNLOAD_DIR) };
+        let downloader_cfg = Downloader {
+            actions: vec!["firmware_update".to_string()],
+            path: format!("{}/download", DOWNLOAD_DIR),
+        };
 
         // Create channels to forward and push action_status on
         let (stx, srx) = flume::bounded(1);
@@ -329,7 +329,8 @@ mod test {
             download_path: None,
         };
         let mut expected_forward = download_update.clone();
-        expected_forward.download_path = Some(downloader_cfg.path + "/firmware_update/1.0/logo.png");
+        expected_forward.download_path =
+            Some(downloader_cfg.path + "/firmware_update/1.0/logo.png");
         let download_action = Action {
             device_id: Default::default(),
             action_id: "1".to_string(),
@@ -358,7 +359,10 @@ mod test {
         // Ensure path exists
         std::fs::create_dir_all(DOWNLOAD_DIR).unwrap();
         // Prepare config
-        let downloader_cfg = Downloader { actions: vec!["firmware_update".to_string()], path : format!("{}/download", DOWNLOAD_DIR) };
+        let downloader_cfg = Downloader {
+            actions: vec!["firmware_update".to_string()],
+            path: format!("{}/download", DOWNLOAD_DIR),
+        };
 
         // Create channels to forward and push action_status on
         let (stx, _) = flume::bounded(1);
@@ -377,7 +381,8 @@ mod test {
             download_path: None,
         };
         let mut expected_forward = download_update.clone();
-        expected_forward.download_path = Some(downloader_cfg.path + "/firmware_update/1.0/logo.png");
+        expected_forward.download_path =
+            Some(downloader_cfg.path + "/firmware_update/1.0/logo.png");
         let download_action = Action {
             device_id: Default::default(),
             action_id: "1".to_string(),

--- a/uplink/src/collector/tcpjson.rs
+++ b/uplink/src/collector/tcpjson.rs
@@ -114,6 +114,8 @@ struct TcpJson {
 }
 
 impl TcpJson {
+    /// NOTE: We only expect one action to be processed over uplink's bridge at a time,
+    /// which is what current_action achieves
     pub async fn collect(
         &mut self,
         mut client: Framed<TcpStream, LinesCodec>,

--- a/uplink/src/collector/tcpjson.rs
+++ b/uplink/src/collector/tcpjson.rs
@@ -86,19 +86,6 @@ impl Bridge {
             let mut current_action_: Option<CurrentAction> = None;
 
             loop {
-                // Update action_status for current action
-                if self.actions_tx.receiver_count() == 0 && current_action_.is_some() {
-                    if let Err(e) = self
-                        .action_status
-                        .fill(ActionResponse::failure(
-                            current_action_.take().unwrap().id.as_str(),
-                            "bridge disconnected",
-                        ))
-                        .await
-                    {
-                        error!("Failed to fill. Error = {:?}", e);
-                    }
-                }
                 select! {
                     v = listener.accept() =>  {
                         match v {

--- a/uplink/src/collector/tcpjson.rs
+++ b/uplink/src/collector/tcpjson.rs
@@ -213,8 +213,7 @@ impl TcpJson {
                         }
                     };
 
-                    // If incoming data is a response for an action, drop it
-                    // if timeout is already sent to cloud
+                    // If incoming data is a response for an action, set in_execution and forward
                     if data.stream == "action_status" {
                         let response = match ActionResponse::from_payload(&data) {
                             Ok(response) => response,

--- a/uplink/src/collector/tcpjson.rs
+++ b/uplink/src/collector/tcpjson.rs
@@ -46,6 +46,8 @@ pub struct Bridge {
     action_status: Stream<ActionResponse>,
     status_tx: Sender<ActionResponse>,
     status_rx: Receiver<ActionResponse>,
+    close_tx: Sender<()>,
+    close_rx: Receiver<()>,
 }
 
 const ACTION_TIMEOUT: Duration = Duration::from_secs(30);
@@ -59,8 +61,19 @@ impl Bridge {
     ) -> Bridge {
         let (actions_tx, _) = channel(10);
         let (status_tx, status_rx) = bounded(10);
+        let (close_tx, close_rx) = bounded(1);
 
-        Bridge { action_status, data_tx, config, actions_rx, actions_tx, status_tx, status_rx }
+        Bridge {
+            action_status,
+            data_tx,
+            config,
+            actions_rx,
+            actions_tx,
+            status_tx,
+            status_rx,
+            close_tx,
+            close_rx,
+        }
     }
 
     pub async fn start(&mut self) -> Result<(), Error> {
@@ -156,6 +169,17 @@ impl Bridge {
                             error!("Failed to fill. Error = {:?}", e);
                         }
                     }
+
+                    // In case one of the connected applications drops, check to see if all apps are down.
+                    // In which case send a failure response with the message "Bridge disconnected".
+                    _ = self.close_rx.recv_async() =>  {
+                        if self.actions_tx.receiver_count() == 0 && current_action_.is_some(){
+                            let status = ActionResponse::failure(&current_action_.take().unwrap().id, "Bridge disconnected");
+                            if let Err(e) = self.action_status.fill(status).await {
+                                error!("Failed to fill. Error = {:?}", e);
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -167,10 +191,15 @@ impl Bridge {
             status_tx: self.status_tx.clone(),
             streams: Streams::new(self.config.clone(), self.data_tx.clone()),
             actions_rx: self.actions_tx.subscribe(),
+            close_tx: self.close_tx.clone(),
         };
         tokio::task::spawn(async move {
             if let Err(e) = tcp_json.collect(framed).await {
                 error!("Bridge failed. Error = {:?}", e);
+            }
+
+            if let Err(e) = tcp_json.close_tx.send_async(()).await {
+                error!("Failed to send close message. Error = {:?}", e);
             }
         });
     }
@@ -180,6 +209,7 @@ struct TcpJson {
     streams: Streams,
     status_tx: Sender<ActionResponse>,
     actions_rx: BRx<Action>,
+    close_tx: Sender<()>,
 }
 
 impl TcpJson {


### PR DESCRIPTION
Closes #<!--Issue Number-->

Enable multiple collectors, broadcasting actions as received, to all connected applications.

### Changes
- Accept multiple TCP connections
- Broadcast actions to all connected applications, let the application choose if they want to process the received action or not

NOTE: `current_action` still limits how many actions we can process at a time, so if an action was broadcast to all connected apps, uplink will not broadcast the next action until the action being processed times out or returns a `"Completed"/"Failed"` status.

### Why?
Users might want to connect multiple applications to a single uplink instance, with the same TCP port/bridge.

### Trials Performed
1. Multiple applications are able to connect and send data, while also being able to receive the same action as each other.
2. When no application is connected, bridge down error is forwarded to platform.