### PR TITLE
fix: set `Config.apis.enabled = false` by default

### DIFF
--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -128,6 +128,7 @@ pub struct Config {
     pub device_id: String,
     pub broker: String,
     pub port: u16,
+    #[serde(default)]
     pub apis: TracingConfig,
     pub authentication: Option<Authentication>,
     pub tcpapps: HashMap<String, AppConfig>,


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->
Default to disabled when config is missing

### Why?
<!--Detailed description of why the changes had to be made-->
HTTP handler must be ideally disabled by default and only if configured to be so, should it be enabled

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
Run against `simulator.toml` which doesn't configure the apis field, observed to not throw the following error anymore:
```
Error: missing field `apis`
```