### PR TITLE
feat: handle all demo actions with simulator

### DIFF
--- a/simulator.sh
+++ b/simulator.sh
@@ -25,7 +25,7 @@ start_devices() {
 }
 
 create_uplink_config() {
-    printf "processes = [] \naction_redirections = { send_file = \"load_file\", update_firmware = \"install_firmware\" } \n\n[tcpapps.1] \nport = 500$1 \nactions= [{ name = \"load_file\" }, { name = \"install_firmware\" }] \n\n[downloader] \nactions= [{ name = \"send_file\" }, { name = \"update_firmware\" }] \npath = \"/var/tmp/ota/$1\"" > devices/device_$1.toml
+    printf "processes = [] \naction_redirections = { send_file = \"load_file\", update_firmware = \"install_firmware\" } \n\n[tcpapps.1] \nport = 500$1 \nactions= [{ name = \"load_file\" }, { name = \"install_firmware\" }, { name = \"update_config\" }, { name = \"unlock\" }, { name = \"lock\" }] \n\n[downloader] \nactions= [{ name = \"send_file\" }, { name = \"update_firmware\" }] \npath = \"/var/tmp/ota/$1\"" > devices/device_$1.toml
 }
 
 download_auth_config() {


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->
Add missing demo actions for use with simulator

### Why?
<!--Detailed description of why the changes had to be made-->
Handle all actions from demo, i.e. "send_file", "update_firmware", "update_config", "unlock", "lock"

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
Used against stage simulator and triggered actions for "update_config", "unlock", "lock" it was observed that actions were run successfully on uplink and actions were updated on platform as such:
```
  [2m2023-03-07T15:20:17.919897Z[0m [32m INFO[0m [1;32muplink::base::mqtt[0m[32m: [32mAction = Action { device_id: None, action_id: "127", kind: "process", name: "update_config", payload: "{\"name\":\"greeting\",\"version\":\"v1.1\",\"message\":\"Hello, World!\"}" }[0m

  [2m2023-03-07T15:20:17.920064Z[0m [32m INFO[0m [1;32muplink::base::bridge[0m[32m: [32mReceived action: Action { device_id: None, action_id: "127", kind: "process", name: "update_config", payload: "{\"name\":\"greeting\",\"version\":\"v1.1\",\"message\":\"Hello, World!\"}" }[0m

  [2m2023-03-07T15:20:17.920186Z[0m [32m INFO[0m [1;32muplink::base::bridge[0m[32m: [32mAction response = ActionResponse { action_id: "127", device_id: None, sequence: 0, timestamp: 1678202417920, state: "Received", progress: 0, errors: [], done_response: None }[0m

  [2m2023-03-07T15:20:17.920253Z[0m [34mDEBUG[0m [1;34muplink::base::bridge::stream[0m[34m: [34mSequence number anomaly! [0, 0[0m

  [2m2023-03-07T15:20:17.920377Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/action/status with size = 104[0m

  [2m2023-03-07T15:20:17.920664Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(54)[0m

  [2m2023-03-07T15:20:18.026680Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 54 })[0m

  [2m2023-03-07T15:20:18.568198Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/events/device_shadow/jsonarray with size = 184[0m

  [2m2023-03-07T15:20:18.568771Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(55)[0m

  [2m2023-03-07T15:20:18.599348Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 55 })[0m

  [2m2023-03-07T15:20:18.922466Z[0m [32m INFO[0m [1;32muplink::base::bridge[0m[32m: [32mAction response = ActionResponse { action_id: "127", device_id: None, sequence: 0, timestamp: 1678202418922, state: "in_progress", progress: 10, errors: [], done_response: None }[0m

  [2m2023-03-07T15:20:18.922529Z[0m [34mDEBUG[0m [1;34muplink::base::bridge::stream[0m[34m: [34mSequence number anomaly! [0, 0[0m

  [2m2023-03-07T15:20:18.922712Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/action/status with size = 108[0m

  [2m2023-03-07T15:20:18.922955Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(56)[0m

  [2m2023-03-07T15:20:18.954402Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 56 })[0m

  [2m2023-03-07T15:20:19.570577Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/events/device_shadow/jsonarray with size = 183[0m

  [2m2023-03-07T15:20:19.570929Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(57)[0m

  [2m2023-03-07T15:20:19.602265Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 57 })[0m

  [2m2023-03-07T15:20:19.923990Z[0m [32m INFO[0m [1;32muplink::base::bridge[0m[32m: [32mAction response = ActionResponse { action_id: "127", device_id: None, sequence: 0, timestamp: 1678202419922, state: "in_progress", progress: 20, errors: [], done_response: None }[0m

  [2m2023-03-07T15:20:19.924117Z[0m [34mDEBUG[0m [1;34muplink::base::bridge::stream[0m[34m: [34mSequence number anomaly! [0, 0[0m

  [2m2023-03-07T15:20:19.924437Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/action/status with size = 108[0m

  [2m2023-03-07T15:20:19.925037Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(58)[0m

  [2m2023-03-07T15:20:19.925518Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/events/imu/jsonarray with size = 27056[0m

  [2m2023-03-07T15:20:19.926065Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(59)[0m

  [2m2023-03-07T15:20:19.957987Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 58 })[0m

  [2m2023-03-07T15:20:19.990646Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 59 })[0m

  [2m2023-03-07T15:20:20.573728Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/events/device_shadow/jsonarray with size = 183[0m

  [2m2023-03-07T15:20:20.574091Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(60)[0m

  [2m2023-03-07T15:20:20.607018Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 60 })[0m

  [2m2023-03-07T15:20:20.922960Z[0m [32m INFO[0m [1;32muplink::base::bridge[0m[32m: [32mAction response = ActionResponse { action_id: "127", device_id: None, sequence: 0, timestamp: 1678202420922, state: "in_progress", progress: 30, errors: [], done_response: None }[0m

  [2m2023-03-07T15:20:20.923055Z[0m [34mDEBUG[0m [1;34muplink::base::bridge::stream[0m[34m: [34mSequence number anomaly! [0, 0[0m

  [2m2023-03-07T15:20:20.923184Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/action/status with size = 108[0m

  [2m2023-03-07T15:20:20.923368Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(61)[0m

  [2m2023-03-07T15:20:20.956254Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 61 })[0m

  [2m2023-03-07T15:20:21.575766Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/events/device_shadow/jsonarray with size = 182[0m

  [2m2023-03-07T15:20:21.576037Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(62)[0m

  [2m2023-03-07T15:20:21.608064Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 62 })[0m

  [2m2023-03-07T15:20:21.923177Z[0m [32m INFO[0m [1;32muplink::base::bridge[0m[32m: [32mAction response = ActionResponse { action_id: "127", device_id: None, sequence: 0, timestamp: 1678202421922, state: "in_progress", progress: 40, errors: [], done_response: None }[0m

  [2m2023-03-07T15:20:21.923228Z[0m [34mDEBUG[0m [1;34muplink::base::bridge::stream[0m[34m: [34mSequence number anomaly! [0, 0[0m

  [2m2023-03-07T15:20:21.923302Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/action/status with size = 108[0m

  [2m2023-03-07T15:20:21.923481Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(63)[0m

  [2m2023-03-07T15:20:21.955497Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 63 })[0m

  [2m2023-03-07T15:20:22.577905Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/events/device_shadow/jsonarray with size = 183[0m

  [2m2023-03-07T15:20:22.578102Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(64)[0m

  [2m2023-03-07T15:20:22.611966Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 64 })[0m

  [2m2023-03-07T15:20:22.923422Z[0m [32m INFO[0m [1;32muplink::base::bridge[0m[32m: [32mAction response = ActionResponse { action_id: "127", device_id: None, sequence: 0, timestamp: 1678202422922, state: "in_progress", progress: 50, errors: [], done_response: None }[0m

  [2m2023-03-07T15:20:22.923513Z[0m [34mDEBUG[0m [1;34muplink::base::bridge::stream[0m[34m: [34mSequence number anomaly! [0, 0[0m

  [2m2023-03-07T15:20:22.923783Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/action/status with size = 108[0m

  [2m2023-03-07T15:20:22.924114Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(65)[0m

  [2m2023-03-07T15:20:22.957675Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 65 })[0m

  [2m2023-03-07T15:20:23.580004Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/events/device_shadow/jsonarray with size = 182[0m

  [2m2023-03-07T15:20:23.580413Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(66)[0m

  [2m2023-03-07T15:20:23.613748Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 66 })[0m

  [2m2023-03-07T15:20:23.923612Z[0m [32m INFO[0m [1;32muplink::base::bridge[0m[32m: [32mAction response = ActionResponse { action_id: "127", device_id: None, sequence: 0, timestamp: 1678202423922, state: "in_progress", progress: 60, errors: [], done_response: None }[0m

  [2m2023-03-07T15:20:23.923764Z[0m [34mDEBUG[0m [1;34muplink::base::bridge::stream[0m[34m: [34mSequence number anomaly! [0, 0[0m

  [2m2023-03-07T15:20:23.924041Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/action/status with size = 108[0m

  [2m2023-03-07T15:20:23.924558Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(67)[0m

  [2m2023-03-07T15:20:23.957109Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 67 })[0m

  [2m2023-03-07T15:20:24.581991Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/events/device_shadow/jsonarray with size = 183[0m

  [2m2023-03-07T15:20:24.582323Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(68)[0m

  [2m2023-03-07T15:20:24.615031Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 68 })[0m

  [2m2023-03-07T15:20:24.922776Z[0m [32m INFO[0m [1;32muplink::base::bridge[0m[32m: [32mAction response = ActionResponse { action_id: "127", device_id: None, sequence: 0, timestamp: 1678202424922, state: "in_progress", progress: 70, errors: [], done_response: None }[0m

  [2m2023-03-07T15:20:24.922845Z[0m [34mDEBUG[0m [1;34muplink::base::bridge::stream[0m[34m: [34mSequence number anomaly! [0, 0[0m

  [2m2023-03-07T15:20:24.922977Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/action/status with size = 108[0m

  [2m2023-03-07T15:20:24.923231Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(69)[0m

  [2m2023-03-07T15:20:24.956705Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 69 })[0m

  [2m2023-03-07T15:20:25.258927Z[0m [32m INFO[0m [1;32muplink::collector::utils::streams[0m[32m: [32m       device_shadow: points = 10    batches = 10    latency = 4812[0m

  [2m2023-03-07T15:20:25.258982Z[0m [32m INFO[0m [1;32muplink::collector::utils::streams[0m[32m: [32m                 imu: points = 98    batches = 1     latency = 4665[0m

  [2m2023-03-07T15:20:25.258989Z[0m [32m INFO[0m [1;32muplink::collector::utils::streams[0m[32m: [32m               motor: points = 40    batches = 0     latency = 0[0m

  [2m2023-03-07T15:20:25.258995Z[0m [32m INFO[0m [1;32muplink::collector::utils::streams[0m[32m: [32m                 bms: points = 40    batches = 0     latency = 0[0m

  [2m2023-03-07T15:20:25.259000Z[0m [32m INFO[0m [1;32muplink::collector::utils::streams[0m[32m: [32m                 gps: points = 10    batches = 0     latency = 0[0m

  [2m2023-03-07T15:20:25.259006Z[0m [32m INFO[0m [1;32muplink::collector::utils::streams[0m[32m: [32m    peripheral_state: points = 10    batches = 0     latency = 0[0m

  [2m2023-03-07T15:20:25.259315Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(70)[0m

  [2m2023-03-07T15:20:25.259363Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(71)[0m

  [2m2023-03-07T15:20:25.259369Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(72)[0m

  [2m2023-03-07T15:20:25.259372Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(73)[0m

  [2m2023-03-07T15:20:25.259375Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(74)[0m

  [2m2023-03-07T15:20:25.259378Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(75)[0m

  [2m2023-03-07T15:20:25.259388Z[0m [32m INFO[0m [1;32muplink::base::serializer[0m[32m: [32m           normal: batches = 19  errors = 0 lost = 0 disk_files = 0   write_memory = 0 B read_memory = 0 B[0m

  [2m2023-03-07T15:20:25.259634Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(76)[0m

  [2m2023-03-07T15:20:25.291942Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 70 })[0m

  [2m2023-03-07T15:20:25.291996Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 71 })[0m

  [2m2023-03-07T15:20:25.292003Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 72 })[0m

  [2m2023-03-07T15:20:25.292008Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 73 })[0m

  [2m2023-03-07T15:20:25.292012Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 74 })[0m

  [2m2023-03-07T15:20:25.292016Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 75 })[0m

  [2m2023-03-07T15:20:25.322161Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 76 })[0m

  [2m2023-03-07T15:20:25.584234Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/events/device_shadow/jsonarray with size = 183[0m

  [2m2023-03-07T15:20:25.584515Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(77)[0m

  [2m2023-03-07T15:20:25.616807Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 77 })[0m

  [2m2023-03-07T15:20:25.922693Z[0m [32m INFO[0m [1;32muplink::base::bridge[0m[32m: [32mAction response = ActionResponse { action_id: "127", device_id: None, sequence: 0, timestamp: 1678202425922, state: "in_progress", progress: 80, errors: [], done_response: None }[0m

  [2m2023-03-07T15:20:25.922780Z[0m [34mDEBUG[0m [1;34muplink::base::bridge::stream[0m[34m: [34mSequence number anomaly! [0, 0[0m

  [2m2023-03-07T15:20:25.922988Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/action/status with size = 108[0m

  [2m2023-03-07T15:20:25.923221Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(78)[0m

  [2m2023-03-07T15:20:25.956102Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 78 })[0m

  [2m2023-03-07T15:20:26.585575Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/events/device_shadow/jsonarray with size = 185[0m

  [2m2023-03-07T15:20:26.585724Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(79)[0m

  [2m2023-03-07T15:20:26.617768Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 79 })[0m

  [2m2023-03-07T15:20:26.923149Z[0m [32m INFO[0m [1;32muplink::base::bridge[0m[32m: [32mAction response = ActionResponse { action_id: "127", device_id: None, sequence: 0, timestamp: 1678202426922, state: "in_progress", progress: 90, errors: [], done_response: None }[0m

  [2m2023-03-07T15:20:26.923201Z[0m [34mDEBUG[0m [1;34muplink::base::bridge::stream[0m[34m: [34mSequence number anomaly! [0, 0[0m

  [2m2023-03-07T15:20:26.923356Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/action/status with size = 108[0m

  [2m2023-03-07T15:20:26.923491Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(80)[0m

  [2m2023-03-07T15:20:26.955274Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 80 })[0m

  [2m2023-03-07T15:20:27.588459Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/events/device_shadow/jsonarray with size = 184[0m

  [2m2023-03-07T15:20:27.588694Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(81)[0m

  [2m2023-03-07T15:20:27.619766Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 81 })[0m

  [2m2023-03-07T15:20:27.922680Z[0m [32m INFO[0m [1;32muplink::base::bridge[0m[32m: [32mAction response = ActionResponse { action_id: "127", device_id: None, sequence: 0, timestamp: 1678202427922, state: "Completed", progress: 100, errors: [], done_response: None }[0m

  [2m2023-03-07T15:20:27.922743Z[0m [34mDEBUG[0m [1;34muplink::base::bridge::stream[0m[34m: [34mSequence number anomaly! [0, 0[0m

  [2m2023-03-07T15:20:27.922833Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/1/action/status with size = 107[0m

  [2m2023-03-07T15:20:27.923058Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(82)[0m

  [2m2023-03-07T15:20:27.954863Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 82 })[0m
```