### PR TITLE
fix: store downloaded file with `file_name`

### DIFF
--- a/uplink/src/collector/downloader.rs
+++ b/uplink/src/collector/downloader.rs
@@ -173,7 +173,7 @@ impl FileDownloader {
         let url = update.url.clone();
 
         // Create file to actually download into
-        let (file, file_path) = self.create_file(&action.name, &url, &update.version)?;
+        let (file, file_path) = self.create_file(&action.name, &update.version)?;
 
         // Create handler to perform download from URL
         // TODO: Error out for 1XX/3XX responses
@@ -193,16 +193,13 @@ impl FileDownloader {
     }
 
     /// Creates file to download into
-    fn create_file(&self, name: &str, url: &str, version: &str) -> Result<(File, String), Error> {
+    fn create_file(&self, name: &str, file_name: &str) -> Result<(File, String), Error> {
         // Ensure that directory for downloading file into, of the format `path/to/{version}/`, exists
         let mut download_path = PathBuf::from(self.config.path.clone());
         download_path.push(name);
-        download_path.push(version);
         create_dir_all(&download_path)?;
 
         let mut file_path = download_path.to_owned();
-        let file_name =
-            url.split('/').last().ok_or_else(|| Error::FileNameMissing(url.to_owned()))?;
         file_path.push(file_name);
         let file_path = file_path.as_path();
         let file = File::create(file_path)?;

--- a/uplink/src/collector/downloader.rs
+++ b/uplink/src/collector/downloader.rs
@@ -173,7 +173,7 @@ impl FileDownloader {
         let url = update.url.clone();
 
         // Create file to actually download into
-        let (file, file_path) = self.create_file(&action.name, &update.version)?;
+        let (file, file_path) = self.create_file(&action.name, &update.file_name)?;
 
         // Create handler to perform download from URL
         // TODO: Error out for 1XX/3XX responses
@@ -266,8 +266,8 @@ impl FileDownloader {
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct DownloadFile {
     url: String,
-    #[serde(alias = "file_name")]
-    version: String,
+    #[serde(alias = "version")]
+    file_name: String,
     /// Path to location in fs where file will be stored
     download_path: Option<String>,
 }
@@ -319,7 +319,7 @@ mod test {
         // Create a firmware update action
         let download_update = DownloadFile {
             url: "https://github.com/bytebeamio/uplink/raw/main/docs/logo.png".to_string(),
-            version: "1.0".to_string(),
+            file_name: "1.0".to_string(),
             download_path: None,
         };
         let mut expected_forward = download_update.clone();
@@ -383,7 +383,7 @@ mod test {
         // Create a firmware update action
         let download_update = DownloadFile {
             url: "https://github.com/bytebeamio/uplink/raw/main/docs/logo.png".to_string(),
-            version: "1.0".to_string(),
+            file_name: "1.0".to_string(),
             download_path: None,
         };
         let mut expected_forward = download_update.clone();


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->
Store file with `file_name` instead of `artifact`.

### Why?
<!--Detailed description of why the changes had to be made-->
Files are provided from platform under the name artifact while they should be instead stored with the `file_name` defined in received action.

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
Action created on platform to `send_file`, uplink configured with file downloader, observed the file to download at the appropriate path in fs: `{download_path}/{action_name}/{file_name}` instead of `{download_path}/{action_name}/{file_name}/artifact`.

unit testing of download action