### PR TITLE
feat: update platform about app and bridge stats from uplink

### DIFF
--- a/configs/config.toml
+++ b/configs/config.toml
@@ -54,6 +54,18 @@ buf_size = 1
 buf_size = 10
 flush_period = 30
 
+# Bridge stats such as number of actions and responses that have been handled, the id of action
+# currently being handled, etc. This is an optional config, and will disable the stream if left
+# unconfigured.
+[bridge_stats]
+buf_size = 10
+
+# App stats such as number of actions and responses that have been forwarded to the connected
+# app, the id of action currently that was last forwarded, timestamp at app's connection, etc. 
+# This is also an optional config, and will disable the stream if left unconfigured.
+[app_stats]
+buf_size = 10
+
 # The action_status stream is used to push progress of Actions in execution.
 # This configuration is required or will lead to fallback to default config.
 #

--- a/docs/apps.md
+++ b/docs/apps.md
@@ -61,7 +61,7 @@ An example success response to an action with the id `"123"`, would look like:
 }
 ```
 
-> **NOTE:** Uplink broadcasts actions to all connected applications and expects the applications to handle the action appropriately. There is a timeout mechanism which on being triggered will send a ***Failure*** response to platform and stop forwarding any *Progress* responses from the connected applications. In order to not trigger this timeout, an application must keep sending timely *Progress* responses(faster than once every 30 seconds) until a final ***Failure*** or ***Completion*** response is made to uplink.
+> **NOTE:** Uplink broadcasts actions to all connected applications and expects only one application to handle the action. There is a timeout mechanism which on being triggered will send a ***Failed*** response to platform and stop forwarding any *Progress* responses from the connected applications. In order to not trigger this timeout, an application must keep sending timely *Progress* responses(faster than once every 30 seconds) until a final ***Failed*** or ***Completed*** response is made to uplink.
 
 ## Demonstration
 We have provided examples written in python and golang to demonstrate how you can receive Actions and reply back with either data or responses. You can checkout the examples provided in the `demo/` directory and execute them as such:

--- a/docs/apps.md
+++ b/docs/apps.md
@@ -61,6 +61,8 @@ An example success response to an action with the id `"123"`, would look like:
 }
 ```
 
+> **NOTE:** Uplink broadcasts actions to all connected applications and expects the applications to handle the action appropriately. There is a timeout mechanism which on being triggered will send a ***Failure*** response to platform and stop forwarding any *Progress* responses from the connected applications. In order to not trigger this timeout, an application must keep sending timely *Progress* responses(faster than once every 30 seconds) until a final ***Failure*** or ***Completion*** response is made to uplink.
+
 ## Demonstration
 We have provided examples written in python and golang to demonstrate how you can receive Actions and reply back with either data or responses. You can checkout the examples provided in the `demo/` directory and execute them as such:
 1. Ensure uplink is running on device and connected to relevant broker.

--- a/uplink/src/base/actions.rs
+++ b/uplink/src/base/actions.rs
@@ -23,7 +23,7 @@ pub struct Action {
     pub payload: String,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ActionResponse {
     pub action_id: String,
     // sequence number

--- a/uplink/src/base/middleware/mod.rs
+++ b/uplink/src/base/middleware/mod.rs
@@ -74,12 +74,9 @@ impl Middleware {
 
             let action_id = action.action_id.clone();
             let action_name = action.name.clone();
-            let error = match self.handle(action).await {
-                Ok(_) => continue,
-                Err(e) => e,
-            };
-
-            self.forward_action_error(&action_id, &action_name, error).await;
+            if let Err(error) = self.handle(action).await {
+                self.forward_action_error(&action_id, &action_name, error).await;
+            }
         }
     }
 

--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -91,6 +91,8 @@ pub struct Config {
     pub streams: HashMap<String, StreamConfig>,
     pub action_status: StreamConfig,
     pub serializer_metrics: Option<StreamConfig>,
+    pub bridge_stats: Option<StreamConfig>,
+    pub app_stats: Option<StreamConfig>,
     pub downloader: Option<Downloader>,
     pub stats: Stats,
     pub simulator: Option<SimulatorConfig>,

--- a/uplink/src/collector/downloader.rs
+++ b/uplink/src/collector/downloader.rs
@@ -50,8 +50,8 @@ use reqwest::{Certificate, Client, ClientBuilder, Identity, Response};
 use serde::{Deserialize, Serialize};
 
 use std::fs::{create_dir_all, File};
-use std::{io::Write, path::PathBuf};
 use std::time::Duration;
+use std::{io::Write, path::PathBuf};
 
 use crate::base::{Authentication, Downloader};
 use crate::{Action, ActionResponse, Stream};
@@ -120,7 +120,7 @@ impl FileDownloader {
             }
             None => client_builder,
         }
-            .build()?;
+        .build()?;
 
         // Create rendezvous channel with flume
         let (download_tx, download_rx) = flume::bounded(0);
@@ -164,13 +164,10 @@ impl FileDownloader {
                 }
                 tokio::time::sleep(Duration::from_secs(30)).await;
             }
-            match error {
-                None => {}
-                Some(e) => {
-                    let status = ActionResponse::failure(&self.action_id, e.to_string())
-                        .set_sequence(self.sequence());
-                    self.send_status(status).await;
-                }
+            if let Some(e) = error {
+                let status = ActionResponse::failure(&self.action_id, e.to_string())
+                    .set_sequence(self.sequence());
+                self.send_status(status).await;
             }
         }
     }
@@ -310,7 +307,10 @@ mod test {
         // Ensure path exists
         std::fs::create_dir_all(DOWNLOAD_DIR).unwrap();
         // Prepare config
-        let downloader_cfg = Downloader { actions: vec!["firmware_update".to_string()], path : format!("{}/download", DOWNLOAD_DIR) };
+        let downloader_cfg = Downloader {
+            actions: vec!["firmware_update".to_string()],
+            path: format!("{}/download", DOWNLOAD_DIR),
+        };
 
         // Create channels to forward and push action_status on
         let (stx, srx) = flume::bounded(1);
@@ -329,7 +329,8 @@ mod test {
             download_path: None,
         };
         let mut expected_forward = download_update.clone();
-        expected_forward.download_path = Some(downloader_cfg.path + "/firmware_update/1.0/logo.png");
+        expected_forward.download_path =
+            Some(downloader_cfg.path + "/firmware_update/1.0/logo.png");
         let download_action = Action {
             device_id: Default::default(),
             action_id: "1".to_string(),
@@ -358,7 +359,10 @@ mod test {
         // Ensure path exists
         std::fs::create_dir_all(DOWNLOAD_DIR).unwrap();
         // Prepare config
-        let downloader_cfg = Downloader { actions: vec!["firmware_update".to_string()], path : format!("{}/download", DOWNLOAD_DIR) };
+        let downloader_cfg = Downloader {
+            actions: vec!["firmware_update".to_string()],
+            path: format!("{}/download", DOWNLOAD_DIR),
+        };
 
         // Create channels to forward and push action_status on
         let (stx, _) = flume::bounded(1);
@@ -377,7 +381,8 @@ mod test {
             download_path: None,
         };
         let mut expected_forward = download_update.clone();
-        expected_forward.download_path = Some(downloader_cfg.path + "/firmware_update/1.0/logo.png");
+        expected_forward.download_path =
+            Some(downloader_cfg.path + "/firmware_update/1.0/logo.png");
         let download_action = Action {
             device_id: Default::default(),
             action_id: "1".to_string(),

--- a/uplink/src/collector/tcpjson.rs
+++ b/uplink/src/collector/tcpjson.rs
@@ -114,6 +114,8 @@ struct TcpJson {
 }
 
 impl TcpJson {
+    /// NOTE: We only expect one action to be processed over uplink's bridge at a time,
+    /// which is what current_action achieves
     pub async fn collect(
         &mut self,
         mut client: Framed<TcpStream, LinesCodec>,

--- a/uplink/src/collector/tcpjson.rs
+++ b/uplink/src/collector/tcpjson.rs
@@ -46,8 +46,6 @@ pub struct Bridge {
     action_status: Stream<ActionResponse>,
     status_tx: Sender<ActionResponse>,
     status_rx: Receiver<ActionResponse>,
-    close_tx: Sender<()>,
-    close_rx: Receiver<()>,
 }
 
 const ACTION_TIMEOUT: Duration = Duration::from_secs(30);
@@ -61,19 +59,8 @@ impl Bridge {
     ) -> Bridge {
         let (actions_tx, _) = channel(10);
         let (status_tx, status_rx) = bounded(10);
-        let (close_tx, close_rx) = bounded(1);
 
-        Bridge {
-            action_status,
-            data_tx,
-            config,
-            actions_rx,
-            actions_tx,
-            status_tx,
-            status_rx,
-            close_tx,
-            close_rx,
-        }
+        Bridge { action_status, data_tx, config, actions_rx, actions_tx, status_tx, status_rx }
     }
 
     pub async fn start(&mut self) -> Result<(), Error> {
@@ -169,17 +156,6 @@ impl Bridge {
                             error!("Failed to fill. Error = {:?}", e);
                         }
                     }
-
-                    // In case one of the connected applications drops, check to see if all apps are down.
-                    // In which case send a failure response with the message "Bridge disconnected".
-                    _ = self.close_rx.recv_async() =>  {
-                        if self.actions_tx.receiver_count() == 0 && current_action_.is_some(){
-                            let status = ActionResponse::failure(&current_action_.take().unwrap().id, "Bridge disconnected");
-                            if let Err(e) = self.action_status.fill(status).await {
-                                error!("Failed to fill. Error = {:?}", e);
-                            }
-                        }
-                    }
                 }
             }
         }
@@ -191,15 +167,10 @@ impl Bridge {
             status_tx: self.status_tx.clone(),
             streams: Streams::new(self.config.clone(), self.data_tx.clone()),
             actions_rx: self.actions_tx.subscribe(),
-            close_tx: self.close_tx.clone(),
         };
         tokio::task::spawn(async move {
             if let Err(e) = tcp_json.collect(framed).await {
                 error!("Bridge failed. Error = {:?}", e);
-            }
-
-            if let Err(e) = tcp_json.close_tx.send_async(()).await {
-                error!("Failed to send close message. Error = {:?}", e);
             }
         });
     }
@@ -209,7 +180,6 @@ struct TcpJson {
     streams: Streams,
     status_tx: Sender<ActionResponse>,
     actions_rx: BRx<Action>,
-    close_tx: Sender<()>,
 }
 
 impl TcpJson {

--- a/uplink/src/collector/tcpjson.rs
+++ b/uplink/src/collector/tcpjson.rs
@@ -86,19 +86,6 @@ impl Bridge {
             let mut current_action_: Option<CurrentAction> = None;
 
             loop {
-                // Update action_status for current action
-                if self.actions_tx.receiver_count() == 0 && current_action_.is_some() {
-                    if let Err(e) = self
-                        .action_status
-                        .fill(ActionResponse::failure(
-                            current_action_.take().unwrap().id.as_str(),
-                            "bridge disconnected",
-                        ))
-                        .await
-                    {
-                        error!("Failed to fill. Error = {:?}", e);
-                    }
-                }
                 select! {
                     v = listener.accept() =>  {
                         match v {

--- a/uplink/src/collector/tcpjson.rs
+++ b/uplink/src/collector/tcpjson.rs
@@ -46,6 +46,8 @@ pub struct Bridge {
     action_status: Stream<ActionResponse>,
     status_tx: Sender<ActionResponse>,
     status_rx: Receiver<ActionResponse>,
+    close_tx: Sender<()>,
+    close_rx: Receiver<()>,
 }
 
 const ACTION_TIMEOUT: Duration = Duration::from_secs(30);
@@ -59,8 +61,19 @@ impl Bridge {
     ) -> Bridge {
         let (actions_tx, _) = channel(10);
         let (status_tx, status_rx) = bounded(10);
+        let (close_tx, close_rx) = bounded(1);
 
-        Bridge { action_status, data_tx, config, actions_rx, actions_tx, status_tx, status_rx }
+        Bridge {
+            action_status,
+            data_tx,
+            config,
+            actions_rx,
+            actions_tx,
+            status_tx,
+            status_rx,
+            close_tx,
+            close_rx,
+        }
     }
 
     pub async fn start(&mut self) -> Result<(), Error> {
@@ -156,6 +169,17 @@ impl Bridge {
                             error!("Failed to fill. Error = {:?}", e);
                         }
                     }
+
+                    // In case one of the connected applications drops, check to see if all apps are down.
+                    // In which case send a failure response with the message "Bridge disconnected".
+                    _ = self.close_rx.recv_async() =>  {
+                        if self.actions_tx.receiver_count() == 0 && current_action_.is_some(){
+                            let status = ActionResponse::failure(&current_action_.take().unwrap().id, "Bridge disconnected");
+                            if let Err(e) = self.action_status.fill(status).await {
+                                error!("Failed to fill. Error = {:?}", e);
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -167,10 +191,15 @@ impl Bridge {
             status_tx: self.status_tx.clone(),
             streams: Streams::new(self.config.clone(), self.data_tx.clone()),
             actions_rx: self.actions_tx.subscribe(),
+            close_tx: self.close_tx.clone(),
         };
         tokio::task::spawn(async move {
             if let Err(e) = tcp_json.collect(framed).await {
                 error!("Bridge failed. Error = {:?}", e);
+            }
+
+            if let Err(e) = tcp_json.close_tx.send_async(()).await {
+                error!("Failed to send close message. Error = {:?}", e);
             }
         });
     }
@@ -180,6 +209,7 @@ struct TcpJson {
     streams: Streams,
     status_tx: Sender<ActionResponse>,
     actions_rx: BRx<Action>,
+    close_tx: Sender<()>,
 }
 
 impl TcpJson {

--- a/uplink/src/collector/tcpjson/stats.rs
+++ b/uplink/src/collector/tcpjson/stats.rs
@@ -1,0 +1,183 @@
+use std::{
+    sync::Arc,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use flume::Sender;
+use log::error;
+use serde::Serialize;
+
+use crate::{Action, ActionResponse, Config, Package, Point, Stream};
+
+#[derive(Serialize, Clone, Debug, Default)]
+pub struct BridgeStats {
+    app_count: usize,
+    total_connections: usize,
+    sequence: u32,
+    timestamp: u64,
+    actions_received: u32,
+    current_action: Option<String>,
+    error: Option<String>,
+    connected: bool,
+}
+
+impl Point for BridgeStats {
+    fn sequence(&self) -> u32 {
+        self.sequence
+    }
+
+    fn timestamp(&self) -> u64 {
+        self.timestamp
+    }
+}
+
+pub struct BridgeStatsHandler {
+    stats: BridgeStats,
+    stat_stream: Option<Stream<BridgeStats>>,
+}
+
+impl BridgeStatsHandler {
+    pub fn new(config: Arc<Config>, data_tx: Sender<Box<dyn Package>>) -> Self {
+        let stat_stream = config.bridge_stats.as_ref().map(|stat_config| {
+            Stream::with_config(
+                &"uplink_bridge_stats".to_string(),
+                &config.project_id,
+                &config.device_id,
+                stat_config,
+                data_tx,
+            )
+        });
+        let stats = BridgeStats { connected: false, ..Default::default() };
+
+        Self { stat_stream, stats }
+    }
+
+    pub fn capture_action(&mut self, action_id: String) {
+        self.stats.current_action = Some(action_id)
+    }
+
+    pub fn capture_error(&mut self, error: String) {
+        self.stats.error = Some(error);
+    }
+
+    pub async fn update(&mut self, app_count: usize) {
+        self.stats.sequence += 1;
+        self.stats.timestamp =
+            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis() as u64;
+        self.stats.app_count = app_count;
+
+        let stat_stream = match &mut self.stat_stream {
+            Some(s) => s,
+            _ => return,
+        };
+
+        if let Err(e) = stat_stream.fill(self.stats.clone()).await {
+            error!("Failed to send data. Error = {:?}", e);
+        }
+    }
+
+    pub fn accept(&mut self) -> usize {
+        self.stats.total_connections += 1;
+        self.stats.total_connections
+    }
+
+    pub fn reset_action(&mut self) {
+        self.stats.current_action = None;
+    }
+
+    pub fn reset_error(&mut self) {
+        self.stats.error = None;
+    }
+}
+
+#[derive(Serialize, Clone, Default, Debug)]
+struct AppStats {
+    app_id: usize,
+    sequence: u32,
+    timestamp: u64,
+    connection_timestamp: u64,
+    actions_received: u32,
+    last_action: Option<String>,
+    actions_responded: u32,
+    last_response: Option<ActionResponse>,
+    error: Option<String>,
+    connected: bool,
+}
+
+impl Point for AppStats {
+    fn sequence(&self) -> u32 {
+        self.sequence
+    }
+
+    fn timestamp(&self) -> u64 {
+        self.timestamp
+    }
+}
+
+pub struct AppStatsHandler {
+    stats: AppStats,
+    stat_stream: Option<Stream<AppStats>>,
+}
+
+impl AppStatsHandler {
+    pub fn new(app_id: usize, config: Arc<Config>, data_tx: Sender<Box<dyn Package>>) -> Self {
+        let stats = AppStats {
+            connection_timestamp: SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis()
+                as u64,
+            connected: true,
+            app_id,
+            ..Default::default()
+        };
+        let stat_stream = config.app_stats.as_ref().map(|stat_config| {
+            Stream::with_config(
+                &"uplink_app_stats".to_string(),
+                &config.project_id,
+                &config.device_id,
+                stat_config,
+                data_tx,
+            )
+        });
+
+        Self { stats, stat_stream }
+    }
+
+    pub fn capture_response(&mut self, response: &ActionResponse) {
+        self.stats.last_response = Some(response.clone());
+        self.stats.actions_responded += 1;
+    }
+
+    pub fn capture_action(&mut self, action: &Action) {
+        self.stats.last_action = Some(action.action_id.clone());
+        self.stats.actions_received += 1;
+    }
+
+    pub fn capture_error(&mut self, error: String) {
+        self.stats.error = Some(error);
+    }
+
+    pub async fn update(&mut self) {
+        self.stats.sequence += 1;
+        self.stats.timestamp =
+            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis() as u64;
+
+        let stat_stream = match &mut self.stat_stream {
+            Some(s) => s,
+            _ => return,
+        };
+
+        if let Err(e) = stat_stream.fill(self.stats.clone()).await {
+            error!("Failed to send data. Error = {:?}", e);
+        }
+    }
+
+    pub fn disconnect(&mut self, error: String) {
+        self.stats.connected = false;
+        self.capture_error(error);
+    }
+
+    pub fn reset(&mut self) {
+        self.stats.error = None;
+        self.stats.last_action = None;
+        self.stats.last_response = None;
+    }
+}

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -63,8 +63,8 @@ pub mod config {
     max_file_size = 104857600 # 100MB
     max_file_count = 3
 
-    # Create empty streams map
-    [streams]
+    [streams.uplink_app_stats]
+    buf_size = 1 # ensure this stream flushes immediately
 
     # [serializer_metrics] is left disabled by default
 


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
Updates platform about bridge stats when:
- New app connects to bridge.
- There is a failure in handling data/action response.
- App disconnects from bridge.
- There is an error while sending actions to connected apps.

### Why?
There is currently no way to track the working of uplink's bridge other than the error response when an action can't be forwarded to a connected device.

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->