### PR TITLE
Add 'ignore_actions_if_no_clients'

### DIFF
--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -94,6 +94,7 @@ pub struct Config {
     pub downloader: Option<Downloader>,
     pub stats: Stats,
     pub simulator: Option<SimulatorConfig>,
+    pub ignore_actions_if_no_clients: Option<bool>,
     #[cfg(target_os = "linux")]
     pub journalctl: Option<JournalctlConfig>,
     #[cfg(target_os = "android")]

--- a/uplink/src/bin/test.rs
+++ b/uplink/src/bin/test.rs
@@ -1,0 +1,53 @@
+use std::time::Duration;
+
+#[tokio::main]
+async fn main() {
+    let (t1, r1) = flume::bounded(1);
+    let (t2, r2) = flume::bounded(10);
+    {
+        let r1 = r1.clone();
+        let t2 = t2.clone();
+        tokio::spawn(async move {
+            loop {
+                let value = match r1.recv_async().await {
+                    Ok(value) => value,
+                    Err(_) => break,
+                };
+                first_response(value);
+                match t2.send_async(value).await {
+                    Ok(value) => value,
+                    Err(_) => break,
+                }
+            }
+        });
+    }
+    // tokio::spawn(async move {
+    //     loop {
+    //         let value = match r2.recv_async().await {
+    //             Ok(value) => value,
+    //             Err(_) => break,
+    //         };
+    //         second_response(value);
+    //     }
+    // });
+
+    tokio::spawn(async move {
+        let mut idx = 1;
+        loop {
+            match t1.send_async(idx).await {
+                Ok(value) => value,
+                Err(_) => break,
+            };
+            idx += 1;
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+    }).await.unwrap();
+}
+
+fn first_response(value: u32) {
+    println!("first_response: {}", value);
+}
+
+fn second_response(value: u32) {
+    println!("second_response: {}", value);
+}

--- a/uplink/src/collector/tcpjson.rs
+++ b/uplink/src/collector/tcpjson.rs
@@ -70,10 +70,14 @@ impl Bridge {
                     }
                     action = self.actions_rx.recv_async() => {
                         let action = action?;
-                        error!("Bridge down!! Action ID = {}", action.action_id);
-                        let status = ActionResponse::failure(&action.action_id, "Bridge down");
-                        if let Err(e) = self.action_status.fill(status).await {
-                            error!("Failed to send busy status. Error = {:?}", e);
+                        if self.config.ignore_actions_if_no_clients.unwrap_or(false) {
+                            error!("No clients connected, ignoring action = {:?}", action);
+                        } else {
+                            error!("No clients connected, Action ID = {}", action.action_id);
+                            let status = ActionResponse::failure(&action.action_id, "Bridge down");
+                            if let Err(e) = self.action_status.fill(status).await {
+                                error!("Failed to send busy status. Error = {:?}", e);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
### Changes
Added `ignore_actions_if_client_disconnected` boolean flag to config. Works as name suggests.

### Why?
Actions received between uplink start and client connect are failed needlessly.
