### PR TITLE
fix: ignore rest of file in case of corruption

### DIFF
--- a/uplink/src/base/serializer.rs
+++ b/uplink/src/base/serializer.rs
@@ -318,6 +318,10 @@ impl<C: MqttClient> Serializer<C> {
                     let publish = match read(storage.reader(), max_packet_size) {
                         Ok(Packet::Publish(publish)) => publish,
                         Ok(packet) => unreachable!("Unexpected packet: {:?}", packet),
+                        Err(rumqttc::Error::InsufficientBytes(n)) => {
+                            error!("Failed to read {n} bytes from storage, required to construct a packet, ignoring rest of file.");
+                            continue;
+                        },
                         Err(e) => {
                             error!("Failed to read from storage. Forcing into Normal mode. Error = {:?}", e);
                             return Ok(Status::Normal)


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
ignores files that are corrupted when catching up.

### Why?
Currently on reading a corrupted file, serializer jumps into normal mode, the expected behavior should be such that the file is ignored and the next file, if any is loaded.

### Trials Performed
Wrote test and confirmed on device