### PR TITLE
fix: compilation for android targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1562,9 +1562,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2556,6 +2556,7 @@ dependencies = [
  "lazy_static",
  "log",
  "rand 0.8.5",
+ "regex",
  "reqwest",
  "rumqttc",
  "serde",

--- a/uplink/Cargo.toml
+++ b/uplink/Cargo.toml
@@ -31,5 +31,9 @@ sysinfo = "0.26"
 lazy_static = "1.4.0"
 glob = "0.3"
 
+[target.'cfg(target_os = "android")'.dependencies]
+regex = "1.7.1"
+time = { version = "0.3.17", features = ["macros"]}
+
 [build-dependencies]
 vergen = { version = "7", features = ["git", "build", "time"] }

--- a/uplink/src/collector/logging/logcat.rs
+++ b/uplink/src/collector/logging/logcat.rs
@@ -1,7 +1,6 @@
 use std::process::{Command, Stdio};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use chrono::{Datelike, Local, Timelike};
 use serde::{Deserialize, Serialize};
 
 use super::LoggingConfig;
@@ -91,14 +90,14 @@ lazy_static::lazy_static! {
 
 pub fn parse_logcat_time(s: &str) -> Option<u64> {
     let matches = LOGCAT_TIME_RE.captures(s)?;
-    let date = Local::now()
-        .with_month(matches.get(1)?.as_str().parse::<u32>().ok()?)?
-        .with_day(matches.get(2)?.as_str().parse::<u32>().ok()?)?
-        .with_hour(matches.get(3)?.as_str().parse::<u32>().ok()?)?
-        .with_minute(matches.get(4)?.as_str().parse::<u32>().ok()?)?
-        .with_second(matches.get(5)?.as_str().parse::<u32>().ok()?)?
-        .with_second(matches.get(6)?.as_str().parse::<u32>().ok()? * 1_000_000)?;
-    Some(date.timestamp_millis() as _)
+    let date = time::OffsetDateTime::now_utc()
+        .replace_month(matches.get(1)?.as_str().parse::<u8>().ok()?.try_into().ok()?).ok()?
+        .replace_day(matches.get(2)?.as_str().parse::<u8>().ok()?).ok()?
+        .replace_hour(matches.get(3)?.as_str().parse::<u8>().ok()?).ok()?
+        .replace_minute(matches.get(4)?.as_str().parse::<u8>().ok()?).ok()?
+        .replace_second(matches.get(5)?.as_str().parse::<u8>().ok()?).ok()?
+        .replace_microsecond(matches.get(6)?.as_str().parse::<u32>().ok()? * 1_000_000).ok()?;
+    Some(date.unix_timestamp() as _)
 }
 
 impl LogEntry {


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
Use time instead of chrono and add dependencies specific to android targets

### Why?
For compilation to android targets

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->