### PR TITLE
feat: complete actions with no redirection

### DIFF
--- a/uplink/src/base/bridge/mod.rs
+++ b/uplink/src/base/bridge/mod.rs
@@ -270,7 +270,13 @@ impl Bridge {
                 Some(n) => n,
                 None => {
                     // NOTE: send success reponse for actions that don't have redirections configured
-                    let response = ActionResponse::success(&inflight_action.id);
+                    let warning = format!(
+                        "Action redirection for {} not configured",
+                        inflight_action.action.name
+                    );
+                    warn!("{warning}");
+                    let mut response = ActionResponse::success(&inflight_action.id);
+                    response.errors.push(warning);
                     if let Err(e) = self.action_status.fill(response).await {
                         error!("Failed to send status. Error = {:?}", e);
                     }

--- a/uplink/src/base/bridge/mod.rs
+++ b/uplink/src/base/bridge/mod.rs
@@ -269,6 +269,12 @@ impl Bridge {
             let fwd_name = match self.action_redirections.get(&inflight_action.action.name) {
                 Some(n) => n,
                 None => {
+                    // NOTE: send success reponse for actions that don't have redirections configured
+                    let response = ActionResponse::success(&inflight_action.id);
+                    if let Err(e) = self.action_status.fill(response).await {
+                        error!("Failed to send status. Error = {:?}", e);
+                    }
+
                     self.clear_current_action();
                     return;
                 }

--- a/uplink/src/base/bridge/mod.rs
+++ b/uplink/src/base/bridge/mod.rs
@@ -270,13 +270,8 @@ impl Bridge {
                 Some(n) => n,
                 None => {
                     // NOTE: send success reponse for actions that don't have redirections configured
-                    let warning = format!(
-                        "Action redirection for {} not configured",
-                        inflight_action.action.name
-                    );
-                    warn!("{warning}");
-                    let mut response = ActionResponse::success(&inflight_action.id);
-                    response.errors.push(warning);
+                    warn!("Action redirection for {} not configured", inflight_action.action.name);
+                    let response = ActionResponse::success(&inflight_action.id);
                     if let Err(e) = self.action_status.fill(response).await {
                         error!("Failed to send status. Error = {:?}", e);
                     }


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->

### Why?
<!--Detailed description of why the changes had to be made-->
Action handlers that don't send complete response but end with progress at 100 could be part of multi-stage actions, but if they have no redirections configured, uplink should send the completion response.

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->

![Screenshot from 2023-03-09 11-38-15](https://user-images.githubusercontent.com/18750864/223935285-cde3dca5-01b1-4a6e-8a92-a681f4e1bf7a.png)