### PR TITLE
feat: collect and forward `stream_metrics`

### DIFF
--- a/configs/config.toml
+++ b/configs/config.toml
@@ -15,14 +15,22 @@ max_inflight = 100
 # triggered from cloud.
 actions = ["tunshell"]
 
-# Serializer Metrics module publishes associated stats, to keep track of 
-# serializer performance. By default it is disabled and metrics will not
-# be forwarded to platform. 
+# Metrics configurations are available for serializer and streams. By default 
+# they are disabled and no metrics will not be forwarded to platform. 
 # Parameters
 # - topic(optional): One can configure to push stats to a specific topic,
 #   different from the default by configuring it with this field.
+#
+# Serializer module can publish associated metrics, to keep track of 
+# serializer performance. 
 [serializer_metrics]
 topic = "/tenants/{tenant_id}/devices/{device_id}/metrics/jsonarray"
+
+# Serializer module can also publishe stream metrics, to keep track of latencies 
+# and batch sizes on a per-stream basis.
+# NOTE: Leaving this configuration empty like the following tells uplink to enable
+# sending metrics, but with default topic string.
+[stream_metrics]
 
 # Configuration details associated with uplink's persistent storage module
 # which writes publish packets to disk in case of slow or crashed network.

--- a/configs/config.toml
+++ b/configs/config.toml
@@ -16,7 +16,7 @@ max_inflight = 100
 actions = ["tunshell"]
 
 # Metrics configurations are available for serializer and streams. By default 
-# they are disabled and no metrics will not be forwarded to platform. 
+# they are disabled and no metrics will be forwarded to platform. 
 # Parameters
 # - topic(optional): One can configure to push stats to a specific topic,
 #   different from the default by configuring it with this field.
@@ -24,6 +24,7 @@ actions = ["tunshell"]
 # Serializer module can publish associated metrics, to keep track of 
 # serializer performance. 
 [serializer_metrics]
+enabled = true
 topic = "/tenants/{tenant_id}/devices/{device_id}/metrics/jsonarray"
 
 # Serializer module can also publishe stream metrics, to keep track of latencies 
@@ -31,6 +32,7 @@ topic = "/tenants/{tenant_id}/devices/{device_id}/metrics/jsonarray"
 # NOTE: Leaving this configuration empty like the following tells uplink to enable
 # sending metrics, but with default topic string.
 [stream_metrics]
+enabled = true
 
 # Configuration details associated with uplink's persistent storage module
 # which writes publish packets to disk in case of slow or crashed network.

--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -98,6 +98,7 @@ pub struct Config {
     pub streams: HashMap<String, StreamConfig>,
     pub action_status: StreamConfig,
     pub serializer_metrics: Option<MetricsConfig>,
+    pub stream_metrics: Option<MetricsConfig>,
     pub downloader: Option<Downloader>,
     pub stats: Stats,
     pub simulator: Option<SimulatorConfig>,

--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -126,6 +126,10 @@ pub trait Package: Send + Debug {
     fn first_timestamp(&self) -> u64;
     fn last_timestamp(&self) -> u64;
     fn batch_latency(&self) -> u64;
+
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 }
 
 /// Signals status of stream buffer

--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -79,6 +79,7 @@ pub struct Downloader {
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct MetricsConfig {
+    pub enabled: bool,
     pub topic: Option<String>,
 }
 
@@ -97,8 +98,8 @@ pub struct Config {
     pub persistence: Option<Persistence>,
     pub streams: HashMap<String, StreamConfig>,
     pub action_status: StreamConfig,
-    pub serializer_metrics: Option<MetricsConfig>,
-    pub stream_metrics: Option<MetricsConfig>,
+    pub serializer_metrics: MetricsConfig,
+    pub stream_metrics: MetricsConfig,
     pub downloader: Option<Downloader>,
     pub stats: Stats,
     pub simulator: Option<SimulatorConfig>,

--- a/uplink/src/base/serializer.rs
+++ b/uplink/src/base/serializer.rs
@@ -1,16 +1,18 @@
-use crate::{Config, Package, Point};
+use std::io;
+use std::sync::Arc;
 
 use bytes::Bytes;
 use disk::Storage;
 use flume::{Receiver, RecvError};
 use log::{error, info};
 use rumqttc::*;
-use serde::Serialize;
-use std::io;
-use std::sync::Arc;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use thiserror::Error;
 use tokio::{select, time};
+
+mod metrics;
+
+use crate::{Config, Package};
+use metrics::SerializerMetrics;
 
 #[derive(thiserror::Error, Debug)]
 pub enum MqttError {
@@ -162,7 +164,7 @@ pub struct Serializer<C: MqttClient> {
     collector_rx: Receiver<Box<dyn Package>>,
     client: C,
     storage: Option<Storage>,
-    metrics: Option<Metrics>,
+    metrics: Option<SerializerMetrics>,
 }
 
 impl<C: MqttClient> Serializer<C> {
@@ -183,7 +185,7 @@ impl<C: MqttClient> Serializer<C> {
             None => None,
         };
 
-        let metrics = Metrics::new(config.clone());
+        let metrics = SerializerMetrics::new(config.clone());
 
         Ok(Serializer { config, collector_rx, client, storage, metrics })
     }
@@ -501,102 +503,6 @@ async fn send_publish<C: MqttClient>(
 ) -> Result<C, MqttError> {
     client.publish_bytes(topic, QoS::AtLeastOnce, false, payload).await?;
     Ok(client)
-}
-
-#[derive(Debug, Default, Serialize, Clone)]
-pub struct Metrics {
-    #[serde(skip)]
-    topic: String,
-    sequence: u32,
-    timestamp: u64,
-    total_sent_size: usize,
-    total_disk_size: usize,
-    lost_segments: usize,
-    errors: String,
-    error_count: usize,
-}
-
-impl Metrics {
-    pub fn new(config: Arc<Config>) -> Option<Metrics> {
-        let topic = match &config.serializer_metrics.as_ref()?.topic {
-            Some(topic) => topic.to_owned(),
-            _ => {
-                String::from("/tenants/")
-                    + &config.project_id
-                    + "/devices/"
-                    + &config.device_id
-                    + "/events/"
-                    + &"metrics"
-                    + "/jsonarray"
-            }
-        };
-
-        Some(Metrics { topic, errors: String::with_capacity(1024), ..Default::default() })
-    }
-
-    pub fn add_total_sent_size(&mut self, size: usize) {
-        self.total_sent_size = self.total_sent_size.saturating_add(size);
-    }
-
-    pub fn add_total_disk_size(&mut self, size: usize) {
-        self.total_disk_size = self.total_disk_size.saturating_add(size);
-    }
-
-    pub fn sub_total_disk_size(&mut self, size: usize) {
-        self.total_disk_size = self.total_disk_size.saturating_sub(size);
-    }
-
-    pub fn increment_lost_segments(&mut self) {
-        self.lost_segments += 1;
-    }
-
-    // pub fn add_error<S: Into<String>>(&mut self, error: S) {
-    //     self.error_count += 1;
-    //     if self.errors.len() > 1024 {
-    //         return;
-    //     }
-    //
-    //     self.errors.push_str(", ");
-    //     self.errors.push_str(&error.into());
-    // }
-
-    pub fn add_errors<S: Into<String>>(&mut self, error: S, count: usize) {
-        self.error_count += count;
-        if self.errors.len() > 1024 {
-            return;
-        }
-
-        self.errors.push_str(&error.into());
-        self.errors.push_str(" | ");
-    }
-
-    pub fn update(&mut self) -> Metrics {
-        let timestamp =
-            SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or(Duration::from_secs(0));
-        self.timestamp = timestamp.as_millis() as u64;
-        self.sequence += 1;
-
-        self.clone()
-    }
-
-    pub fn clear(&mut self) {
-        self.errors.clear();
-        self.lost_segments = 0;
-    }
-}
-
-impl Point for Metrics {
-    fn sequence(&self) -> u32 {
-        self.sequence
-    }
-
-    fn timestamp(&self) -> u64 {
-        self.timestamp
-    }
-
-    fn collection_timestamp(&self) -> u64 {
-        self.timestamp
-    }
 }
 
 #[cfg(test)]

--- a/uplink/src/base/serializer/metrics.rs
+++ b/uplink/src/base/serializer/metrics.rs
@@ -4,6 +4,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use serde::Serialize;
 
+use crate::base::MetricsConfig;
 use crate::Config;
 
 #[derive(Debug, Default, Serialize, Clone)]
@@ -24,14 +25,15 @@ pub struct SerializerMetricsHandler {
 
 impl SerializerMetricsHandler {
     pub fn new(config: Arc<Config>) -> Option<Self> {
-        let topic = match &config.serializer_metrics.as_ref()?.topic {
-            Some(topic) => topic.to_owned(),
+        let topic = match &config.serializer_metrics {
+            MetricsConfig { enabled: false, .. } => return None,
+            MetricsConfig { topic: Some(topic), .. } => topic.to_owned(),
             _ => {
                 String::from("/tenants/")
                     + &config.project_id
                     + "/devices/"
                     + &config.device_id
-                    + "/events/metrics/jsonarray"
+                    + "/events/serializer_metrics/jsonarray"
             }
         };
 
@@ -111,8 +113,9 @@ pub struct StreamMetricsHandler {
 
 impl StreamMetricsHandler {
     pub fn new(config: Arc<Config>) -> Option<Self> {
-        let topic = match &config.stream_metrics.as_ref()?.topic {
-            Some(topic) => topic.to_owned(),
+        let topic = match &config.stream_metrics {
+            MetricsConfig { enabled: false, .. } => return None,
+            MetricsConfig { topic: Some(topic), .. } => topic.to_owned(),
             _ => {
                 String::from("/tenants/")
                     + &config.project_id

--- a/uplink/src/base/serializer/metrics.rs
+++ b/uplink/src/base/serializer/metrics.rs
@@ -98,8 +98,8 @@ pub struct StreamMetrics {
     sequence: u32,
     stream: String,
     point_count: usize,
-    batch_count: usize,
-    average_latency: f64,
+    batch_count: u64,
+    average_latency: u64,
     min_latency: u64,
     max_latency: u64,
 }
@@ -136,12 +136,11 @@ impl StreamMetricsHandler {
 
         metrics.max_latency = metrics.max_latency.max(batch_latency);
         metrics.min_latency = metrics.min_latency.min(batch_latency);
-        let total_latency =
-            (metrics.average_latency * metrics.batch_count as f64) + batch_latency as f64;
+        let total_latency = (metrics.average_latency * metrics.batch_count) + batch_latency;
 
         metrics.batch_count += 1;
         metrics.point_count += point_count;
-        metrics.average_latency = total_latency / metrics.batch_count as f64;
+        metrics.average_latency = total_latency / metrics.batch_count;
     }
 
     pub fn streams(&mut self) -> Streams {

--- a/uplink/src/base/serializer/metrics.rs
+++ b/uplink/src/base/serializer/metrics.rs
@@ -1,0 +1,88 @@
+use std::{
+    sync::Arc,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use serde::Serialize;
+
+use crate::Config;
+
+#[derive(Debug, Default, Serialize, Clone)]
+pub struct SerializerMetrics {
+    #[serde(skip)]
+    pub topic: String,
+    sequence: u32,
+    timestamp: u64,
+    total_sent_size: usize,
+    total_disk_size: usize,
+    lost_segments: usize,
+    errors: String,
+    error_count: usize,
+}
+
+impl SerializerMetrics {
+    pub fn new(config: Arc<Config>) -> Option<Self> {
+        let topic = match &config.serializer_metrics.as_ref()?.topic {
+            Some(topic) => topic.to_owned(),
+            _ => {
+                String::from("/tenants/")
+                    + &config.project_id
+                    + "/devices/"
+                    + &config.device_id
+                    + "/events/metrics/jsonarray"
+            }
+        };
+
+        Some(Self { topic, errors: String::with_capacity(1024), ..Default::default() })
+    }
+
+    pub fn add_total_sent_size(&mut self, size: usize) {
+        self.total_sent_size = self.total_sent_size.saturating_add(size);
+    }
+
+    pub fn add_total_disk_size(&mut self, size: usize) {
+        self.total_disk_size = self.total_disk_size.saturating_add(size);
+    }
+
+    pub fn sub_total_disk_size(&mut self, size: usize) {
+        self.total_disk_size = self.total_disk_size.saturating_sub(size);
+    }
+
+    pub fn increment_lost_segments(&mut self) {
+        self.lost_segments += 1;
+    }
+
+    // pub fn add_error<S: Into<String>>(&mut self, error: S) {
+    //     self.error_count += 1;
+    //     if self.errors.len() > 1024 {
+    //         return;
+    //     }
+    //
+    //     self.errors.push_str(", ");
+    //     self.errors.push_str(&error.into());
+    // }
+
+    pub fn add_errors<S: Into<String>>(&mut self, error: S, count: usize) {
+        self.error_count += count;
+        if self.errors.len() > 1024 {
+            return;
+        }
+
+        self.errors.push_str(&error.into());
+        self.errors.push_str(" | ");
+    }
+
+    pub fn update(&mut self) -> Self {
+        let timestamp =
+            SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or(Duration::from_secs(0));
+        self.timestamp = timestamp.as_millis() as u64;
+        self.sequence += 1;
+
+        self.clone()
+    }
+
+    pub fn clear(&mut self) {
+        self.errors.clear();
+        self.lost_segments = 0;
+    }
+}

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -62,7 +62,11 @@ pub mod config {
     # Create empty streams map
     [streams]
 
-    # [serializer_metrics] is left disabled by default
+    [serializer_metrics]
+    enabled = false
+
+    [stream_metrics]
+    enabled = false
 
     [action_status]
     topic = "/tenants/{tenant_id}/devices/{device_id}/action/status"
@@ -103,7 +107,7 @@ pub mod config {
 
         replace_topic_placeholders(&mut config.action_status, tenant_id, device_id);
 
-        if let Some(config) = &mut config.serializer_metrics {
+        for config in [&mut config.serializer_metrics, &mut config.stream_metrics] {
             if let Some(topic) = &config.topic {
                 let topic = topic.replace("{tenant_id}", tenant_id);
                 let topic = topic.replace("{device_id}", device_id);


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
Adds handler to keep track of per stream metrics.

### Why?
Enables monitoring of uplink working at a per-stream level.

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
Run against main_app sending `device_shadow` with differing `buf_sizes`
1. when set to buf size 1, i.e. direct flush, json looks like
```
[
    {
        "timestamp": 1672339700764,
        "sequence": 4,
        "stream: "device_shadow",
        "point_count": 7,
        "batch_count": 7,
        "average_latency": 0.0,
        "min_latency": 0,
        "max_latency": 0
    }
]
```
2. 10 points, with slightly large latencies(~45s according to the following):
```
[
    {
        "timestamp": 1672340100612,
        "sequence": 1,
        "stream": "device_shadow",
        "point_count": 10,
        "batch_count": 1,
        "average_latency": 45046.0,
        "min_latency": 45046,
        "max_latency": 45046
    }
]
```