### PR TITLE
feat: global config to bypass uplink metrics collectors

### DIFF
--- a/configs/config.toml
+++ b/configs/config.toml
@@ -34,6 +34,11 @@ topic = "/tenants/{tenant_id}/devices/{device_id}/metrics/jsonarray"
 [stream_metrics]
 enabled = true
 
+# Some streams the user might want to not include when measuring uplink's metrics,
+# or even for batching. Mentioned streams if not otherwise configured will also be
+# flushed on a single point entering, ensuring instant forwarding to platform.
+bypass_streams = ["mainapp_metrics"]
+
 # Configuration details associated with uplink's persistent storage module
 # which writes publish packets to disk in case of slow or crashed network.
 # 

--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -91,9 +91,6 @@ pub struct Downloader {
 pub struct MetricsConfig {
     pub enabled: bool,
     pub topic: Option<String>,
-    /// List of streams that are to be ignored by uplink's stat collector
-    #[serde(default)]
-    pub black_list: Vec<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]
@@ -113,6 +110,9 @@ pub struct Config {
     pub action_status: StreamConfig,
     pub serializer_metrics: MetricsConfig,
     pub stream_metrics: MetricsConfig,
+    /// List of streams that are to be ignored by uplink's internal metrics collectors
+    #[serde(default)]
+    pub bypass_streams: Vec<String>,
     pub downloader: Option<Downloader>,
     pub stats: Stats,
     pub simulator: Option<SimulatorConfig>,

--- a/uplink/src/base/serializer/metrics.rs
+++ b/uplink/src/base/serializer/metrics.rs
@@ -129,7 +129,7 @@ impl StreamMetricsHandler {
 
         Some(Self {
             topic,
-            black_list: config.stream_metrics.black_list.clone(),
+            black_list: config.bypass_streams.clone(),
             map: Default::default(),
         })
     }

--- a/uplink/src/collector/util.rs
+++ b/uplink/src/collector/util.rs
@@ -91,7 +91,7 @@ impl Streams {
                     return;
                 }
 
-               let stream = Stream::dynamic(
+                let stream = Stream::dynamic(
                     &data.stream,
                     &self.config.project_id,
                     &self.config.device_id,

--- a/uplink/src/collector/util.rs
+++ b/uplink/src/collector/util.rs
@@ -91,22 +91,12 @@ impl Streams {
                     return;
                 }
 
-                let stream = if self.config.bypass_streams.contains(&data.stream) {
-                    Stream::dynamic_with_size(
-                        &data.stream,
-                        &self.config.project_id,
-                        &self.config.device_id,
-                        1,
-                        self.data_tx.clone(),
-                    )
-                } else {
-                    Stream::dynamic(
-                        &data.stream,
-                        &self.config.project_id,
-                        &self.config.device_id,
-                        self.data_tx.clone(),
-                    )
-                };
+               let stream = Stream::dynamic(
+                    &data.stream,
+                    &self.config.project_id,
+                    &self.config.device_id,
+                    self.data_tx.clone(),
+                );
                 self.map.entry(data.stream.to_owned()).or_insert(stream)
             }
         };

--- a/uplink/src/collector/util.rs
+++ b/uplink/src/collector/util.rs
@@ -91,12 +91,22 @@ impl Streams {
                     return;
                 }
 
-                let stream = Stream::dynamic(
-                    &data.stream,
-                    &self.config.project_id,
-                    &self.config.device_id,
-                    self.data_tx.clone(),
-                );
+                let stream = if self.config.bypass_streams.contains(&data.stream) {
+                    Stream::dynamic_with_size(
+                        &data.stream,
+                        &self.config.project_id,
+                        &self.config.device_id,
+                        1,
+                        self.data_tx.clone(),
+                    )
+                } else {
+                    Stream::dynamic(
+                        &data.stream,
+                        &self.config.project_id,
+                        &self.config.device_id,
+                        self.data_tx.clone(),
+                    )
+                };
                 self.map.entry(data.stream.to_owned()).or_insert(stream)
             }
         };

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -113,17 +113,17 @@ pub mod config {
                 let topic = topic.replace("{device_id}", device_id);
                 config.topic = Some(topic);
             }
+        }
 
-            for stat in [
-                "disk_stats",
-                "network_stats",
-                "processor_stats",
-                "process_stats",
-                "component_stats",
-                "system_stats",
-            ] {
-                config.black_list.push("uplink_".to_string() + stat);
-            }
+        for stat in [
+            "disk_stats",
+            "network_stats",
+            "processor_stats",
+            "process_stats",
+            "component_stats",
+            "system_stats",
+        ] {
+            config.bypass_streams.push("uplink_".to_string() + stat);
         }
 
         Ok(config)


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
Adds a new field that allows users to configure certain streams, allowing them to bypass the metrics collector, instead of per metrics config black listing.

### Why?
Currently configuration has to be made for each collector, the PR allows a global configuration that bypasses the stream from metrics collectors.

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->