### PR TITLE
fix: action definition in sim config generator

### DIFF
--- a/simulator.sh
+++ b/simulator.sh
@@ -25,7 +25,7 @@ start_devices() {
 }
 
 create_uplink_config() {
-    printf "processes = [] \naction_redirections = { send_file = \"load_file\", update_firmware = \"install_firmware\" } \n\n[tcpapps.1] \nport = 500$1 \nactions= [\"load_file\", \"install_firmware\"] \n\n[downloader] \nactions= [\"send_file\", \"update_firmware\"] \npath = \"/var/tmp/ota/$1\"" > devices/device_$1.toml
+    printf "processes = [] \naction_redirections = { send_file = \"load_file\", update_firmware = \"install_firmware\" } \n\n[tcpapps.1] \nport = 500$1 \nactions= [{ name = \"load_file\" }, { name = \"install_firmware\" }] \n\n[downloader] \nactions= [{ name = \"send_file\" }, { name = \"update_firmware\" }] \npath = \"/var/tmp/ota/$1\"" > devices/device_$1.toml
 }
 
 download_auth_config() {


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
Make changes to config generation code in `simulator.sh` necessary to allow it to run against new uplink.

### Why?
<!--Detailed description of why the changes had to be made-->

### Trials Performed
Receive a "update_firmware" action, uplink observed to have run downloader as expected and then action redirection forwards the action to TCP port that accepts "install_firmware" actions and is running simulator code, which then continuously sends mock installation action statuses:
```
[2m2023-03-07T08:34:16.957969Z[0m [32m INFO[0m [1;32muplink::base::mqtt[0m[32m: [32mAction = Action { device_id: None, action_id: "5369", kind: "process", name: "update_firmware", payload: "{\"content-length\":223,\"status\":false,\"url\":\"https://firmware.cloud.bytebeam.io/api/v1/firmwares/v3.0.1/artifact\",\"version\":\"v3.0.1\"}" }[0m

  [2m2023-03-07T08:34:16.958071Z[0m [32m INFO[0m [1;32muplink::base::bridge[0m[32m: [32mReceived action: Action { device_id: None, action_id: "5369", kind: "process", name: "update_firmware", payload: "{\"content-length\":223,\"status\":false,\"url\":\"https://firmware.cloud.bytebeam.io/api/v1/firmwares/v3.0.1/artifact\",\"version\":\"v3.0.1\"}" }[0m

  [2m2023-03-07T08:34:16.958148Z[0m [32m INFO[0m [1;32muplink::base::bridge[0m[32m: [32mAction response = ActionResponse { action_id: "5369", device_id: None, sequence: 0, timestamp: 1678178056958, state: "Received", progress: 0, errors: [], done_response: None }[0m

  [2m2023-03-07T08:34:16.958186Z[0m [34mDEBUG[0m [1;34muplink::base::bridge::stream[0m[34m: [34mSequence number anomaly! [0, 0[0m

  [2m2023-03-07T08:34:16.958220Z[0m [32m INFO[0m [1;32muplink::base::bridge[0m[32m: [32mAction response = ActionResponse { action_id: "5369", device_id: None, sequence: 1, timestamp: 1678178056958, state: "Downloading", progress: 0, errors: [], done_response: None }[0m

  [2m2023-03-07T08:34:16.958301Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/action/status with size = 105[0m

  [2m2023-03-07T08:34:16.958395Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/action/status with size = 108[0m

  [2m2023-03-07T08:34:16.958425Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(97)[0m

  [2m2023-03-07T08:34:16.958455Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(98)[0m

  [2m2023-03-07T08:34:17.071896Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 97 })[0m

  [2m2023-03-07T08:34:17.071979Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 98 })[0m

  [2m2023-03-07T08:34:17.217193Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/events/device_shadow/jsonarray with size = 184[0m

  [2m2023-03-07T08:34:17.217427Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(99)[0m

  [2m2023-03-07T08:34:17.251722Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 99 })[0m

  [2m2023-03-07T08:34:17.578311Z[0m [32m INFO[0m [1;32muplink::collector::downloader[0m[32m: [32mDownloading from https://firmware.cloud.bytebeam.io/api/v1/firmwares/v3.0.1/artifact into /var/tmp/ota/1/update_firmware/v3.0.1[0m

  [2m2023-03-07T08:34:17.578427Z[0m [32m INFO[0m [1;32muplink::collector::downloader[0m[32m: [32mFirmware downloaded successfully[0m

  [2m2023-03-07T08:34:17.578531Z[0m [32m INFO[0m [1;32muplink::base::bridge[0m[32m: [32mAction response = ActionResponse { action_id: "5369", device_id: None, sequence: 2, timestamp: 1678178057578, state: "Downloaded", progress: 100, errors: [], done_response: Some(Action { device_id: None, action_id: "5369", kind: "process", name: "update_firmware", payload: "{\"url\":\"https://firmware.cloud.bytebeam.io/api/v1/firmwares/v3.0.1/artifact\",\"file_name\":\"v3.0.1\",\"download_path\":\"/var/tmp/ota/1/update_firmware/v3.0.1\"}" }) }[0m

  [2m2023-03-07T08:34:17.578704Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/action/status with size = 109[0m

  [2m2023-03-07T08:34:17.578967Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(100)[0m

  [2m2023-03-07T08:34:17.613101Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 100 })[0m

  [2m2023-03-07T08:34:18.219605Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/events/device_shadow/jsonarray with size = 183[0m

  [2m2023-03-07T08:34:18.219829Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(1)[0m

  [2m2023-03-07T08:34:18.255356Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 1 })[0m

  [2m2023-03-07T08:34:18.581485Z[0m [32m INFO[0m [1;32muplink::base::bridge[0m[32m: [32mAction response = ActionResponse { action_id: "5369", device_id: None, sequence: 0, timestamp: 1678178058580, state: "in_progress", progress: 10, errors: [], done_response: None }[0m

  [2m2023-03-07T08:34:18.581581Z[0m [34mDEBUG[0m [1;34muplink::base::bridge::stream[0m[34m: [34mSequence number anomaly! [0, 2[0m

  [2m2023-03-07T08:34:18.581695Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/action/status with size = 109[0m

  [2m2023-03-07T08:34:18.581923Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(2)[0m

  [2m2023-03-07T08:34:18.619100Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 2 })[0m

  [2m2023-03-07T08:34:19.129821Z[0m [34mDEBUG[0m [1;34muplink::base::bridge[0m[34m: [34mFlushing stream = gps[0m

  [2m2023-03-07T08:34:19.130011Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/events/gps/jsonarray with size = 5030[0m

  [2m2023-03-07T08:34:19.130210Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(3)[0m

  [2m2023-03-07T08:34:19.135009Z[0m [34mDEBUG[0m [1;34muplink::base::bridge[0m[34m: [34mFlushing stream = peripheral_state[0m

  [2m2023-03-07T08:34:19.135238Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/events/peripheral_state/jsonarray with size = 12702[0m

  [2m2023-03-07T08:34:19.135521Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(4)[0m

  [2m2023-03-07T08:34:19.165072Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 3 })[0m

  [2m2023-03-07T08:34:19.201146Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 4 })[0m

  [2m2023-03-07T08:34:19.220621Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/events/device_shadow/jsonarray with size = 185[0m

  [2m2023-03-07T08:34:19.220734Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(5)[0m

  [2m2023-03-07T08:34:19.255725Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 5 })[0m

  [2m2023-03-07T08:34:19.581433Z[0m [32m INFO[0m [1;32muplink::base::bridge[0m[32m: [32mAction response = ActionResponse { action_id: "5369", device_id: None, sequence: 0, timestamp: 1678178059581, state: "in_progress", progress: 20, errors: [], done_response: None }[0m

  [2m2023-03-07T08:34:19.581487Z[0m [34mDEBUG[0m [1;34muplink::base::bridge::stream[0m[34m: [34mSequence number anomaly! [0, 0[0m

  [2m2023-03-07T08:34:19.581551Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/action/status with size = 109[0m

  [2m2023-03-07T08:34:19.581684Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(6)[0m

  [2m2023-03-07T08:34:19.618883Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 6 })[0m

  [2m2023-03-07T08:34:20.222252Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/events/device_shadow/jsonarray with size = 185[0m

  [2m2023-03-07T08:34:20.222394Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(7)[0m

  [2m2023-03-07T08:34:20.257507Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 7 })[0m

  [2m2023-03-07T08:34:20.581159Z[0m [32m INFO[0m [1;32muplink::base::bridge[0m[32m: [32mAction response = ActionResponse { action_id: "5369", device_id: None, sequence: 0, timestamp: 1678178060580, state: "in_progress", progress: 30, errors: [], done_response: None }[0m

  [2m2023-03-07T08:34:20.581197Z[0m [34mDEBUG[0m [1;34muplink::base::bridge::stream[0m[34m: [34mSequence number anomaly! [0, 0[0m

  [2m2023-03-07T08:34:20.581243Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/action/status with size = 109[0m

  [2m2023-03-07T08:34:20.581382Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(8)[0m

  [2m2023-03-07T08:34:20.616937Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 8 })[0m

  [2m2023-03-07T08:34:21.223990Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/events/device_shadow/jsonarray with size = 184[0m

  [2m2023-03-07T08:34:21.224157Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(9)[0m

  [2m2023-03-07T08:34:21.260424Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 9 })[0m

  [2m2023-03-07T08:34:21.581693Z[0m [32m INFO[0m [1;32muplink::base::bridge[0m[32m: [32mAction response = ActionResponse { action_id: "5369", device_id: None, sequence: 0, timestamp: 1678178061580, state: "in_progress", progress: 40, errors: [], done_response: None }[0m

  [2m2023-03-07T08:34:21.581800Z[0m [34mDEBUG[0m [1;34muplink::base::bridge::stream[0m[34m: [34mSequence number anomaly! [0, 0[0m

  [2m2023-03-07T08:34:21.581924Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/action/status with size = 109[0m

  [2m2023-03-07T08:34:21.582343Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(10)[0m

  [2m2023-03-07T08:34:21.618741Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 10 })[0m

  [2m2023-03-07T08:34:22.224834Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/events/device_shadow/jsonarray with size = 185[0m

  [2m2023-03-07T08:34:22.225001Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(11)[0m

  [2m2023-03-07T08:34:22.260688Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 11 })[0m

  [2m2023-03-07T08:34:22.581623Z[0m [32m INFO[0m [1;32muplink::base::bridge[0m[32m: [32mAction response = ActionResponse { action_id: "5369", device_id: None, sequence: 0, timestamp: 1678178062580, state: "in_progress", progress: 50, errors: [], done_response: None }[0m

  [2m2023-03-07T08:34:22.581739Z[0m [34mDEBUG[0m [1;34muplink::base::bridge::stream[0m[34m: [34mSequence number anomaly! [0, 0[0m

  [2m2023-03-07T08:34:22.581923Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/action/status with size = 109[0m

  [2m2023-03-07T08:34:22.582184Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(12)[0m

  [2m2023-03-07T08:34:22.617269Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 12 })[0m

  [2m2023-03-07T08:34:23.226674Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/events/device_shadow/jsonarray with size = 182[0m

  [2m2023-03-07T08:34:23.226959Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(13)[0m

  [2m2023-03-07T08:34:23.262697Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 13 })[0m

  [2m2023-03-07T08:34:23.475362Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/events/imu/jsonarray with size = 26950[0m

  [2m2023-03-07T08:34:23.475832Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(14)[0m

  [2m2023-03-07T08:34:23.548750Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 14 })[0m

  [2m2023-03-07T08:34:23.580822Z[0m [32m INFO[0m [1;32muplink::base::bridge[0m[32m: [32mAction response = ActionResponse { action_id: "5369", device_id: None, sequence: 0, timestamp: 1678178063580, state: "in_progress", progress: 60, errors: [], done_response: None }[0m

  [2m2023-03-07T08:34:23.580891Z[0m [34mDEBUG[0m [1;34muplink::base::bridge::stream[0m[34m: [34mSequence number anomaly! [0, 0[0m

  [2m2023-03-07T08:34:23.580962Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/action/status with size = 109[0m

  [2m2023-03-07T08:34:23.581142Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(15)[0m

  [2m2023-03-07T08:34:23.615912Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 15 })[0m

  [2m2023-03-07T08:34:24.227827Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/events/device_shadow/jsonarray with size = 183[0m

  [2m2023-03-07T08:34:24.228026Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(16)[0m

  [2m2023-03-07T08:34:24.263770Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 16 })[0m

  [2m2023-03-07T08:34:24.580930Z[0m [32m INFO[0m [1;32muplink::base::bridge[0m[32m: [32mAction response = ActionResponse { action_id: "5369", device_id: None, sequence: 0, timestamp: 1678178064580, state: "in_progress", progress: 70, errors: [], done_response: None }[0m

  [2m2023-03-07T08:34:24.580991Z[0m [34mDEBUG[0m [1;34muplink::base::bridge::stream[0m[34m: [34mSequence number anomaly! [0, 0[0m

  [2m2023-03-07T08:34:24.581051Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/action/status with size = 109[0m

  [2m2023-03-07T08:34:24.581217Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(17)[0m

  [2m2023-03-07T08:34:24.615766Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 17 })[0m

  [2m2023-03-07T08:34:25.228422Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/events/device_shadow/jsonarray with size = 183[0m

  [2m2023-03-07T08:34:25.228542Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(18)[0m

  [2m2023-03-07T08:34:25.262629Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 18 })[0m

  [2m2023-03-07T08:34:25.581458Z[0m [32m INFO[0m [1;32muplink::base::bridge[0m[32m: [32mAction response = ActionResponse { action_id: "5369", device_id: None, sequence: 0, timestamp: 1678178065581, state: "in_progress", progress: 80, errors: [], done_response: None }[0m

  [2m2023-03-07T08:34:25.581539Z[0m [34mDEBUG[0m [1;34muplink::base::bridge::stream[0m[34m: [34mSequence number anomaly! [0, 0[0m

  [2m2023-03-07T08:34:25.581635Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/action/status with size = 109[0m

  [2m2023-03-07T08:34:25.581789Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(19)[0m

  [2m2023-03-07T08:34:25.617874Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 19 })[0m

  [2m2023-03-07T08:34:26.230193Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/events/device_shadow/jsonarray with size = 184[0m

  [2m2023-03-07T08:34:26.230419Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(20)[0m

  [2m2023-03-07T08:34:26.266280Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 20 })[0m

  [2m2023-03-07T08:34:26.581246Z[0m [32m INFO[0m [1;32muplink::base::bridge[0m[32m: [32mAction response = ActionResponse { action_id: "5369", device_id: None, sequence: 0, timestamp: 1678178066580, state: "in_progress", progress: 90, errors: [], done_response: None }[0m

  [2m2023-03-07T08:34:26.581420Z[0m [34mDEBUG[0m [1;34muplink::base::bridge::stream[0m[34m: [34mSequence number anomaly! [0, 0[0m

  [2m2023-03-07T08:34:26.581622Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/action/status with size = 109[0m

  [2m2023-03-07T08:34:26.581911Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(21)[0m

  [2m2023-03-07T08:34:26.619094Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 21 })[0m

  [2m2023-03-07T08:34:26.669769Z[0m [32m INFO[0m [1;32muplink::collector::utils::streams[0m[32m: [32m                 gps: points = 10    batches = 0     latency = 0[0m

  [2m2023-03-07T08:34:26.669891Z[0m [32m INFO[0m [1;32muplink::collector::utils::streams[0m[32m: [32m    peripheral_state: points = 10    batches = 0     latency = 0[0m

  [2m2023-03-07T08:34:26.669918Z[0m [32m INFO[0m [1;32muplink::collector::utils::streams[0m[32m: [32m               motor: points = 40    batches = 0     latency = 0[0m

  [2m2023-03-07T08:34:26.669940Z[0m [32m INFO[0m [1;32muplink::collector::utils::streams[0m[32m: [32m       device_shadow: points = 10    batches = 10    latency = 5053[0m

  [2m2023-03-07T08:34:26.669940Z[0m [32m INFO[0m [1;32muplink::base::serializer[0m[32m: [32m           normal: batches = 25  errors = 0 lost = 0 disk_files = 0   write_memory = 0 B read_memory = 0 B[0m

  [2m2023-03-07T08:34:26.669960Z[0m [32m INFO[0m [1;32muplink::collector::utils::streams[0m[32m: [32m                 imu: points = 99    batches = 1     latency = 6804[0m

  [2m2023-03-07T08:34:26.670085Z[0m [32m INFO[0m [1;32muplink::collector::utils::streams[0m[32m: [32m                 bms: points = 40    batches = 0     latency = 0[0m

  [2m2023-03-07T08:34:26.670228Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(22)[0m

  [2m2023-03-07T08:34:26.670307Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(23)[0m

  [2m2023-03-07T08:34:26.670327Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(24)[0m

  [2m2023-03-07T08:34:26.670344Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(25)[0m

  [2m2023-03-07T08:34:26.670362Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(26)[0m

  [2m2023-03-07T08:34:26.670378Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(27)[0m

  [2m2023-03-07T08:34:26.670406Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(28)[0m

  [2m2023-03-07T08:34:26.705425Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 22 })[0m

  [2m2023-03-07T08:34:26.705502Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 23 })[0m

  [2m2023-03-07T08:34:26.705513Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 24 })[0m

  [2m2023-03-07T08:34:26.705520Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 25 })[0m

  [2m2023-03-07T08:34:26.705527Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 26 })[0m

  [2m2023-03-07T08:34:26.705533Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 27 })[0m

  [2m2023-03-07T08:34:26.739322Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 28 })[0m

  [2m2023-03-07T08:34:27.232184Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/events/device_shadow/jsonarray with size = 184[0m

  [2m2023-03-07T08:34:27.232313Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(29)[0m

  [2m2023-03-07T08:34:27.268959Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 29 })[0m

  [2m2023-03-07T08:34:27.580898Z[0m [32m INFO[0m [1;32muplink::base::bridge[0m[32m: [32mAction response = ActionResponse { action_id: "5369", device_id: None, sequence: 0, timestamp: 1678178067580, state: "Completed", progress: 100, errors: [], done_response: None }[0m

  [2m2023-03-07T08:34:27.580965Z[0m [34mDEBUG[0m [1;34muplink::base::bridge::stream[0m[34m: [34mSequence number anomaly! [0, 0[0m

  [2m2023-03-07T08:34:27.581051Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/action/status with size = 108[0m

  [2m2023-03-07T08:34:27.581182Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(30)[0m

  [2m2023-03-07T08:34:27.615758Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 30 })[0m
```