### PR TITLE
fix: maintain progress in case file size unknown

### DIFF
--- a/uplink/src/collector/downloader.rs
+++ b/uplink/src/collector/downloader.rs
@@ -222,6 +222,7 @@ impl FileDownloader {
         };
         let mut downloaded = 0;
         let mut next = 1;
+        let mut progress = 1;
         let mut stream = resp.bytes_stream();
 
         // Download and store to disk by streaming as chunks
@@ -238,8 +239,8 @@ impl FileDownloader {
                 let percentage = match content_length {
                     Some(content_length) => 100 * downloaded / content_length,
                     None => {
-                        downloaded = (downloaded + 1) % 101;
-                        downloaded
+                        progress += if progress < 99 { 1 } else { 0 };
+                        progress
                     }
                 };
 


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->

### Why?
<!--Detailed description of why the changes had to be made-->
Currently file downloader sends action responses with wonky progress values when the download server doesn't provide file size in HTTP response. To fix this, the PR uses a counter called progress which keeps incrementing progress till 99, only setting it to 100 on completion. This means that progress could remain in the 10s if the file isn't large enough and the downloader doesn't have the info of file size expected.

### Trials Performed
Downloading file of size 35MB, response's progress shows following values in log:
```
response.progress = 2
response.progress = 3
response.progress = 4
response.progress = 5
response.progress = 6
response.progress = 7
response.progress = 8
response.progress = 9
response.progress = 10
response.progress = 11
response.progress = 12
response.progress = 13
response.progress = 14
response.progress = 15
response.progress = 16
response.progress = 17
response.progress = 18
response.progress = 19
response.progress = 20
response.progress = 21
response.progress = 22
response.progress = 23
response.progress = 24
response.progress = 25
response.progress = 26
response.progress = 27
response.progress = 28
response.progress = 29
response.progress = 30
response.progress = 31
response.progress = 32
response.progress = 33
response.progress = 34
response.progress = 35
response.progress = 36
response.progress = 37
response.progress = 38
response.progress = 39
response.progress = 40
response.progress = 41
response.progress = 42
response.progress = 43
response.progress = 44
response.progress = 45
response.progress = 46
response.progress = 47
response.progress = 48
response.progress = 49
response.progress = 50
response.progress = 51
response.progress = 52
response.progress = 53
response.progress = 54
response.progress = 55
response.progress = 56
response.progress = 57
response.progress = 58
response.progress = 59
response.progress = 60
response.progress = 61
response.progress = 62
response.progress = 63
response.progress = 64
response.progress = 65
response.progress = 66
response.progress = 67
response.progress = 68
response.progress = 69
response.progress = 70
response.progress = 71
response.progress = 72
response.progress = 73
response.progress = 74
response.progress = 75
response.progress = 76
response.progress = 77
response.progress = 78
response.progress = 79
response.progress = 80
response.progress = 81
response.progress = 82
response.progress = 83
response.progress = 84
response.progress = 85
response.progress = 86
response.progress = 87
response.progress = 88
response.progress = 89
response.progress = 90
response.progress = 91
response.progress = 92
response.progress = 93
response.progress = 94
response.progress = 95
response.progress = 96
response.progress = 97
response.progress = 98
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 99
response.progress = 100
```