### PR TITLE
feat: allow configuring per action timeouts

### DIFF
--- a/configs/config.toml
+++ b/configs/config.toml
@@ -1,7 +1,7 @@
 # Collection of binaries which uplink can spawn as a process
 # This ensures that user is protected against random actions
 # triggered from cloud.
-processes = ["echo"]
+processes = [{ name = "echo" , duration = 30 }]
 action_redirections = { "firmware_update" = "install_update", "send_file" = "load_file" }
 
 # MQTT client configuration
@@ -23,7 +23,7 @@ keep_alive = 30
 # - actions: A list of actions that uplink can forward to the app
 [tcpapps.1]
 port = 5555
-actions = ["install_update", "load_file"]
+actions = [{ name = "install_update", duration =  60 }, { name = "load_file", duration = 60 }]
 
 [tcpapps.2]
 port = 5556
@@ -98,7 +98,7 @@ buf_size = 1
 # - actions: List of actions names that can trigger the downloader
 # - path: Location in fs where the files are downloaded into
 [downloader]
-actions = ["update_firmware", "send_file"]
+actions = [{ name = "update_firmware" , duration = 30 }, { name = "send_file", duration = 30 }]
 path = "/var/tmp/ota-file"
 
 # Configurations associated with the system stats module of uplink, if enabled

--- a/configs/simulator.toml
+++ b/configs/simulator.toml
@@ -1,11 +1,11 @@
 
-processes = ["echo"]
+processes = [{ name = "echo", duration = 60 }]
 
-action_redirections = { "firmware_update" = "install_update", "send_file" = "load_file" }
+action_redirections = { "update_firmware" = "install_update", "send_file" = "load_file" }
 
 [tcpapps.1]
 port = 5555
-actions = ["install_update", "load_file"]
+actions = [{ name = "install_update", duration = 60 }, { name = "load_file", duration = 30 }]
 
 [persistence]
 path = "/tmp/uplink"
@@ -15,4 +15,9 @@ max_file_count = 3
 [simulator]
 num_devices = 1
 gps_paths = "./paths/"
-actions = ["update_firmware", "send_file", "lock", "unlock"]
+actions = [
+    { name = "update_firmware", duration = 30 },
+    { name = "send_file", duration = 30 },
+    { name = "lock", duration = 30 },
+    { name = "unlock", duration = 30 }
+]

--- a/configs/stress.toml
+++ b/configs/stress.toml
@@ -1,11 +1,11 @@
 
-processes = ["echo"]
+processes = [{ name = "echo", duration = 30 }]
 
-action_redirections = { "firmware_update" = "install_update", "send_file" = "load_file" }
+action_redirections = { "update_firmware" = "install_update", "send_file" = "load_file" }
 
 [tcpapps.1]
 port = 5555
-actions = ["install_update", "load_file"]
+actions = [{ name = "install_update", duration = 30 }, { name = "load_file", duration = 30 }]
 
 [persistence]
 path = "/tmp/uplink"
@@ -15,4 +15,9 @@ max_file_count = 3
 [simulator]
 num_devices = 20
 gps_paths = "./paths/"
-actions = ["update_firmware", "send_file", "lock", "unlock"]
+actions = [
+    { name = "update_firmware", duration = 30 },
+    { name = "send_file", duration = 30 },
+    { name = "lock", duration = 30 },
+    { name = "unlock", duration = 30 }
+]

--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -64,7 +64,7 @@ pub struct SimulatorConfig {
     /// path to directory containing files with gps paths to be used in simulation
     pub gps_paths: String,
     /// actions that are to be routed to simulator
-    pub actions: Vec<String>,
+    pub actions: Vec<ActionRoute>,
     #[serde(skip)]
     pub actions_subscriptions: Vec<String>,
 }
@@ -78,7 +78,7 @@ pub struct JournalctlConfig {
 
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct DownloaderConfig {
-    pub actions: Vec<String>,
+    pub actions: Vec<ActionRoute>,
     pub path: String,
 }
 
@@ -103,10 +103,10 @@ pub struct MqttMetricsConfig {
     pub topic: String,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[derive(Debug, Clone, Deserialize, Default)]
 pub struct AppConfig {
     pub port: u16,
-    pub actions: Vec<String>,
+    pub actions: Vec<ActionRoute>,
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]
@@ -123,6 +123,18 @@ pub struct MqttConfig {
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]
+pub struct ActionRoute {
+    pub name: String,
+    pub duration: u64,
+}
+
+impl From<&ActionRoute> for ActionRoute {
+    fn from(value: &ActionRoute) -> Self {
+        value.clone()
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
 pub struct Config {
     pub project_id: String,
     pub device_id: String,
@@ -133,7 +145,7 @@ pub struct Config {
     pub authentication: Option<Authentication>,
     pub tcpapps: HashMap<String, AppConfig>,
     pub mqtt: MqttConfig,
-    pub processes: Vec<String>,
+    pub processes: Vec<ActionRoute>,
     #[serde(skip)]
     pub actions_subscription: String,
     pub persistence: Option<Persistence>,

--- a/uplink/src/collector/downloader.rs
+++ b/uplink/src/collector/downloader.rs
@@ -279,7 +279,7 @@ pub struct DownloadFile {
 mod test {
     use std::{collections::HashMap, time::Duration};
 
-    use crate::base::{bridge::Event, DownloaderConfig, MqttConfig};
+    use crate::base::{bridge::Event, DownloaderConfig, MqttConfig, ActionRoute};
 
     use super::*;
     use flume::TrySendError;
@@ -305,10 +305,8 @@ mod test {
         // Ensure path exists
         std::fs::create_dir_all(DOWNLOAD_DIR).unwrap();
         // Prepare config
-        let downloader_cfg = DownloaderConfig {
-            actions: vec!["firmware_update".to_owned()],
-            path: format!("{DOWNLOAD_DIR}/uplink-test"),
-        };
+        let downloader_cfg =
+            DownloaderConfig { actions: vec![ActionRoute { name: "firmware_update".to_owned(), duration: 10 }], path: format!("{DOWNLOAD_DIR}/uplink-test") };
         let config = config(downloader_cfg.clone());
         let (events_tx, events_rx) = flume::bounded(1);
         let bridge_tx = BridgeTx { events_tx };
@@ -370,7 +368,7 @@ mod test {
         std::fs::create_dir_all(DOWNLOAD_DIR).unwrap();
         // Prepare config
         let downloader_cfg = DownloaderConfig {
-            actions: vec!["firmware_update".to_string()],
+            actions: vec![ActionRoute { name: "firmware_update".to_owned(), duration: 10 }],
             path: format!("{}/download", DOWNLOAD_DIR),
         };
         let config = config(downloader_cfg.clone());

--- a/uplink/src/collector/process.rs
+++ b/uplink/src/collector/process.rs
@@ -6,6 +6,7 @@ use tokio::process::{Child, Command};
 use tokio::{pin, select, time};
 
 use crate::base::bridge::BridgeTx;
+use crate::base::ActionRoute;
 use crate::{ActionResponse, Package};
 
 use std::io;
@@ -84,7 +85,7 @@ impl ProcessHandler {
         Ok(())
     }
 
-    pub async fn start(mut self, processes: Vec<String>) -> Result<(), Error> {
+    pub async fn start(mut self, processes: Vec<ActionRoute>) -> Result<(), Error> {
         let action_rx = self.bridge_tx.register_action_routes(processes).await;
 
         loop {

--- a/uplink/src/collector/tunshell.rs
+++ b/uplink/src/collector/tunshell.rs
@@ -6,7 +6,7 @@ use tokio_compat_02::FutureExt;
 use tunshell_client::{Client, ClientMode, Config, HostShell};
 
 use crate::{
-    base::{self, bridge::BridgeTx},
+    base::{self, bridge::BridgeTx, ActionRoute},
     ActionResponse,
 };
 
@@ -43,7 +43,8 @@ impl TunshellSession {
 
     #[tokio::main(flavor = "current_thread")]
     pub async fn start(self) {
-        let actions_rx = self.bridge.register_action_route("launch_shell").await;
+        let route = ActionRoute { name: "launch_shell".to_owned(), duration: 10 };
+        let actions_rx = self.bridge.register_action_route(route).await;
 
         while let Ok(action) = actions_rx.recv_async().await {
             let action_id = action.action_id.clone();

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -54,11 +54,6 @@ pub mod config {
     const DEFAULT_CONFIG: &str = r#"
     run_logcat = true
 
-    # Whitelist of binaries which uplink can spawn as a process
-    # This makes sure that user is protected against random actions
-    # triggered from cloud.
-    actions = ["tunshell"]
-
     [mqtt]
     max_packet_size = 256000
     max_inflight = 100
@@ -69,7 +64,7 @@ pub mod config {
 
     # Downloader config
     [downloader]
-    actions = ["update_firmware", "send_file"]
+    actions = [{ name = "update_firmware", duration = 60 }, { name = "send_file", duration = 60 }]
     path = "/var/tmp/ota-file"
 
     [stream_metrics]


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->

### Why?
<!--Detailed description of why the changes had to be made-->

### Trials Performed
[x] Use config.toml with 30s timeout for "update_firmware" action
[x] Start uplink and trigger "update_firmware" action on platform
[x] Observe action send failure response at 30s from action being received:
```
  2023-02-23T18:40:10.157051Z ERROR uplink::base::bridge::bridge: Timeout waiting for action response. Action ID = 91
```