### PR TITLE
feat: make `keep_alive` configurable

### DIFF
--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -86,6 +86,7 @@ pub struct Config {
     pub bridge_port: u16,
     pub max_packet_size: usize,
     pub max_inflight: u16,
+    pub keep_alive: u64,
     pub actions: Vec<String>,
     pub persistence: Option<Persistence>,
     pub streams: HashMap<String, StreamConfig>,

--- a/uplink/src/base/mqtt.rs
+++ b/uplink/src/base/mqtt.rs
@@ -123,7 +123,7 @@ fn mqttoptions(config: &Config) -> MqttOptions {
     // let (rsa_private, ca) = get_certs(&config.key.unwrap(), &config.ca.unwrap());
     let mut mqttoptions = MqttOptions::new(&config.device_id, &config.broker, config.port);
     mqttoptions.set_max_packet_size(config.max_packet_size, config.max_packet_size);
-    mqttoptions.set_keep_alive(Duration::from_secs(60));
+    mqttoptions.set_keep_alive(Duration::from_secs(config.keep_alive));
     mqttoptions.set_inflight(config.max_inflight);
 
     if let Some(auth) = config.authentication.clone() {

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -52,6 +52,7 @@ pub mod config {
     run_logcat = true
     max_packet_size = 102400
     max_inflight = 100
+    keep_alive = 60
 
     # Whitelist of binaries which uplink can spawn as a process
     # This makes sure that user is protected against random actions

--- a/uplink/src/main.rs
+++ b/uplink/src/main.rs
@@ -108,6 +108,7 @@ fn banner(commandline: &CommandLine, config: &Arc<Config>) {
     println!("    secure_transport: {}", config.authentication.is_some());
     println!("    max_packet_size: {}", config.max_packet_size);
     println!("    max_inflight_messages: {}", config.max_inflight);
+    println!("    keep_alive_timeout: {}", config.keep_alive);
     if let Some(persistence) = &config.persistence {
         println!("    persistence_dir: {}", persistence.path);
         println!("    persistence_max_segment_size: {}", persistence.max_file_size);

--- a/uplink/src/main.rs
+++ b/uplink/src/main.rs
@@ -76,7 +76,9 @@ fn initialize_logging(commandline: &CommandLine) {
     }
 
     if commandline.modules.is_empty() {
-        config.add_filter_allow_str("uplink").add_filter_allow_str("disk");
+        for module in ["uplink", "disk"] {
+            config.add_filter_allow(module.to_string());
+        }
     } else {
         for module in commandline.modules.iter() {
             config.add_filter_allow(module.to_string());
@@ -102,6 +104,7 @@ fn banner(commandline: &CommandLine, config: &Arc<Config>) {
     println!("    project_id: {}", config.project_id);
     println!("    device_id: {}", config.device_id);
     println!("    remote: {}:{}", config.broker, config.port);
+    println!("    bridge_port: {}", config.bridge_port);
     println!("    secure_transport: {}", config.authentication.is_some());
     println!("    max_packet_size: {}", config.max_packet_size);
     println!("    max_inflight_messages: {}", config.max_inflight);


### PR DESCRIPTION
Closes #EXP-116

<!--Brief description of the purpose behind opening the PR-->

### Changes
Enables config of rumqttc's `keep_alive` value, while defaulting to 60s.

### Why?
<!--Detailed description of why the changes had to be made-->
Users may want to config this according to custom requirements.

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->