### PR TITLE
feat: implement `OTAInstaller`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "adler32"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -653,6 +659,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "flate2"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "flume"
 version = "0.10.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1264,6 +1280,15 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
 
 [[package]]
 name = "mio"
@@ -2470,6 +2495,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempdir"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3020,6 +3056,7 @@ dependencies = [
  "bytes 1.3.0",
  "config",
  "disk",
+ "flate2",
  "flume",
  "futures-util",
  "glob",
@@ -3035,6 +3072,7 @@ dependencies = [
  "serde_json",
  "structopt",
  "sysinfo",
+ "tar",
  "thiserror",
  "time",
  "tokio 1.22.0",
@@ -3420,6 +3458,15 @@ checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 dependencies = [
  "winapi 0.2.8",
  "winapi-build",
+]
+
+[[package]]
+name = "xattr"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/uplink/Cargo.toml
+++ b/uplink/Cargo.toml
@@ -34,6 +34,8 @@ lazy_static = "1.4.0"
 glob = "0.3"
 pretty-bytes = "0.2.2"
 regex = "1.7.1"
+flate2 = "1"
+tar = "0.4"
 
 [build-dependencies]
 vergen = { version = "7", features = ["git", "build", "time"] }

--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -84,7 +84,7 @@ pub struct InstallerConfig {
     pub path: String,
     #[serde(default)]
     pub actions: Vec<ActionRoute>,
-    pub uplink_addr: String,
+    pub uplink_port: u16,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]

--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -79,6 +79,13 @@ pub struct DownloaderConfig {
     pub actions: Vec<ActionRoute>,
 }
 
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct InstallerConfig {
+    pub path: String,
+    #[serde(default)]
+    pub actions: Vec<ActionRoute>,
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct StreamMetricsConfig {
     pub enabled: bool,
@@ -157,6 +164,7 @@ pub struct Config {
     pub downloader: DownloaderConfig,
     pub system_stats: Stats,
     pub simulator: Option<SimulatorConfig>,
+    pub ota_installer: InstallerConfig,
     #[serde(default)]
     pub action_redirections: HashMap<String, String>,
     #[serde(default)]

--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -84,6 +84,7 @@ pub struct InstallerConfig {
     pub path: String,
     #[serde(default)]
     pub actions: Vec<ActionRoute>,
+    pub uplink_addr: String,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]

--- a/uplink/src/collector/downloader.rs
+++ b/uplink/src/collector/downloader.rs
@@ -273,7 +273,7 @@ pub struct DownloadFile {
     #[serde(alias = "version")]
     file_name: String,
     /// Path to location in fs where file will be stored
-    download_path: Option<String>,
+    pub download_path: Option<String>,
 }
 
 #[cfg(test)]

--- a/uplink/src/collector/installer.rs
+++ b/uplink/src/collector/installer.rs
@@ -75,7 +75,7 @@ impl OTAInstaller {
     async fn installer(&self, action: &Action) -> Result<(), Error> {
         let script_path = PathBuf::from(self.config.path.clone()).join("update.sh");
         let mut cmd = Command::new(script_path);
-        cmd.kill_on_drop(true).stdout(Stdio::piped());
+        cmd.arg(&action.action_id).kill_on_drop(true).stdout(Stdio::piped());
         let child = cmd.spawn()?;
 
         self.spawn_and_capture_stdout(child, action).await?;

--- a/uplink/src/collector/installer.rs
+++ b/uplink/src/collector/installer.rs
@@ -72,8 +72,8 @@ impl OTAInstaller {
     // Run `update.sh` from extracted tarball
     async fn installer(&self, action: &Action) -> Result<(), Error> {
         let script_path = PathBuf::from(self.config.path.clone()).join("update.sh");
-        let mut cmd = Command::new(script_path);
-        cmd.arg(&action.action_id).kill_on_drop(true).stdout(Stdio::piped());
+        let mut cmd = Command::new("/bin/sh");
+        cmd.arg(script_path).arg(&action.action_id).kill_on_drop(true).stdout(Stdio::piped());
         let child = cmd.spawn()?;
 
         self.spawn_and_capture_stdout(child, action).await?;

--- a/uplink/src/collector/installer.rs
+++ b/uplink/src/collector/installer.rs
@@ -70,8 +70,8 @@ impl OTAInstaller {
     // Run `update.sh` from extracted tarball
     async fn installer(&self, action: &Action) -> Result<(), Error> {
         let script_path = PathBuf::from(self.config.path.clone()).join("update.sh");
-        let mut cmd = Command::new("/bin/sh");
-        cmd.arg(script_path).arg(&self.config.uplink_addr).arg(&action.action_id);
+        let mut cmd = Command::new("/bin/bash");
+        cmd.arg(script_path).arg(self.config.uplink_port.to_string()).arg(&action.action_id);
         cmd.spawn()?;
 
         Ok(())

--- a/uplink/src/collector/installer.rs
+++ b/uplink/src/collector/installer.rs
@@ -1,0 +1,114 @@
+use std::{fs::File, path::PathBuf, process::Stdio, sync::Arc, time::Duration};
+
+use flate2::read::GzDecoder;
+use log::{debug, error, info};
+use tar::Archive;
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::{Child, Command};
+use tokio::{pin, select, time};
+
+use super::downloader::DownloadFile;
+use crate::base::{bridge::BridgeTx, InstallerConfig};
+use crate::{Action, ActionResponse, Config};
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("Serde error: {0}")]
+    Serde(#[from] serde_json::Error),
+    #[error("File io Error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("Download path missing from received action")]
+    MissingPath,
+    #[error("No stdout in spawned action")]
+    NoStdout,
+}
+
+pub struct OTAInstaller {
+    config: InstallerConfig,
+    bridge_tx: BridgeTx,
+}
+
+impl OTAInstaller {
+    pub fn new(config: Arc<Config>, bridge_tx: BridgeTx) -> Self {
+        let config = config.ota_installer.clone();
+        Self { config, bridge_tx }
+    }
+
+    #[tokio::main]
+    pub async fn start(&self) {
+        let actions_rx = match self.bridge_tx.register_action_routes(&self.config.actions).await {
+            Some(r) => r,
+            _ => return,
+        };
+
+        while let Ok(action) = actions_rx.recv_async().await {
+            if let Err(e) = self.extractor(&action) {
+                error!("Error extracting zip: {e}");
+                self.forward_action_error(action, e).await;
+                continue;
+            }
+
+            if let Err(e) = self.installer(&action).await {
+                error!("Error installing: {e}");
+                self.forward_action_error(action, e).await;
+            }
+        }
+    }
+
+    async fn forward_action_error(&self, action: Action, error: Error) {
+        let status = ActionResponse::failure(&action.action_id, error.to_string());
+        self.bridge_tx.send_action_response(status).await
+    }
+
+    fn extractor(&self, action: &Action) -> Result<(), Error> {
+        let info: DownloadFile = serde_json::from_str(&action.payload)?;
+        let path = info.download_path.ok_or(Error::MissingPath)?;
+        let tar_gz = File::open(path)?;
+        let tar = GzDecoder::new(tar_gz);
+        let mut archive = Archive::new(tar);
+        archive.unpack(&self.config.path)?;
+
+        Ok(())
+    }
+
+    // Run `update.sh` from extracted tarball
+    async fn installer(&self, action: &Action) -> Result<(), Error> {
+        let script_path = PathBuf::from(self.config.path.clone()).join("update.sh");
+        let mut cmd = Command::new(script_path);
+        cmd.kill_on_drop(true).stdout(Stdio::piped());
+        let child = cmd.spawn()?;
+
+        self.spawn_and_capture_stdout(child, action).await?;
+
+        Ok(())
+    }
+
+    /// Capture stdout from running update script and push to cloud
+    pub async fn spawn_and_capture_stdout(
+        &self,
+        mut child: Child,
+        action: &Action,
+    ) -> Result<(), Error> {
+        let stdout = child.stdout.take().ok_or(Error::NoStdout)?;
+        let mut stdout = BufReader::new(stdout).lines();
+
+        let timeout = time::sleep(Duration::from_secs(10));
+        pin!(timeout);
+
+        loop {
+            select! {
+                 Ok(Some(line)) = stdout.next_line() => {
+                    let status: ActionResponse = match serde_json::from_str(&line) {
+                        Ok(status) => status,
+                        Err(e) => ActionResponse::failure(&action.action_id, e.to_string()),
+                    };
+
+                    debug!("Action status: {:?}", status);
+                    self.bridge_tx.send_action_response(status).await;
+                 }
+                 status = child.wait() => info!("Action done!! Status = {:?}", status),
+                 _ = &mut timeout => return Ok(())
+            }
+        }
+    }
+}

--- a/uplink/src/collector/installer.rs
+++ b/uplink/src/collector/installer.rs
@@ -70,8 +70,11 @@ impl OTAInstaller {
     // Run `update.sh` from extracted tarball
     async fn installer(&self, action: &Action) -> Result<(), Error> {
         let script_path = PathBuf::from(self.config.path.clone()).join("update.sh");
-        let mut cmd = Command::new("/bin/bash");
-        cmd.arg(script_path).arg(self.config.uplink_port.to_string()).arg(&action.action_id);
+        let mut cmd = Command::new("sh");
+        cmd.arg("-C")
+            .arg(script_path)
+            .arg(&action.action_id)
+            .arg(self.config.uplink_port.to_string());
         cmd.spawn()?;
 
         Ok(())

--- a/uplink/src/collector/installer.rs
+++ b/uplink/src/collector/installer.rs
@@ -95,7 +95,7 @@ impl OTAInstaller {
 
         loop {
             select! {
-                 Ok(Some(line)) = stdout.next_line() => {
+                Ok(Some(line)) = stdout.next_line() => {
                     let status: ActionResponse = match serde_json::from_str(&line) {
                         Ok(status) => status,
                         Err(e) => ActionResponse::failure(&action.action_id, e.to_string()),
@@ -103,9 +103,12 @@ impl OTAInstaller {
 
                     debug!("Action status: {:?}", status);
                     self.bridge_tx.send_action_response(status).await;
-                 }
-                 status = child.wait() => info!("Action done!! Status = {:?}", status),
-                 _ = &mut timeout => return Ok(())
+                }
+                status = child.wait() => {
+                    info!("Action done!! Status = {:?}", status);
+                    return Ok(())
+                },
+                _ = &mut timeout => return Ok(())
             }
         }
     }

--- a/uplink/src/collector/mod.rs
+++ b/uplink/src/collector/mod.rs
@@ -1,4 +1,5 @@
 pub mod downloader;
+pub mod installer;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub mod logging;
 pub mod process;

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -7,6 +7,7 @@ use anyhow::Error;
 use base::bridge::stream::Stream;
 use base::monitor::Monitor;
 use collector::downloader::FileDownloader;
+use collector::installer::OTAInstaller;
 use collector::process::ProcessHandler;
 use collector::systemstats::StatCollector;
 use collector::tunshell::TunshellSession;
@@ -321,6 +322,9 @@ impl Uplink {
 
         let file_downloader = FileDownloader::new(config.clone(), bridge_tx.clone())?;
         thread::spawn(move || file_downloader.start());
+
+        let ota_installer = OTAInstaller::new(config.clone(), bridge_tx.clone());
+        thread::spawn(move || ota_installer.start());
 
         #[cfg(any(target_os="linux", target_os="android"))]
         {

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -95,6 +95,9 @@ pub mod config {
     enabled = true
     process_names = ["uplink"]
     update_period = 30
+
+    [tcpapps.1]
+    port = 5555
 "#;
 
     /// Reads config file to generate config struct and replaces places holders

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -104,7 +104,7 @@ pub mod config {
     [ota_installer]
     path = "/var/tmp/ota"
     actions = [{ name = "install_firmware", timeout = 60 }]
-    uplink_addr = "localhost:5555"
+    uplink_port = 5555
 "#;
 
     /// Reads config file to generate config struct and replaces places holders

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -18,8 +18,8 @@ pub mod base;
 pub mod collector;
 
 pub mod config {
-    use crate::base::{StreamConfig, DEFAULT_TIMEOUT};
     pub use crate::base::{Config, Persistence, Stats};
+    use crate::base::{StreamConfig, DEFAULT_TIMEOUT};
     use config::{Environment, File, FileFormat};
     use std::fs;
     use structopt::StructOpt;
@@ -335,9 +335,13 @@ impl Uplink {
         let ota_installer = OTAInstaller::new(config.clone(), bridge_tx.clone());
         thread::spawn(move || ota_installer.start());
 
-        #[cfg(any(target_os="linux", target_os="android"))]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         {
-            let logger = collector::logging::LoggerInstance::new(config.clone(), self.data_tx.clone(), bridge_tx.clone());
+            let logger = collector::logging::LoggerInstance::new(
+                config.clone(),
+                self.data_tx.clone(),
+                bridge_tx.clone(),
+            );
             thread::spawn(move || logger.start());
         }
 

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -104,6 +104,7 @@ pub mod config {
     [ota_installer]
     path = "/var/tmp/ota"
     actions = [{ name = "install_firmware", timeout = 60 }]
+    uplink_addr = "localhost:5555"
 "#;
 
     /// Reads config file to generate config struct and replaces places holders

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -54,6 +54,8 @@ pub mod config {
     }
 
     const DEFAULT_CONFIG: &str = r#"
+    action_redirections = { "update_firmware" = "install_firmware" }
+    
     [mqtt]
     max_packet_size = 256000
     max_inflight = 100
@@ -98,6 +100,10 @@ pub mod config {
 
     [tcpapps.1]
     port = 5555
+
+    [ota_installer]
+    path = "/var/tmp/ota"
+    actions = [{ name = "install_firmware", timeout = 60 }]
 "#;
 
     /// Reads config file to generate config struct and replaces places holders

--- a/uplink/src/main.rs
+++ b/uplink/src/main.rs
@@ -131,7 +131,14 @@ fn banner(commandline: &CommandLine, config: &Arc<Config>) {
         println!("    persistence_max_segment_size: {}", persistence.max_file_size);
         println!("    persistence_max_segment_count: {}", persistence.max_file_count);
     }
-    println!("    download_path: {}", config.downloader.path);
+    println!(
+        "    downloader:\n\tpath: {}\n\tactions: {:?}",
+        config.downloader.path, config.downloader.actions
+    );
+    println!(
+        "    installer:\n\tpath: {}\n\tactions: {:?}",
+        config.ota_installer.path, config.ota_installer.actions
+    );
     if config.system_stats.enabled {
         println!("    processes: {:?}", config.system_stats.process_names);
     }


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->
Adds an built-in application installer that runs and disowns a shell script which connects back to uplink over tcp

### Why?
To enable application updates without customer having to write their own handler

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
tar the following `update.sh`:
```sh
#!/bin/bash

# COPROC[1] is the stdin for netcat
# COPROC[0] is the stdout of netcat
# By echoing to the stdin of nc, we write to the port 5555
ACTION_ID=$1
PORT=$2

echo "Received action{$ACTION_ID}, updating status with uplink on localhost:$PORT"

coproc nc localhost $PORT

# Send success to uplink
echo "{ \"stream\": \"action_status\", \"sequence\": 0, \"timestamp\": $(date +%s%3N), \"action_id\": \"$ACTION_ID\", \"state\": \"Installing\", \"progress\": 0, \"errors\": [] }" >&"${COPROC[1]}"

sleep 5
# Send success to uplink
echo "{ \"stream\": \"action_status\", \"sequence\": 0, \"timestamp\": $(date +%s%3N), \"action_id\": \"$ACTION_ID\", \"state\": \"Completed\", \"progress\": 100, \"errors\": [] }" >&"${COPROC[1]}"
```
```sh
tar -cf installer.tar.gz update.sh
```
Upload as firmware version to platform, create an action and use the created version against device.
```
  
  2023-03-18T04:46:46.498187Z  INFO uplink::base::mqtt: Subscribe -> "/tenants/demo/devices/21/actions"

  2023-03-18T04:46:46.498259Z DEBUG uplink::base::mqtt: Outgoing = Subscribe(1)

  2023-03-18T04:46:46.536639Z DEBUG uplink::base::mqtt: Incoming = SubAck(SubAck { pkid: 1, return_codes: [Success(AtLeastOnce)] })

  2023-03-18T04:46:52.186630Z DEBUG uplink::base::mqtt: Outgoing = PubAck(1)

  2023-03-18T04:46:52.186768Z  INFO uplink::base::mqtt: Action = Action { device_id: None, action_id: "191", kind: "process", name: "update_firmware", payload: "{\"content-length\":10240,\"status\":false,\"url\":\"https://firmware.stage.bytebeam.io/api/v1/firmwares/7.8.9/artifact\",\"version\":\"7.8.9\"}" }

  2023-03-18T04:46:52.187037Z  INFO uplink::base::bridge: Received action: Action { device_id: None, action_id: "191", kind: "process", name: "update_firmware", payload: "{\"content-length\":10240,\"status\":false,\"url\":\"https://firmware.stage.bytebeam.io/api/v1/firmwares/7.8.9/artifact\",\"version\":\"7.8.9\"}" }

  2023-03-18T04:46:52.187150Z  INFO uplink::base::bridge: Action response = ActionResponse { action_id: "191", device_id: None, sequence: 0, timestamp: 1679114812187, state: "Received", progress: 0, errors: [], done_response: None }

  2023-03-18T04:46:52.187387Z DEBUG uplink::base::bridge::stream: Sequence number anomaly! [0, 0

  2023-03-18T04:46:52.187423Z TRACE uplink::base::bridge::stream: Flushing stream name: action_status, topic: /tenants/demo/devices/21/action/status

  2023-03-18T04:46:52.187459Z  INFO uplink::base::bridge: Action response = ActionResponse { action_id: "191", device_id: None, sequence: 1, timestamp: 1679114812187, state: "Downloading", progress: 0, errors: [], done_response: None }

  2023-03-18T04:46:52.187480Z TRACE uplink::base::bridge::stream: Flushing stream name: action_status, topic: /tenants/demo/devices/21/action/status

  2023-03-18T04:46:52.187506Z TRACE uplink::base::serializer: Data received on stream: action_status; message count = 1; batching latency = 0

  2023-03-18T04:46:52.187608Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/21/action/status with size = 104

  2023-03-18T04:46:52.187651Z TRACE uplink::base::serializer: Data received on stream: action_status; message count = 1; batching latency = 0

  2023-03-18T04:46:52.187672Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/21/action/status with size = 107

  2023-03-18T04:46:52.187824Z DEBUG uplink::base::mqtt: Outgoing = Publish(2)

  2023-03-18T04:46:52.187873Z DEBUG uplink::base::mqtt: Outgoing = Publish(3)

  2023-03-18T04:46:52.322860Z DEBUG uplink::base::mqtt: Incoming = PubAck(PubAck { pkid: 2 })

  2023-03-18T04:46:52.322919Z DEBUG uplink::base::mqtt: Incoming = PubAck(PubAck { pkid: 3 })

  2023-03-18T04:46:52.489113Z  INFO uplink::collector::downloader: Downloading from https://firmware.stage.bytebeam.io/api/v1/firmwares/7.8.9/artifact into /var/tmp/ota-file/update_firmware/7.8.9

  2023-03-18T04:46:52.489508Z  INFO uplink::collector::downloader: Firmware downloaded successfully

  2023-03-18T04:46:52.489741Z  INFO uplink::base::bridge: Action response = ActionResponse { action_id: "191", device_id: None, sequence: 2, timestamp: 1679114812489, state: "Downloaded", progress: 100, errors: [], done_response: Some(Action { device_id: None, action_id: "191", kind: "process", name: "update_firmware", payload: "{\"url\":\"https://firmware.stage.bytebeam.io/api/v1/firmwares/7.8.9/artifact\",\"file_name\":\"7.8.9\",\"download_path\":\"/var/tmp/ota-file/update_firmware/7.8.9\"}" }) }

  2023-03-18T04:46:52.489846Z TRACE uplink::base::bridge::stream: Flushing stream name: action_status, topic: /tenants/demo/devices/21/action/status

  2023-03-18T04:46:52.490014Z TRACE uplink::base::serializer: Data received on stream: action_status; message count = 1; batching latency = 0

  2023-03-18T04:46:52.490080Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/21/action/status with size = 108

  2023-03-18T04:46:52.490361Z DEBUG uplink::base::mqtt: Outgoing = Publish(4)

this is deb update
  2023-03-18T04:46:52.495778Z  INFO uplink::collector::tcpjson: Accepted connection from app = 1 on 127.0.0.1:44016

  2023-03-18T04:46:52.495896Z TRACE uplink::collector::tcpjson: 1: Received line = "{ \"stream\": \"action_status\", \"sequence\": 0, \"timestamp\": 1679114812494, \"action_id\": \"191\", \"state\": \"Completed\", \"progress\": 100, \"errors\": [] }"

  2023-03-18T04:46:52.496047Z  INFO uplink::base::bridge: Action response = ActionResponse { action_id: "191", device_id: None, sequence: 0, timestamp: 1679114812494, state: "Completed", progress: 100, errors: [], done_response: None }

  2023-03-18T04:46:52.496095Z DEBUG uplink::base::bridge::stream: Sequence number anomaly! [0, 2

  2023-03-18T04:46:52.496109Z TRACE uplink::base::bridge::stream: Flushing stream name: action_status, topic: /tenants/demo/devices/21/action/status

  2023-03-18T04:46:52.496174Z TRACE uplink::base::serializer: Data received on stream: action_status; message count = 1; batching latency = 0

  2023-03-18T04:46:52.496251Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/21/action/status with size = 107

  2023-03-18T04:46:52.496447Z DEBUG uplink::base::mqtt: Outgoing = Publish(5)

  2023-03-18T04:46:52.528136Z DEBUG uplink::base::mqtt: Incoming = PubAck(PubAck { pkid: 4 })
```