### PR TITLE
fix: allow stream topics to be optional

### DIFF
--- a/uplink/src/base/bridge/stream.rs
+++ b/uplink/src/base/bridge/stream.rs
@@ -70,7 +70,8 @@ where
         config: &StreamConfig,
         tx: Sender<Box<dyn Package>>,
     ) -> Stream<T> {
-        let mut stream = Stream::new(name, &config.topic, config.buf_size, tx);
+        // this unwrap is safe because all `None` topics are replaced with default value in `initialize_config()`
+        let mut stream = Stream::new(name, config.topic.as_ref().unwrap(), config.buf_size, tx);
         stream.flush_period = Duration::from_secs(config.flush_period);
         stream
     }

--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -28,7 +28,7 @@ fn default_file_count() -> usize {
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct StreamConfig {
-    pub topic: String,
+    pub topic: Option<String>,
     pub buf_size: usize,
     #[serde(default = "default_timeout")]
     /// Duration(in seconds) that bridge collector waits from


### PR DESCRIPTION
Closes #<!--Issue Number-->

Fixes regression from uplink 1.x

### Changes

Make `stream.<name>.topic` optional and set default values like uplink 1.x

### Why?
<!--Detailed description of why the changes had to be made-->

### Trials Performed
Manual testing using config files.