### PR TITLE
fix: default stream topics

### DIFF
--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -93,11 +93,11 @@ pub mod config {
     timeout = 10
 
     [streams.device_shadow]
-    topic = "/tenants/{tenant_id}/devices/{device_id}/device_shadow/jsonarray"
+    topic = "/tenants/{tenant_id}/devices/{device_id}/events/device_shadow/jsonarray"
     buf_size = 1
 
     [stats]
-    topic = "/tenants/{tenant_id}/devices/{device_id}/uplink_stats/jsonarray"
+    topic = "/tenants/{tenant_id}/devices/{device_id}/events/uplink_stats/jsonarray"
     enabled = false
     process_names = ["uplink"]
     update_period = 30


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->
Add missing level with the word "events" to properly resolve stream as expected by the data pipeline.

### Why?
<!--Detailed description of why the changes had to be made-->
The stream topics for device shadow and uplink system stats in `DEFAULT_CONFIG` are missing a level with the word `events`, leading to data being lost in the pipeline.

### Trials Performed
Run against stage, data is received in appropriate stream when used without changing topic in config with toml