### PR TITLE
feat: collect and log `batching_latency` as a metric

### DIFF
--- a/uplink/src/base/actions.rs
+++ b/uplink/src/base/actions.rs
@@ -37,6 +37,9 @@ pub struct ActionResponse {
     pub progress: u8,
     // list of error
     pub errors: Vec<String>,
+    // timestamp at creation
+    #[serde(skip)]
+    pub collection_timestamp: u64,
 }
 
 impl ActionResponse {
@@ -45,6 +48,7 @@ impl ActionResponse {
             .duration_since(UNIX_EPOCH)
             .unwrap_or(Duration::from_secs(0))
             .as_millis() as u64;
+        let collection_timestamp = timestamp;
 
         ActionResponse {
             action_id: id.to_owned(),
@@ -53,6 +57,7 @@ impl ActionResponse {
             state: state.to_owned(),
             progress,
             errors,
+            collection_timestamp,
         }
     }
 
@@ -95,6 +100,7 @@ impl From<&ActionResponse> for Payload {
             stream: "action_status".to_owned(),
             sequence: resp.sequence,
             timestamp: resp.timestamp,
+            collection_timestamp: resp.collection_timestamp,
             payload: json!({
                 "id": resp.action_id,
                 "state": resp.state,
@@ -112,5 +118,9 @@ impl Point for ActionResponse {
 
     fn timestamp(&self) -> u64 {
         self.timestamp
+    }
+
+    fn collection_timestamp(&self) -> u64 {
+        self.collection_timestamp
     }
 }

--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -117,9 +117,9 @@ pub trait Package: Send + Debug {
     fn serialize(&self) -> serde_json::Result<Vec<u8>>;
     fn anomalies(&self) -> Option<(String, usize)>;
     fn len(&self) -> usize;
-    fn first_timestamp(&self) -> Option<u64>;
-    fn last_timestamp(&self) -> Option<u64>;
-    fn batch_latency(&self) -> Option<u64>;
+    fn first_timestamp(&self) -> u64;
+    fn last_timestamp(&self) -> u64;
+    fn batch_latency(&self) -> u64;
 }
 
 /// Signals status of stream buffer
@@ -393,19 +393,19 @@ where
         self.buffer.len()
     }
 
-    fn first_timestamp(&self) -> Option<u64> {
-        self.buffer.first().map(|p| p.timestamp())
+    fn first_timestamp(&self) -> u64 {
+        self.buffer.first().expect("Zero Points in Package!").timestamp()
     }
 
-    fn last_timestamp(&self) -> Option<u64> {
-        self.buffer.last().map(|p| p.timestamp())
+    fn last_timestamp(&self) -> u64 {
+        self.buffer.last().expect("Zero Points in Package!").timestamp()
     }
 
-    fn batch_latency(&self) -> Option<u64> {
-        let first_timestamp = self.first_timestamp()?;
-        let last_timestamp = self.last_timestamp()?;
+    fn batch_latency(&self) -> u64 {
+        let first_timestamp = self.first_timestamp();
+        let last_timestamp = self.last_timestamp();
 
-        Some(last_timestamp - first_timestamp)
+        last_timestamp - first_timestamp
     }
 }
 

--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -1,4 +1,5 @@
-use std::{collections::HashMap, fmt::Debug, mem, sync::Arc, time::Duration};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::{collections::HashMap, fmt::Debug, mem, sync::Arc};
 
 use flume::{SendError, Sender};
 use log::{debug, trace};
@@ -436,6 +437,16 @@ pub struct Payload {
     pub payload: Value,
     #[serde(skip)]
     pub collection_timestamp: u64,
+}
+
+impl Payload {
+    /// Sets collection_timestamp for Payload
+    pub fn set_collection_timestamp(mut self) -> Self {
+        self.collection_timestamp =
+            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis() as u64;
+
+        self
+    }
 }
 
 impl Point for Payload {

--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -106,6 +106,7 @@ pub struct Config {
 pub trait Point: Send + Debug {
     fn sequence(&self) -> u32;
     fn timestamp(&self) -> u64;
+    fn collection_timestamp(&self) -> u64;
 }
 
 pub trait Package: Send + Debug {
@@ -415,6 +416,8 @@ pub struct Payload {
     pub timestamp: u64,
     #[serde(flatten)]
     pub payload: Value,
+    #[serde(skip)]
+    pub collection_timestamp: u64,
 }
 
 impl Point for Payload {
@@ -424,5 +427,9 @@ impl Point for Payload {
 
     fn timestamp(&self) -> u64 {
         self.timestamp
+    }
+
+    fn collection_timestamp(&self) -> u64 {
+        self.collection_timestamp
     }
 }

--- a/uplink/src/base/serializer.rs
+++ b/uplink/src/base/serializer.rs
@@ -219,7 +219,8 @@ impl<C: MqttClient> Serializer<C> {
             let payload = data.serialize()?;
             let stream = data.stream();
             let msg_count = data.len();
-            info!("Data received on stream: {stream}; message count = {msg_count}");
+            let batch_latency = data.batch_latency();
+            info!("Data received on stream: {stream}; message count = {msg_count}; batching latency = {batch_latency}");
 
             let mut publish = Publish::new(topic.as_ref(), QoS::AtLeastOnce, payload);
             publish.pkid = 1;
@@ -266,7 +267,8 @@ impl<C: MqttClient> Serializer<C> {
                       let payload = data.serialize()?;
                       let stream = data.stream();
                       let msg_count = data.len();
-                      info!("Data received on stream: {stream}; message count = {msg_count}");
+                      let batch_latency = data.batch_latency();
+                      info!("Data received on stream: {stream}; message count = {msg_count}; batching latency = {batch_latency}");
 
                       let payload_size = payload.len();
                       let mut publish = Publish::new(topic.as_ref(), QoS::AtLeastOnce, payload);
@@ -345,7 +347,8 @@ impl<C: MqttClient> Serializer<C> {
                       let payload = data.serialize()?;
                       let stream = data.stream();
                       let msg_count = data.len();
-                      info!("Data received on stream: {stream}; message count = {msg_count}");
+                      let batch_latency = data.batch_latency();
+                      info!("Data received on stream: {stream}; message count = {msg_count}; batching latency = {batch_latency}");
 
                       let payload_size = payload.len();
                       let mut publish = Publish::new(topic.as_ref(), QoS::AtLeastOnce, payload);
@@ -426,7 +429,8 @@ impl<C: MqttClient> Serializer<C> {
                     let payload = data.serialize()?;
                     let stream = data.stream();
                     let msg_count = data.len();
-                    info!("Data received on stream: {stream}; message count = {msg_count}");
+                    let batch_latency = data.batch_latency();
+                    info!("Data received on stream: {stream}; message count = {msg_count}; batching latency = {batch_latency}");
 
                     let payload_size = payload.len();
                     match self.client.try_publish(topic.as_ref(), QoS::AtLeastOnce, false, payload) {

--- a/uplink/src/base/serializer.rs
+++ b/uplink/src/base/serializer.rs
@@ -564,6 +564,10 @@ impl Point for Metrics {
     fn timestamp(&self) -> u64 {
         self.timestamp
     }
+
+    fn collection_timestamp(&self) -> u64 {
+        self.timestamp
+    }
 }
 
 #[cfg(test)]
@@ -715,6 +719,7 @@ mod test {
                 stream: "hello".to_owned(),
                 sequence: i,
                 timestamp: 0,
+                collection_timestamp: 0,
                 payload: serde_json::from_str("{\"msg\": \"Hello, World!\"}")?,
             };
             self.stream.push(payload)?;

--- a/uplink/src/collector/logging/journalctl.rs
+++ b/uplink/src/collector/logging/journalctl.rs
@@ -80,8 +80,15 @@ impl LogEntry {
         let payload = serde_json::to_value(self)?;
         // Convert from microseconds to milliseconds
         let timestamp = self.log_timestamp.parse::<u64>()? / 1000;
+        let collection_timestamp = timestamp;
 
-        Ok(Payload { stream: "logs".to_string(), sequence, timestamp, payload })
+        Ok(Payload {
+            stream: "logs".to_string(),
+            sequence,
+            timestamp,
+            payload,
+            collection_timestamp,
+        })
     }
 }
 

--- a/uplink/src/collector/simulator.rs
+++ b/uplink/src/collector/simulator.rs
@@ -154,7 +154,7 @@ impl Partitions {
 
 pub fn generate_gps_data(device: &DeviceData, sequence: u32) -> Payload {
     let timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis() as u64;
-
+    let collection_timestamp = timestamp;
     let path_len = device.path.len() as u32;
     let path_index = ((device.path_offset + sequence) % path_len) as usize;
     let position = device.path.get(path_index).unwrap();
@@ -164,6 +164,7 @@ pub fn generate_gps_data(device: &DeviceData, sequence: u32) -> Payload {
         sequence,
         stream: format!("/tenants/demo/devices/{}/events/gps/jsonarray", device.device_id),
         payload: json!(position),
+        collection_timestamp,
     }
 }
 
@@ -232,6 +233,7 @@ struct Bms {
 
 pub fn generate_bms_data(device: &DeviceData, sequence: u32) -> Payload {
     let timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis() as u64;
+    let collection_timestamp = timestamp;
     let payload = Bms {
         periodicity_ms: 250,
         mosfet_temperature: generate_float(40f64, 45f64),
@@ -281,6 +283,7 @@ pub fn generate_bms_data(device: &DeviceData, sequence: u32) -> Payload {
         sequence,
         stream: format!("/tenants/demo/devices/{}/events/bms/jsonarray", device.device_id),
         payload: json!(payload),
+        collection_timestamp,
     }
 }
 
@@ -299,6 +302,7 @@ struct Imu {
 
 pub fn generate_imu_data(device: &DeviceData, sequence: u32) -> Payload {
     let timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis() as u64;
+    let collection_timestamp = timestamp;
     let payload = Imu {
         ax: generate_float(1f64, 2.8f64),
         ay: generate_float(1f64, 2.8f64),
@@ -316,6 +320,7 @@ pub fn generate_imu_data(device: &DeviceData, sequence: u32) -> Payload {
         sequence,
         stream: format!("/tenants/demo/devices/{}/events/imu/jsonarray", device.device_id),
         payload: json!(payload),
+        collection_timestamp,
     }
 }
 
@@ -331,6 +336,7 @@ struct Motor {
 
 pub fn generate_motor_data(device: &DeviceData, sequence: u32) -> Payload {
     let timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis() as u64;
+    let collection_timestamp = timestamp;
     let payload = Motor {
         motor_temperature1: generate_float(40f64, 45f64),
         motor_temperature2: generate_float(40f64, 45f64),
@@ -346,6 +352,7 @@ pub fn generate_motor_data(device: &DeviceData, sequence: u32) -> Payload {
         sequence,
         stream: format!("/tenants/demo/devices/{}/events/motor/jsonarray", device.device_id),
         payload: json!(payload),
+        collection_timestamp,
     }
 }
 
@@ -364,6 +371,7 @@ struct PeripheralState {
 
 pub fn generate_peripheral_state_data(device: &DeviceData, sequence: u32) -> Payload {
     let timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis() as u64;
+    let collection_timestamp = timestamp;
     let payload = PeripheralState {
         gps_status: generate_bool_string(0.99),
         gsm_status: generate_bool_string(0.99),
@@ -384,6 +392,7 @@ pub fn generate_peripheral_state_data(device: &DeviceData, sequence: u32) -> Pay
             device.device_id
         ),
         payload: json!(payload),
+        collection_timestamp,
     }
 }
 
@@ -401,6 +410,7 @@ struct DeviceShadow {
 
 pub fn generate_device_shadow_data(device: &DeviceData, sequence: u32) -> Payload {
     let timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis() as u64;
+    let collection_timestamp = timestamp;
     let payload = DeviceShadow {
         mode: "economy".to_owned(),
         status: "Locked".to_owned(),
@@ -419,6 +429,7 @@ pub fn generate_device_shadow_data(device: &DeviceData, sequence: u32) -> Payloa
             device.device_id
         ),
         payload: json!(payload),
+        collection_timestamp,
     }
 }
 

--- a/uplink/src/collector/systemstats.rs
+++ b/uplink/src/collector/systemstats.rs
@@ -81,6 +81,10 @@ impl Point for System {
     fn timestamp(&self) -> u64 {
         self.timestamp
     }
+
+    fn collection_timestamp(&self) -> u64 {
+        self.timestamp
+    }
 }
 
 struct SystemStats {
@@ -136,6 +140,10 @@ impl Point for Network {
     }
 
     fn timestamp(&self) -> u64 {
+        self.timestamp
+    }
+
+    fn collection_timestamp(&self) -> u64 {
         self.timestamp
     }
 }
@@ -194,6 +202,10 @@ impl Point for Disk {
     fn timestamp(&self) -> u64 {
         self.timestamp
     }
+
+    fn collection_timestamp(&self) -> u64 {
+        self.timestamp
+    }
 }
 
 struct DiskStats {
@@ -245,6 +257,10 @@ impl Point for Processor {
     fn timestamp(&self) -> u64 {
         self.timestamp
     }
+
+    fn collection_timestamp(&self) -> u64 {
+        self.timestamp
+    }
 }
 
 struct ProcessorStats {
@@ -291,6 +307,10 @@ impl Point for Component {
     }
 
     fn timestamp(&self) -> u64 {
+        self.timestamp
+    }
+
+    fn collection_timestamp(&self) -> u64 {
         self.timestamp
     }
 }
@@ -363,6 +383,10 @@ impl Point for Process {
     }
 
     fn timestamp(&self) -> u64 {
+        self.timestamp
+    }
+
+    fn collection_timestamp(&self) -> u64 {
         self.timestamp
     }
 }

--- a/uplink/src/collector/tcpjson.rs
+++ b/uplink/src/collector/tcpjson.rs
@@ -126,8 +126,8 @@ impl Bridge {
                     let line = line.ok_or(Error::StreamDone)??;
                     info!("Received line = {:?}", line);
 
-                    let data: Payload = match serde_json::from_str(&line) {
-                        Ok(d) => d,
+                    let data = match serde_json::from_str::<Payload>(&line) {
+                        Ok(d) => d.set_collection_timestamp(),
                         Err(e) => {
                             error!("Deserialization error = {:?}", e);
                             continue


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
Adds the methods `collection_timestamp` to `Point` and `first_timestamp`, `last_timestamp`, `batch_latency` to `Package`. Log batch latency from within `Serializer`

### Why?
<!--Detailed description of why the changes had to be made-->

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->