### PR TITLE
fix: use process.cmd[0] if available instead of process.name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ certs/
 config/
 
 devices/
+uplink/src/bin/*

--- a/uplink/src/collector/systemstats.rs
+++ b/uplink/src/collector/systemstats.rs
@@ -610,7 +610,10 @@ impl StatCollector {
         let timestamp =
             SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_millis() as u64;
         for (&id, p) in self.sys.processes() {
-            let name = p.name().to_owned();
+            let name = p.cmd()
+                .get(0)
+                .map(|s| s.to_string())
+                .unwrap_or(p.name().to_string());
 
             if self.config.system_stats.process_names.contains(&name) {
                 let payload = self.processes.push(id.as_u32(), p, name, timestamp);


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes

Use process command line instead of process name if possible

### Why?

process name is trimmed to last 16 characters.

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->