### PR TITLE
feat: multiple tcp ports, one per app re-design

### DIFF
--- a/configs/config.toml
+++ b/configs/config.toml
@@ -16,11 +16,11 @@ actions = ["tunshell"]
 # Required Parameters
 # - port: TCP/IP Port on which application can connect to uplink over
 # - actions: A list of actions that uplink can forward to the app
-[applications.1]
+[tcpapps.1]
 port = 5555
 actions = ["lock", "unlock"]
 
-[applications.2]
+[tcpapps.2]
 port = 5556
 actions = []
 

--- a/configs/config.toml
+++ b/configs/config.toml
@@ -1,6 +1,3 @@
-# TCP Port to connect your applications with uplink
-bridge_port = 5555
-
 # MQTT client configuration
 # 
 # Required Parameters
@@ -15,7 +12,13 @@ max_inflight = 100
 # triggered from cloud.
 actions = ["tunshell"]
 
-# flushed on a single point entering, ensuring instant forwarding to platform.
+# TCP applications that detail applications which connect with uplink
+# Required Parameters
+# - port: TCP/IP Port on which application can connect to uplink over
+# - actions: A list of actions that uplink can forward to the app
+[applications.1]
+port = 5555
+actions = ["lock", "unlock"]
 
 # Metrics configurations are available for serializer and streams. By default 
 # they are disabled and no metrics will be forwarded to platform. 

--- a/configs/config.toml
+++ b/configs/config.toml
@@ -20,6 +20,10 @@ actions = ["tunshell"]
 port = 5555
 actions = ["lock", "unlock"]
 
+[applications.2]
+port = 5556
+actions = []
+
 # Metrics configurations are available for serializer and streams. By default 
 # they are disabled and no metrics will be forwarded to platform. 
 # Parameters

--- a/uplink/src/base/bridge/bridge.rs
+++ b/uplink/src/base/bridge/bridge.rs
@@ -37,6 +37,8 @@ pub struct Bridge {
     /// Action responses going to backend
     action_status: Stream<ActionResponse>,
     /// Apps registered with the bridge
+    /// NOTE: Sometimes action_routes could overlap, the latest route
+    /// to be registered will be used in such a circumstance.
     action_routes: HashMap<String, Sender<Action>>,
     /// Current action that is being processed
     current_action: Option<CurrentAction>,

--- a/uplink/src/base/bridge/bridge.rs
+++ b/uplink/src/base/bridge/bridge.rs
@@ -230,7 +230,10 @@ impl BridgeTx {
         actions_rx
     }
 
-    pub async fn register_action_routes<S: Into<String>>(&self, names: Vec<S>) -> Receiver<Action> {
+    pub async fn register_action_routes<S: Into<String>, V: IntoIterator<Item = S>>(
+        &self,
+        names: V,
+    ) -> Receiver<Action> {
         let (actions_tx, actions_rx) = bounded(0);
 
         for name in names {

--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -99,6 +99,12 @@ pub struct MqttMetricsConfig {
     pub topic: String,
 }
 
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct AppConfig {
+    pub port: u16,
+    pub actions: Vec<String>,
+}
+
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct Config {
     pub project_id: String,
@@ -106,7 +112,7 @@ pub struct Config {
     pub broker: String,
     pub port: u16,
     pub authentication: Option<Authentication>,
-    pub bridge_port: u16,
+    pub applications: HashMap<String, AppConfig>,
     pub max_packet_size: usize,
     pub max_inflight: u16,
     pub keep_alive: u64,

--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -112,7 +112,7 @@ pub struct Config {
     pub broker: String,
     pub port: u16,
     pub authentication: Option<Authentication>,
-    pub applications: HashMap<String, AppConfig>,
+    pub tcpapps: HashMap<String, AppConfig>,
     pub max_packet_size: usize,
     pub max_inflight: u16,
     pub keep_alive: u64,

--- a/uplink/src/collector/tcpjson.rs
+++ b/uplink/src/collector/tcpjson.rs
@@ -50,7 +50,7 @@ impl TcpJson {
         TcpJson { name, config, bridge, actions_rx }
     }
 
-    pub async fn start(&mut self) -> Result<(), Error> {
+    pub async fn start(mut self) -> Result<(), Error> {
         let addr = format!("0.0.0.0:{}", self.config.port);
         let listener = TcpListener::bind(&addr).await?;
 

--- a/uplink/src/main.rs
+++ b/uplink/src/main.rs
@@ -106,16 +106,14 @@ fn banner(commandline: &CommandLine, config: &Arc<Config>) {
     println!("    project_id: {}", config.project_id);
     println!("    device_id: {}", config.device_id);
     println!("    remote: {}:{}", config.broker, config.port);
-    if !config.applications.is_empty() {
-        println!("    applications:");
-        let mut n = 1;
-        for (app, AppConfig { port, actions }) in config.applications.iter() {
-            println!("        {n}.  name: {app:?}");
-            println!("            port: {port}");
-            println!("            actions: {actions:?}");
-            n += 1;
+    if !config.tcpapps.is_empty() {
+        println!("    tcp applications:");
+        for (app, AppConfig { port, actions }) in config.tcpapps.iter() {
+            println!("        name: {app:?}");
+            println!("        port: {port}");
+            println!("        actions: {actions:?}");
+            println!("        --------------------");
         }
-        println!();
     }
     println!("    secure_transport: {}", config.authentication.is_some());
     println!("    max_packet_size: {}", config.max_packet_size);
@@ -165,7 +163,7 @@ fn main() -> Result<(), Error> {
 
     rt.block_on(async {
         let mut handles = JoinSet::new();
-        for (app, cfg) in config.applications.iter() {
+        for (app, cfg) in config.tcpapps.iter() {
             let tcpjson = TcpJson::new(app.to_owned(), cfg.clone(), bridge.clone()).await;
             handles.spawn(async move {
                 if let Err(e) = tcpjson.start().await {

--- a/uplink/src/main.rs
+++ b/uplink/src/main.rs
@@ -107,14 +107,15 @@ fn banner(commandline: &CommandLine, config: &Arc<Config>) {
     println!("    device_id: {}", config.device_id);
     println!("    remote: {}:{}", config.broker, config.port);
     if !config.applications.is_empty() {
-        println!("    connected applications:");
+        println!("    applications:");
         let mut n = 1;
         for (app, AppConfig { port, actions }) in config.applications.iter() {
-            println!("        {n}. {app}:");
+            println!("        {n}.  name: {app:?}");
             println!("            port: {port}");
             println!("            actions: {actions:?}");
             n += 1;
         }
+        println!();
     }
     println!("    secure_transport: {}", config.authentication.is_some());
     println!("    max_packet_size: {}", config.max_packet_size);
@@ -169,8 +170,8 @@ fn main() -> Result<(), Error> {
             let tcpjson = TcpJson::new(app.to_owned(), cfg.clone(), bridge.clone(), actions_rx);
             handles.spawn(async move {
                 if let Err(e) = tcpjson.start().await {
-                error!("App failed. Error = {:?}", e);
-            }
+                    error!("App failed. Error = {:?}", e);
+                }
             });
         }
 

--- a/uplink/src/main.rs
+++ b/uplink/src/main.rs
@@ -166,8 +166,7 @@ fn main() -> Result<(), Error> {
     rt.block_on(async {
         let mut handles = JoinSet::new();
         for (app, cfg) in config.applications.iter() {
-            let actions_rx = bridge.register_action_routes(&cfg.actions).await;
-            let tcpjson = TcpJson::new(app.to_owned(), cfg.clone(), bridge.clone(), actions_rx);
+            let tcpjson = TcpJson::new(app.to_owned(), cfg.clone(), bridge.clone()).await;
             handles.spawn(async move {
                 if let Err(e) = tcpjson.start().await {
                     error!("App failed. Error = {:?}", e);


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->

### Why?
The user configuring uplink to work with their app will have a clear understanding of their requirements, i.e. what all applications will be connecting to uplink, before hand and will hence configure uplink appropriately, thus reducing the heavy lifting from within uplink and significantly improving the quality of life for developers and us maintainers 🥇 

### Trials Performed
Used against multiple demo apps connecting to separate ports, no two apps could connect to the same port together as the other blocks it. Apps received actions that had the app's name mentioned in them.

**Issue noticed that needs resolution in separate PR:** actions could not be forwarded to a connected app if there were multiple apps and one had received an action and had not finished processing it yet(i.e. `state` values of "Finished", "Completed" or on timeout).