### PR TITLE
fix: default to no persistence

### DIFF
--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -58,11 +58,6 @@ pub mod config {
     # triggered from cloud.
     actions = ["tunshell"]
 
-    [persistence]
-    path = "/tmp/uplink"
-    max_file_size = 104857600 # 100MB
-    max_file_count = 3
-
     # Create empty streams map
     [streams]
 


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
Removes the config that enforced default mode of uplink persisting to disk, this should remain an optional feature.

### Why?
<!--Detailed description of why the changes had to be made-->
Users may want to run uplink without persisting to disk.

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->