### PR TITLE
fix: missing reset on current action timeout

### DIFF
--- a/uplink/src/base/bridge/bridge.rs
+++ b/uplink/src/base/bridge/bridge.rs
@@ -193,6 +193,8 @@ impl Bridge {
             return;
         }
 
+        inflight_action.reset_timeout();
+
         // Forward actions included in the config to the appropriate forward route, when
         // they have reached 100% progress but haven't been marked as "Completed"/"Finished".
         if action_done {


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->
**Current behavior**: response from connected application leads is forwarded as is, until the timeout set initially on receiving the action gets triggered. After this, all responses are discarded, which is wrong.

**Expected behavior**: once a response is received, as long as it is not the final response(`state: "Finished"`/`"Completed"`) uplink must expect more responses and only timeout and send a failure response when there are no responses within a suitable period of time, i.e the timeout must be reset whenever the app sends a response, as long as it is for the expected action and not a completion/failure notification, in which case the action is considered completed and timeouts for it must be dropped.

### Why?
<!--Detailed description of why the changes had to be made-->
An action once received, should be waited upon for a response from the connected application, if there is no response from the connected application within an appropriate time period, the application should be considered to have defaulted in providing a response and a failure response should be forwarded to broker. This allows for timely updation of trackers to the state of an action that the connected application isn't sending on it's own.

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
Tests written to test behavior when no responses sent and when a single response is sent, with timing between action being received and the response being forwarded also asserted.