### PR TITLE
Multiple action processors

### DIFF
--- a/tools/utils/Cargo.lock
+++ b/tools/utils/Cargo.lock
@@ -1547,9 +1547,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1618,7 +1618,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite 0.2.9",
  "rustls 0.20.7",
- "rustls-pemfile 1.0.1",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -1651,9 +1651,8 @@ dependencies = [
 
 [[package]]
 name = "rumqttc"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1514bbc994fc9f36ab7f7ae067b3e4758c717aff7a06c4818c6787cad8b086e1"
+version = "0.20.0"
+source = "git+https://github.com/bytebeamio/rumqtt#0baf8497844669b74aac4b4c9313e8808088d7fd"
 dependencies = [
  "bytes 1.3.0",
  "flume",
@@ -1661,7 +1660,7 @@ dependencies = [
  "log",
  "pollster",
  "rustls-native-certs",
- "rustls-pemfile 0.3.0",
+ "rustls-pemfile",
  "thiserror",
  "tokio 1.23.1",
  "tokio-rustls 0.23.4",
@@ -1717,18 +1716,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 1.0.1",
+ "rustls-pemfile",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee86d63972a7c661d1536fefe8c3c8407321c3df668891286de28abcd087360"
-dependencies = [
- "base64 0.13.1",
 ]
 
 [[package]]
@@ -2569,6 +2559,7 @@ dependencies = [
  "lazy_static",
  "log",
  "rand 0.8.5",
+ "regex",
  "reqwest",
  "rumqttc",
  "serde",


### PR DESCRIPTION
### Changes
Allow multiple clients to respond to an action. Send bridge disconnected status only when all clients disconnect.

### Why?
OTA in reactlabs setup consists of multiple steps which are handled by multiple clients.
