### PR TITLE
fix: use `action_id` and let it alias as `id` for "action_status"

### DIFF
--- a/examples/demo.go
+++ b/examples/demo.go
@@ -11,7 +11,7 @@ type ActionStatus struct {
 	Stream    string   `json:"stream"`
 	Sequence  int32    `json:"sequence"`
 	Timestamp int64    `json:"timestamp"`
-	Id        string   `json:"id"`
+	Id        string   `json:"action_id"`
 	State     string   `json:"state"`
 	Progress  int8     `json:"progress"`
 	Errors    []string `json:"errors"`

--- a/examples/demo.py
+++ b/examples/demo.py
@@ -24,7 +24,7 @@ def action_complete(id):
         "stream": "action_status",
         "sequence": 0,
         "timestamp": int(time.time()*1000000),
-        "id": id,
+        "action_id": id,
         "state": "Completed",
         "progress": 100,
         "errors": []

--- a/tools/actions/main.go
+++ b/tools/actions/main.go
@@ -13,7 +13,7 @@ import (
 )
 
 type Action struct {
-	ID      string `json:"id"`
+	ID      string `json:"action_id"`
 	Kind    string `json:"kind"`
 	Command string `json:"name"`
 	Payload string `json:"payload"`

--- a/tools/update_firmware.go
+++ b/tools/update_firmware.go
@@ -9,7 +9,7 @@ import (
 )
 
 type ActionStatus struct {
-	Id       string   `json:"id"`
+	Id       string   `json:"action_id"`
 	Timestamp int64   `json:"timestamp"`
 	State    string   `json:"state"`
 	Progress string   `json:"progress"`

--- a/uplink/src/base/actions.rs
+++ b/uplink/src/base/actions.rs
@@ -25,6 +25,7 @@ pub struct Action {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ActionResponse {
+    #[serde(alias = "id")]
     pub action_id: String,
     // sequence number
     pub sequence: u32,


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
Use `action_id` instead of `id` as field for "action_status" in examples, allow old code to continue working by aliasing it as `id`.

### Why?
This updates the documentary code to support changes made by @bmcpt in #72 and ensures applications written with older uplink in mind aren't broken in the process.  

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
Run against examples with and without the change, both are observed to be working as expected.