### PR TITLE
feat: improve `simulator.sh` cli messaging

### DIFF
--- a/simulator.sh
+++ b/simulator.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 start_devices() {
+    limit=${1:?"Missing device count"}
     kill_devices;
 
-
     echo "Starting uplink and simulator"
-    for id in $(seq 1 $1)
+    for id in $(seq 1 $limit)
     do 
         mkdir -p devices
         # prepare config, please comment below line and download the right config from platform
@@ -44,4 +44,4 @@ kill_devices() {
     echo DONE
 }
 
-$1 $2
+${1:?"Missing command"} ${@:2}


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->

### Why?
<!--Detailed description of why the changes had to be made-->

### Trials Performed
Run `simulator.sh` to create 20 devices with `./simulator.sh start_devices 20`, observed to work as expected, i.e. 20 uplinks created with appropriate configs. Used `./simulator.sh kill_devices` to kill the 20 devices created earlier, all devices stopped as expected.