### PR TITLE
feat: add onfigurable blacklist to `stream_metrics`

### DIFF
--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -87,27 +87,12 @@ pub struct Downloader {
     pub path: String,
 }
 
-fn default_black_list() -> Vec<String> {
-    vec![
-        "mainapp_metrics",
-        "uplink_disk_stats",
-        "uplink_network_stats",
-        "uplink_processor_stats",
-        "uplink_process_stats",
-        "uplink_component_stats",
-        "uplink_system_stats",
-    ]
-    .iter()
-    .map(|x| x.to_string())
-    .collect()
-}
-
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct MetricsConfig {
     pub enabled: bool,
     pub topic: Option<String>,
     /// List of streams that are to be ignored by uplink's stat collector
-    #[serde(default = "default_black_list")]
+    #[serde(default)]
     pub black_list: Vec<String>,
 }
 

--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -87,10 +87,28 @@ pub struct Downloader {
     pub path: String,
 }
 
+fn default_black_list() -> Vec<String> {
+    vec![
+        "mainapp_metrics",
+        "uplink_disk_stats",
+        "uplink_network_stats",
+        "uplink_processor_stats",
+        "uplink_process_stats",
+        "uplink_component_stats",
+        "uplink_system_stats",
+    ]
+    .iter()
+    .map(|x| x.to_string())
+    .collect()
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct MetricsConfig {
     pub enabled: bool,
     pub topic: Option<String>,
+    /// List of streams that are to be ignored by uplink's stat collector
+    #[serde(default = "default_black_list")]
+    pub black_list: Vec<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]

--- a/uplink/src/base/serializer/metrics.rs
+++ b/uplink/src/base/serializer/metrics.rs
@@ -109,6 +109,7 @@ pub struct StreamMetrics {
 
 pub struct StreamMetricsHandler {
     pub topic: String,
+    black_list: Vec<String>,
     map: HashMap<String, StreamMetrics>,
 }
 
@@ -126,12 +127,19 @@ impl StreamMetricsHandler {
             }
         };
 
-        Some(Self { topic, map: Default::default() })
+        Some(Self {
+            topic,
+            black_list: config.stream_metrics.black_list.clone(),
+            map: Default::default(),
+        })
     }
 
     /// Updates the metrics for a stream as deemed necessary with the count of points in batch
     /// and the difference between first and last elements timestamp as latency being inputs.
     pub fn update(&mut self, stream: String, point_count: usize, batch_latency: u64) {
+        if self.black_list.contains(&stream) {
+            return;
+        }
         // Init stream metrics max/min values with opposite extreme values to ensure first latency value is accepted
         let metrics = self.map.entry(stream.clone()).or_insert(StreamMetrics {
             stream,

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -113,6 +113,17 @@ pub mod config {
                 let topic = topic.replace("{device_id}", device_id);
                 config.topic = Some(topic);
             }
+
+            for stat in [
+                "disk_stats",
+                "network_stats",
+                "processor_stats",
+                "process_stats",
+                "component_stats",
+                "system_stats",
+            ] {
+                config.black_list.push("uplink_".to_string() + stat);
+            }
         }
 
         Ok(config)


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
Enables blacklisting streams that shouldn't be tracked for uplink stats

### Why?
Users may want to keep certain streams from having their metrics information tracked

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->