### PR TITLE
clippy for android

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,17 +7,33 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
-
+  clippy:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v2
-    - name: Clippy
-      run: cargo clippy --verbose
-      env:
+      - uses: actions/checkout@v2
+      - name: Clippy
+        run: cargo clippy --verbose
+        env:
           RUSTFLAGS: "-D warnings"
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      - name: Run tests
+        run: cargo test --verbose
+
+  clippy-android:
+    name: Build for aarch64-linux-android
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: sudo apt install unzip
+      - run: cargo install cargo-ndk@2.11.0
+      - name: Setup Android NDK
+        id: ndk
+        uses: nttld/setup-ndk@v1.2.0
+        with:
+          ndk-version: r25b
+      - run: rustup target add aarch64-linux-android
+      - run: cargo ndk --target aarch64-linux-android --platform 23 clippy
+        env:
+          RUST_FLAGS: "-D warnings"
+          ANDROID_NDK_HOME: ${{ steps.ndk.outputs.ndk-path }}
+          ANDROID_NDK_ROOT: ${{ steps.ndk.outputs.ndk-path }}
+

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   clippy:
+    name: Clippy on linux x86
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -19,7 +20,7 @@ jobs:
         run: cargo test --verbose
 
   clippy-android:
-    name: Build for aarch64-linux-android
+    name: Clippy on android aarch64
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
- Removes build step from CI runs on each PR
- Adds clippy run with aarch64-android target for confirming android compatibility of PR

### Why?
Helps to maintain compatibility of codebase with android targets, using aarch64 alone for compute and wait reasons.

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->