### PR TITLE
fix: proper use of configurations for process and downloader apps

### DIFF
--- a/configs/config.toml
+++ b/configs/config.toml
@@ -10,10 +10,10 @@ bridge_port = 5555
 max_packet_size = 102400
 max_inflight = 100
 
-# Whitelist of binaries which uplink can spawn as a process
-# This makes sure that user is protected against random actions
+# Collection of binaries which uplink can spawn as a process
+# This ensures that user is protected against random actions
 # triggered from cloud.
-actions = ["tunshell"]
+processes = ["echo"]
 
 # flushed on a single point entering, ensuring instant forwarding to platform.
 

--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -114,7 +114,7 @@ pub struct Config {
     pub max_packet_size: usize,
     pub max_inflight: u16,
     pub keep_alive: u64,
-    pub actions: Vec<String>,
+    pub processes: Vec<String>,
     #[serde(skip)]
     pub actions_subscription: String,
     pub persistence: Option<Persistence>,

--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -77,7 +77,7 @@ pub struct JournalctlConfig {
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]
-pub struct Downloader {
+pub struct DownloaderConfig {
     pub actions: Vec<String>,
     pub path: String,
 }
@@ -123,7 +123,7 @@ pub struct Config {
     pub stream_metrics: StreamMetricsConfig,
     pub serializer_metrics: SerializerMetricsConfig,
     pub mqtt_metrics: MqttMetricsConfig,
-    pub downloader: Downloader,
+    pub downloader: DownloaderConfig,
     pub stats: Stats,
     pub simulator: Option<SimulatorConfig>,
     #[serde(default)]

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -334,7 +334,7 @@ impl Uplink {
         }
 
         let process_handler = ProcessHandler::new(bridge_tx.clone());
-        let processes = config.actions.clone();
+        let processes = config.processes.clone();
         thread::spawn(move || process_handler.start(processes));
 
         let monitor = Monitor::new(


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
- Rename actions to processes
- use `DownloaderConfig` to route actions meant for file download

### Why?
<!--Detailed description of why the changes had to be made-->

### Trials Performed
Trigger appropriate download file and process actions from platform