### PR TITLE
fix: set default values for persistence config if missing

### DIFF
--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -34,10 +34,20 @@ pub struct StreamConfig {
     pub flush_period: u64,
 }
 
+fn default_file_size() -> usize {
+    104857600 // 100MB
+}
+
+fn default_file_count() -> usize {
+    3
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct Persistence {
     pub path: String,
+    #[serde(default = "default_file_size")]
     pub max_file_size: usize,
+    #[serde(default = "default_file_count")]
     pub max_file_count: usize,
 }
 


### PR DESCRIPTION
Closes #94

<!--Brief description of the purpose behind opening the PR-->

### Changes
Use default values for missing persistence configs

### Why?
Allows backward compatibility with certain config files

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->