### PR TITLE
fix: serializer metrics ouroboros

### DIFF
--- a/configs/config.toml
+++ b/configs/config.toml
@@ -15,6 +15,15 @@ max_inflight = 100
 # triggered from cloud.
 actions = ["tunshell"]
 
+# Serializer Metrics module publishes associated stats, to keep track of 
+# serializer performance. By default it is disabled and metrics will not
+# be forwarded to platform. 
+# Parameters
+# - topic(optional): One can configure to push stats to a specific topic,
+#   different from the default by configuring it with this field.
+[serializer_metrics]
+topic = "/tenants/{tenant_id}/devices/{device_id}/metrics/jsonarray"
+
 # Configuration details associated with uplink's persistent storage module
 # which writes publish packets to disk in case of slow or crashed network.
 # 
@@ -45,17 +54,9 @@ max_file_count = 3
 [streams.device_shadow]
 buf_size = 1
 
-# Built-in streams: Serializer metrics and action status are special cases and need to be
-# separately configured outside of the streams map. The metrics stream is one to which the
-# Serializer Metrics module publishes associated stats, to keep track of serializer performance.
-# If not configured, serializer metrics will not be forwarded to platform. In this example we
-# are enabling and publishing on reaching 10 elements or flushing on 30 seconds timeouts.
-[serializer_metrics]
-buf_size = 10
-flush_period = 30
-
-# The action_status stream is used to push progress of Actions in execution.
-# This configuration is required or will lead to fallback to default config.
+# Built-in streams: action status is a special case of stream and should be configured separately,
+# outside of the streams map. The action_status stream is used to push progress of Actions in
+# execution. This configuration is required or will lead to fallback to default config.
 #
 # NOTE: Action statuses are expected on a specifc topic as configured in example below.
 # This also means that we require a topic to be configured or uplink will error out.

--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -76,6 +76,11 @@ pub struct Downloader {
     pub path: String,
 }
 
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct MetricsConfig {
+    pub topic: Option<String>,
+}
+
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct Config {
     pub project_id: String,
@@ -91,7 +96,7 @@ pub struct Config {
     pub persistence: Option<Persistence>,
     pub streams: HashMap<String, StreamConfig>,
     pub action_status: StreamConfig,
-    pub serializer_metrics: Option<StreamConfig>,
+    pub serializer_metrics: Option<MetricsConfig>,
     pub downloader: Option<Downloader>,
     pub stats: Stats,
     pub simulator: Option<SimulatorConfig>,

--- a/uplink/src/base/serializer.rs
+++ b/uplink/src/base/serializer.rs
@@ -1,4 +1,4 @@
-use crate::{Config, Package, Point, Stream};
+use crate::{Config, Package, Point};
 
 use bytes::Bytes;
 use disk::Storage;
@@ -162,15 +162,13 @@ pub struct Serializer<C: MqttClient> {
     collector_rx: Receiver<Box<dyn Package>>,
     client: C,
     storage: Option<Storage>,
-    metrics: Metrics,
-    metrics_stream: Option<Stream<Metrics>>,
+    metrics: Option<Metrics>,
 }
 
 impl<C: MqttClient> Serializer<C> {
     pub fn new(
         config: Arc<Config>,
         collector_rx: Receiver<Box<dyn Package>>,
-        metrics_stream: Option<Stream<Metrics>>,
         client: C,
     ) -> Result<Serializer<C>, Error> {
         let storage = match &config.persistence {
@@ -185,14 +183,9 @@ impl<C: MqttClient> Serializer<C> {
             None => None,
         };
 
-        Ok(Serializer {
-            config,
-            collector_rx,
-            client,
-            storage,
-            metrics: Metrics::new(),
-            metrics_stream,
-        })
+        let metrics = Metrics::new(config.clone());
+
+        Ok(Serializer { config, collector_rx, client, storage, metrics })
     }
 
     /// Write all data received, from here-on, to disk only.
@@ -257,38 +250,44 @@ impl<C: MqttClient> Serializer<C> {
                         }
                     };
 
-                      let data = data?;
-                      if let Some((errors, count)) = data.anomalies() {
-                        self.metrics.add_errors(errors, count);
-                      }
+                    let data = data?;
+                    if let Some(metrics) = self.metrics.as_mut(){
+                        if let Some((errors, count)) = data.anomalies() {
+                            metrics.add_errors(errors, count);
+                        }
+                    }
 
-                      let topic = data.topic();
-                      let payload = data.serialize()?;
-                      let stream = data.stream();
-                      let msg_count = data.len();
-                      info!("Data received on stream: {stream}; message count = {msg_count}");
+                    let topic = data.topic();
+                    let payload = data.serialize()?;
+                    let stream = data.stream();
+                    let msg_count = data.len();
+                    info!("Data received on stream: {stream}; message count = {msg_count}");
 
-                      let payload_size = payload.len();
-                      let mut publish = Publish::new(topic.as_ref(), QoS::AtLeastOnce, payload);
-                      publish.pkid = 1;
+                    let payload_size = payload.len();
+                    let mut publish = Publish::new(topic.as_ref(), QoS::AtLeastOnce, payload);
+                    publish.pkid = 1;
 
-                      match publish.write(storage.writer()) {
-                           Ok(_) => self.metrics.add_total_disk_size(payload_size),
-                           Err(e) => {
-                               error!("Failed to fill disk buffer. Error = {:?}", e);
-                               continue
-                           }
-                      }
+                    match publish.write(storage.writer()) {
+                        Ok(_) => if let Some(metrics) = self.metrics.as_mut(){
+                            metrics.add_total_disk_size(payload_size)
+                        },
+                        Err(e) => {
+                            error!("Failed to fill disk buffer. Error = {:?}", e);
+                            continue
+                        }
+                    }
 
-                      match storage.flush_on_overflow() {
-                            Ok(deleted) => if deleted.is_some() {
-                                self.metrics.increment_lost_segments();
-                            },
-                            Err(e) => {
-                                error!("Failed to flush disk buffer. Error = {:?}", e);
-                                continue
+                    match storage.flush_on_overflow() {
+                        Ok(deleted) => if let Some(metrics) = self.metrics.as_mut() {
+                            if deleted.is_some() {
+                                metrics.increment_lost_segments();
                             }
-                      }
+                        },
+                        Err(e) => {
+                            error!("Failed to flush disk buffer. Error = {:?}", e);
+                            continue
+                        }
+                    }
                 }
                 o = &mut publish => match o {
                     Ok(_) => return Ok(Status::EventLoopReady),
@@ -336,38 +335,44 @@ impl<C: MqttClient> Serializer<C> {
         loop {
             select! {
                 data = self.collector_rx.recv_async() => {
-                      let data = data?;
-                      if let Some((errors, count)) = data.anomalies() {
-                        self.metrics.add_errors(errors, count);
-                      }
+                    let data = data?;
+                    if let Some(metrics) = self.metrics.as_mut() {
+                        if let Some((errors, count)) = data.anomalies() {
+                            metrics.add_errors(errors, count);
+                        }
+                    }
 
-                      let topic = data.topic();
-                      let payload = data.serialize()?;
-                      let stream = data.stream();
-                      let msg_count = data.len();
-                      info!("Data received on stream: {stream}; message count = {msg_count}");
+                    let topic = data.topic();
+                    let payload = data.serialize()?;
+                    let stream = data.stream();
+                    let msg_count = data.len();
+                    info!("Data received on stream: {stream}; message count = {msg_count}");
 
-                      let payload_size = payload.len();
-                      let mut publish = Publish::new(topic.as_ref(), QoS::AtLeastOnce, payload);
-                      publish.pkid = 1;
+                    let payload_size = payload.len();
+                    let mut publish = Publish::new(topic.as_ref(), QoS::AtLeastOnce, payload);
+                    publish.pkid = 1;
 
-                      match publish.write(storage.writer()) {
-                           Ok(_) => self.metrics.add_total_disk_size(payload_size),
-                           Err(e) => {
-                               error!("Failed to fill disk buffer. Error = {:?}", e);
-                               continue
-                           }
-                      }
+                    match publish.write(storage.writer()) {
+                        Ok(_) => if let Some(metrics) = self.metrics.as_mut() {
+                            metrics.add_total_disk_size(payload_size)
+                        },
+                        Err(e) => {
+                            error!("Failed to fill disk buffer. Error = {:?}", e);
+                            continue
+                        }
+                    }
 
-                      match storage.flush_on_overflow() {
-                            Ok(deleted) => if deleted.is_some() {
-                                self.metrics.increment_lost_segments();
-                            },
-                            Err(e) => {
-                                error!("Failed to flush write buffer to disk during catchup. Error = {:?}", e);
-                                continue
+                    match storage.flush_on_overflow() {
+                        Ok(deleted) => if let Some(metrics) = self.metrics.as_mut() {
+                            if deleted.is_some() {
+                                metrics.increment_lost_segments();
                             }
-                      }
+                        },
+                        Err(e) => {
+                            error!("Failed to flush write buffer to disk during catchup. Error = {:?}", e);
+                            continue
+                        }
+                    }
                 }
                 o = &mut send => {
                     // Send failure implies eventloop crash. Switch state to
@@ -400,8 +405,10 @@ impl<C: MqttClient> Serializer<C> {
 
                     let payload = publish.payload;
                     let payload_size = payload.len();
-                    self.metrics.sub_total_disk_size(payload_size);
-                    self.metrics.add_total_sent_size(payload_size);
+                    if let Some(metrics) = self.metrics.as_mut() {
+                        metrics.sub_total_disk_size(payload_size);
+                        metrics.add_total_sent_size(payload_size);
+                    }
                     send.set(send_publish(client, publish.topic, payload));
                 }
             }
@@ -418,8 +425,10 @@ impl<C: MqttClient> Serializer<C> {
                     let data = data?;
 
                     // Extract anomalies detected by package during collection
-                    if let Some((errors, count)) = data.anomalies() {
-                        self.metrics.add_errors(errors, count);
+                    if let Some(metrics) = self.metrics.as_mut() {
+                        if let Some((errors, count)) = data.anomalies() {
+                            metrics.add_errors(errors, count);
+                        }
                     }
 
                     let topic = data.topic();
@@ -430,8 +439,8 @@ impl<C: MqttClient> Serializer<C> {
 
                     let payload_size = payload.len();
                     match self.client.try_publish(topic.as_ref(), QoS::AtLeastOnce, false, payload) {
-                        Ok(_) => {
-                            self.metrics.add_total_sent_size(payload_size);
+                        Ok(_) => if let Some(metrics) = self.metrics.as_mut() {
+                            metrics.add_total_sent_size(payload_size);
                             continue;
                         }
                         Err(MqttError::TrySend(Request::Publish(publish))) => return Ok(Status::SlowEventloop(publish)),
@@ -439,12 +448,13 @@ impl<C: MqttClient> Serializer<C> {
                     }
 
                 }
-                _ = interval.tick(), if self.metrics_stream.is_some() => {
-                    let metrics = self.metrics.update();
-                    self.metrics.clear();
-                    let stream = self.metrics_stream.as_mut().unwrap();
-                    if let Err(e) = stream.fill(metrics).await {
-                        error!("Couldn't write serializer metrics to stream: {}", e)
+                _ = interval.tick(), if self.metrics.is_some() => {
+                    info!("Publishing serializer metrics to broker");
+                    let metrics = self.metrics.as_mut().unwrap();
+                    let payload = serde_json::to_vec(&vec![metrics.update()])?;
+                    metrics.clear();
+                    if let Err(e) = self.client.try_publish(&metrics.topic, QoS::AtLeastOnce, false, payload) {
+                        error!("Couldn't publish serializer metrics to broker: {}", e)
                     }
                 }
             }
@@ -491,6 +501,8 @@ async fn send_publish<C: MqttClient>(
 
 #[derive(Debug, Default, Serialize, Clone)]
 pub struct Metrics {
+    #[serde(skip)]
+    topic: String,
     sequence: u32,
     timestamp: u64,
     total_sent_size: usize,
@@ -501,8 +513,21 @@ pub struct Metrics {
 }
 
 impl Metrics {
-    pub fn new() -> Metrics {
-        Metrics { errors: String::with_capacity(1024), ..Default::default() }
+    pub fn new(config: Arc<Config>) -> Option<Metrics> {
+        let topic = match &config.serializer_metrics.as_ref()?.topic {
+            Some(topic) => topic.to_owned(),
+            _ => {
+                String::from("/tenants/")
+                    + &config.project_id
+                    + "/devices/"
+                    + &config.device_id
+                    + "/events/"
+                    + &"metrics"
+                    + "/jsonarray"
+            }
+        };
+
+        Some(Metrics { topic, errors: String::with_capacity(1024), ..Default::default() })
     }
 
     pub fn add_total_sent_size(&mut self, size: usize) {
@@ -690,7 +715,7 @@ mod test {
         let (net_tx, net_rx) = flume::bounded(1);
         let client = MockClient { net_tx };
 
-        (Serializer::new(config, data_rx, None, client).unwrap(), data_tx, net_rx)
+        (Serializer::new(config, data_rx, client).unwrap(), data_tx, net_rx)
     }
 
     #[derive(Error, Debug)]

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -104,7 +104,11 @@ pub mod config {
         replace_topic_placeholders(&mut config.action_status, tenant_id, device_id);
 
         if let Some(config) = &mut config.serializer_metrics {
-            replace_topic_placeholders(config, tenant_id, device_id);
+            if let Some(topic) = &config.topic {
+                let topic = topic.replace("{tenant_id}", tenant_id);
+                let topic = topic.replace("{device_id}", device_id);
+                config.topic = Some(topic);
+            }
         }
 
         Ok(config)

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -203,22 +203,7 @@ impl Uplink {
         let (raw_action_tx, raw_action_rx) = bounded(10);
         let mut mqtt = Mqtt::new(self.config.clone(), raw_action_tx);
 
-        let metrics_stream = self.config.serializer_metrics.as_ref().map(|metrics_config| {
-            Stream::with_config(
-                &"metrics".to_owned(),
-                &self.config.project_id,
-                &self.config.device_id,
-                metrics_config,
-                self.bridge_data_tx(),
-            )
-        });
-
-        let serializer = Serializer::new(
-            self.config.clone(),
-            self.data_rx.clone(),
-            metrics_stream,
-            mqtt.client(),
-        )?;
+        let serializer = Serializer::new(self.config.clone(), self.data_rx.clone(), mqtt.client())?;
 
         let actions = Middleware::new(
             self.config.clone(),


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
Push serializer metrics directly to broker instead of through `Stream`

### Why?
If we are to follow the current way of doing things, we will end up collecting stats generated by the stats themselves, this would lead to a snake eating its tail kind of situation which we should avoid.

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
Tested against platform, metrics generated seems to add up.