### PR TITLE
feat: let `Serializer` query `Package`s batch size

### DIFF
--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -113,6 +113,7 @@ pub trait Package: Send + Debug {
     // around custom serialization error types.
     fn serialize(&self) -> serde_json::Result<Vec<u8>>;
     fn anomalies(&self) -> Option<(String, usize)>;
+    fn len(&self) -> usize;
 }
 
 /// Signals status of stream buffer
@@ -376,6 +377,10 @@ where
 
     fn anomalies(&self) -> Option<(String, usize)> {
         self.anomalies()
+    }
+
+    fn len(&self) -> usize {
+        self.buffer.len()
     }
 }
 

--- a/uplink/src/base/serializer.rs
+++ b/uplink/src/base/serializer.rs
@@ -217,6 +217,8 @@ impl<C: MqttClient> Serializer<C> {
             let data = self.collector_rx.recv_async().await?;
             let topic = data.topic();
             let payload = data.serialize()?;
+            let msg_count = data.len();
+            info!("Data received on stream: {topic}; message count = {msg_count}");
 
             let mut publish = Publish::new(topic.as_ref(), QoS::AtLeastOnce, payload);
             publish.pkid = 1;
@@ -261,6 +263,9 @@ impl<C: MqttClient> Serializer<C> {
 
                       let topic = data.topic();
                       let payload = data.serialize()?;
+                      let msg_count = data.len();
+                      info!("Data received on stream: {topic}; message count = {msg_count}");
+
                       let payload_size = payload.len();
                       let mut publish = Publish::new(topic.as_ref(), QoS::AtLeastOnce, payload);
                       publish.pkid = 1;
@@ -336,6 +341,9 @@ impl<C: MqttClient> Serializer<C> {
 
                       let topic = data.topic();
                       let payload = data.serialize()?;
+                      let msg_count = data.len();
+                      info!("Data received on stream: {topic}; message count = {msg_count}");
+
                       let payload_size = payload.len();
                       let mut publish = Publish::new(topic.as_ref(), QoS::AtLeastOnce, payload);
                       publish.pkid = 1;
@@ -413,6 +421,9 @@ impl<C: MqttClient> Serializer<C> {
 
                     let topic = data.topic();
                     let payload = data.serialize()?;
+                    let msg_count = data.len();
+                    info!("Data received on stream: {topic}; message count = {msg_count}");
+
                     let payload_size = payload.len();
                     match self.client.try_publish(topic.as_ref(), QoS::AtLeastOnce, false, payload) {
                         Ok(_) => {


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
This can be helpful to keep track of the number of messages overall handled through a specific stream.

### Why?
For better observability into the data pipeline

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->