### PR TITLE
feat: nest config for mqtt client

### DIFF
--- a/configs/config.toml
+++ b/configs/config.toml
@@ -1,17 +1,21 @@
+# Collection of binaries which uplink can spawn as a process
+# This ensures that user is protected against random actions
+# triggered from cloud.
+processes = ["echo"]
+action_redirections = { "firmware_update" = "install_update", "send_file" = "load_file" }
+
 # MQTT client configuration
 # 
 # Required Parameters
 # - max_packet_size: Maximum packet size acceptable for MQTT messages
 # - max_inflight: Maximum number of outgoing QoS 1/2 messages that can be
 #                 handled by uplink, at a time, requiring acknowledgedment.
+# - keep_alive: Number of seconds after which the MQTT client should ping
+#               the broker if there is no other data exchange.
+[mqtt]
 max_packet_size = 256000
 max_inflight = 100
-
-# Collection of binaries which uplink can spawn as a process
-# This ensures that user is protected against random actions
-# triggered from cloud.
-processes = ["echo"]
-action_redirections = { "firmware_update" = "install_update", "send_file" = "load_file" }
+keep_alive = 30
 
 # TCP applications that detail applications which connect with uplink
 # Required Parameters

--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -110,6 +110,13 @@ pub struct AppConfig {
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]
+pub struct MqttConfig {
+    pub max_packet_size: usize,
+    pub max_inflight: u16,
+    pub keep_alive: u64,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
 pub struct Config {
     pub project_id: String,
     pub device_id: String,
@@ -117,9 +124,7 @@ pub struct Config {
     pub port: u16,
     pub authentication: Option<Authentication>,
     pub tcpapps: HashMap<String, AppConfig>,
-    pub max_packet_size: usize,
-    pub max_inflight: u16,
-    pub keep_alive: u64,
+    pub mqtt: MqttConfig,
     pub processes: Vec<String>,
     #[serde(skip)]
     pub actions_subscription: String,

--- a/uplink/src/base/mqtt/mod.rs
+++ b/uplink/src/base/mqtt/mod.rs
@@ -207,9 +207,9 @@ impl Mqtt {
 fn mqttoptions(config: &Config) -> MqttOptions {
     // let (rsa_private, ca) = get_certs(&config.key.unwrap(), &config.ca.unwrap());
     let mut mqttoptions = MqttOptions::new(&config.device_id, &config.broker, config.port);
-    mqttoptions.set_max_packet_size(config.max_packet_size, config.max_packet_size);
-    mqttoptions.set_keep_alive(Duration::from_secs(config.keep_alive));
-    mqttoptions.set_inflight(config.max_inflight);
+    mqttoptions.set_max_packet_size(config.mqtt.max_packet_size, config.mqtt.max_packet_size);
+    mqttoptions.set_keep_alive(Duration::from_secs(config.mqtt.keep_alive));
+    mqttoptions.set_inflight(config.mqtt.max_inflight);
 
     if let Some(auth) = config.authentication.clone() {
         let ca = auth.ca_certificate.into_bytes();

--- a/uplink/src/base/serializer/serializer.rs
+++ b/uplink/src/base/serializer/serializer.rs
@@ -301,7 +301,7 @@ impl<C: MqttClient> Serializer<C> {
         let mut interval = time::interval(METRICS_INTERVAL);
         self.metrics.set_mode("catchup");
 
-        let max_packet_size = self.config.max_packet_size;
+        let max_packet_size = self.config.mqtt.max_packet_size;
         let client = self.client.clone();
 
         loop {
@@ -628,6 +628,7 @@ mod test {
 
     use super::*;
     use crate::base::bridge::Stream;
+    use crate::base::MqttConfig;
     use crate::{config::Persistence, Payload};
     use std::collections::HashMap;
 
@@ -713,7 +714,7 @@ mod test {
             port: 1883,
             device_id: "123".to_owned(),
             streams: HashMap::new(),
-            max_packet_size: 1024 * 1024,
+            mqtt: MqttConfig { max_packet_size: 1024 * 1024, ..Default::default() },
             ..Default::default()
         }
     }
@@ -818,7 +819,8 @@ mod test {
         );
         write_to_disk(publish.clone(), &mut storage).unwrap();
 
-        let stored_publish = read_from_storage(&mut storage, serializer.config.max_packet_size);
+        let stored_publish =
+            read_from_storage(&mut storage, serializer.config.mqtt.max_packet_size);
 
         // Ensure publish.pkid is 1, as written to disk
         publish.pkid = 1;

--- a/uplink/src/collector/downloader.rs
+++ b/uplink/src/collector/downloader.rs
@@ -279,7 +279,7 @@ pub struct DownloadFile {
 mod test {
     use std::{collections::HashMap, time::Duration};
 
-    use crate::base::{bridge::Event, DownloaderConfig};
+    use crate::base::{bridge::Event, DownloaderConfig, MqttConfig};
 
     use super::*;
     use flume::TrySendError;
@@ -293,7 +293,7 @@ mod test {
             port: 1883,
             device_id: "123".to_owned(),
             streams: HashMap::new(),
-            max_packet_size: 1024 * 1024,
+            mqtt: MqttConfig { max_packet_size: 1024 * 1024, ..Default::default() },
             downloader,
             ..Default::default()
         }

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -52,16 +52,17 @@ pub mod config {
     }
 
     const DEFAULT_CONFIG: &str = r#"
-    bridge_port = 5555
     run_logcat = true
-    max_packet_size = 256000
-    max_inflight = 100
-    keep_alive = 30
 
     # Whitelist of binaries which uplink can spawn as a process
     # This makes sure that user is protected against random actions
     # triggered from cloud.
     actions = ["tunshell"]
+
+    [mqtt]
+    max_packet_size = 256000
+    max_inflight = 100
+    keep_alive = 30
 
     # Create empty streams map
     [streams]

--- a/uplink/src/main.rs
+++ b/uplink/src/main.rs
@@ -122,9 +122,9 @@ fn banner(commandline: &CommandLine, config: &Arc<Config>) {
         }
     }
     println!("    secure_transport: {}", config.authentication.is_some());
-    println!("    max_packet_size: {}", config.max_packet_size);
-    println!("    max_inflight_messages: {}", config.max_inflight);
-    println!("    keep_alive_timeout: {}", config.keep_alive);
+    println!("    max_packet_size: {}", config.mqtt.max_packet_size);
+    println!("    max_inflight_messages: {}", config.mqtt.max_inflight);
+    println!("    keep_alive_timeout: {}", config.mqtt.keep_alive);
     if let Some(persistence) = &config.persistence {
         println!("    persistence_dir: {}", persistence.path);
         println!("    persistence_max_segment_size: {}", persistence.max_file_size);


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->
Nest the configs for MQTT client, i.e. `max_packet_size`, `max_inflight` and `keep_alive` within `Config.mqtt`

### Why?
<!--Detailed description of why the changes had to be made-->

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
Used changed `config.toml` to test working of uplink initialization step, as expected proper config values were extracted from the config file and this was verified with a `dbg!(&config)`.