### PR TITLE
fix: clear `stream_metrics` on write to network

### DIFF
--- a/uplink/src/base/serializer.rs
+++ b/uplink/src/base/serializer.rs
@@ -476,8 +476,9 @@ impl<C: MqttClient> Serializer<C> {
                         handler.clear();
 
                         info!("Publishing serializer metrics to broker");
-                        if let Err(e) = self.client.try_publish(&handler.topic, QoS::AtLeastOnce, false, payload) {
-                            error!("Couldn't publish serializer metrics to broker: {}", e)
+                        match self.client.try_publish(&handler.topic, QoS::AtLeastOnce, false, payload) {
+                            Err(e) => error!("Couldn't publish serializer metrics to broker: {e}"),
+                            _ => handler.clear(),
                         }
                     }
 
@@ -486,11 +487,12 @@ impl<C: MqttClient> Serializer<C> {
                         if data.is_empty() {
                             continue;
                         }
+                        let payload = serde_json::to_vec(&data)?;
 
                         info!("Publishing stream metrics to broker");
-                        let payload = serde_json::to_vec(&data)?;
-                        if let Err(e) = self.client.try_publish(&handler.topic, QoS::AtLeastOnce, false, payload) {
-                            error!("Couldn't publish stream metrics to broker: {}", e)
+                        match self.client.try_publish(&handler.topic, QoS::AtLeastOnce, false, payload) {
+                            Err(e) => error!("Couldn't publish stream metrics to broker: {e}"),
+                            _ => handler.clear(),
                         }
                     }
                 }

--- a/uplink/src/base/serializer.rs
+++ b/uplink/src/base/serializer.rs
@@ -482,7 +482,7 @@ impl<C: MqttClient> Serializer<C> {
                     }
 
                     if let Some(handler) = self.stream_metrics.as_mut() {
-                        let data: Vec<StreamMetrics> = handler.flush().collect();
+                        let data: Vec<&mut StreamMetrics> = handler.streams().collect();
                         if data.is_empty() {
                             continue;
                         }

--- a/uplink/src/base/serializer.rs
+++ b/uplink/src/base/serializer.rs
@@ -482,7 +482,7 @@ impl<C: MqttClient> Serializer<C> {
 
                     if let Some(handler) = self.stream_metrics.as_mut() {
                         info!("Publishing stream metrics to broker");
-                        let data: Vec<&mut StreamMetrics> = handler.streams().collect();
+                        let data: Vec<StreamMetrics> = handler.flush().collect();
                         let payload = serde_json::to_vec(&data)?;
                         if let Err(e) = self.client.try_publish(&handler.topic, QoS::AtLeastOnce, false, payload) {
                             error!("Couldn't publish stream metrics to broker: {}", e)

--- a/uplink/src/base/serializer/metrics.rs
+++ b/uplink/src/base/serializer/metrics.rs
@@ -1,4 +1,4 @@
-use std::collections::hash_map::Drain;
+use std::collections::hash_map::ValuesMut;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use std::{collections::HashMap, sync::Arc};
 
@@ -146,20 +146,20 @@ impl StreamMetricsHandler {
         metrics.average_latency = total_latency / metrics.batch_count;
     }
 
-    pub fn flush(&mut self) -> Streams {
-        Streams { map: self.map.drain() }
+    pub fn streams(&mut self) -> Streams {
+        Streams { values: self.map.values_mut() }
     }
 }
 
 pub struct Streams<'a> {
-    map: Drain<'a, String, StreamMetrics>,
+    values: ValuesMut<'a, String, StreamMetrics>,
 }
 
 impl<'a> Iterator for Streams<'a> {
-    type Item = StreamMetrics;
+    type Item = &'a mut StreamMetrics;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let (_, mut metrics) = self.map.next()?;
+        let metrics = self.values.next()?;
         metrics.sequence += 1;
         metrics.timestamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)

--- a/uplink/src/base/serializer/metrics.rs
+++ b/uplink/src/base/serializer/metrics.rs
@@ -149,6 +149,10 @@ impl StreamMetricsHandler {
     pub fn streams(&mut self) -> Streams {
         Streams { values: self.map.values_mut() }
     }
+
+    pub fn clear(&mut self) {
+        self.map.clear();
+    }
 }
 
 pub struct Streams<'a> {


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
Clears/flushes stream metrics from the map on writing to network. 

### Why?
It is required that we keep track of stats only until they are written to network

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->