### PR TITLE
feat: implement action retries in bridge

### DIFF
--- a/configs/config.toml
+++ b/configs/config.toml
@@ -1,6 +1,11 @@
 # Collection of binaries which uplink can spawn as a process
 # This ensures that user is protected against random actions
 # triggered from cloud.
+# 
+# Action Route Parameters
+# - name: name associated with action
+# - timeout(optional): seconds from receiving an action after which it must complete or be reported as having failed to the platform.
+# - retries(optional): number of times an action can be retried on receiving the associated failure response.
 processes = [{ name = "echo", timeout = 10 }]
 
 action_redirections = { "firmware_update" = "install_update", "send_file" = "load_file" }
@@ -100,7 +105,7 @@ buf_size = 1
 # - actions: List of actions names that can trigger the downloader, with configurable timeouts
 # - path: Location in fs where the files are downloaded into
 [downloader]
-actions = [{ name = "update_firmware" }, { name = "send_file" }]
+actions = [{ name = "update_firmware", retries = 3 }, { name = "send_file" }]
 path = "/var/tmp/ota-file"
 
 # Configurations associated with the system stats module of uplink, if enabled

--- a/uplink/src/base/bridge/mod.rs
+++ b/uplink/src/base/bridge/mod.rs
@@ -270,6 +270,12 @@ impl Bridge {
                 }
             };
 
+            warn!("Action {} has {} retries left", action.action_id, inflight_action.retries);
+            let response = ActionResponse::progress(&inflight_action.id, "Retrying", 0);
+            if let Err(e) = self.action_status.fill(response).await {
+                error!("Failed to fill. Error = {:?}", e);
+            }
+
             if let Err(e) = self.try_route_action(action.clone()) {
                 error!("Failed to route action to app. Error = {:?}", e);
                 self.forward_action_error(action, e).await;

--- a/uplink/src/base/bridge/mod.rs
+++ b/uplink/src/base/bridge/mod.rs
@@ -227,8 +227,11 @@ impl Bridge {
             Some(app_tx) => {
                 let (duration, retries) =
                     app_tx.try_send(action.clone()).map_err(|_| Error::UnresponsiveReceiver)?;
+                let retries = match &self.current_action {
+                    Some(a) => a.retries,
+                    _ => retries,
+                };
                 self.current_action = Some(CurrentAction::new(action, duration, retries));
-
                 Ok(())
             }
             None => Err(Error::NoRoute(action.name)),

--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -125,6 +125,8 @@ pub struct ActionRoute {
     pub name: String,
     #[serde(default = "default_timeout")]
     pub timeout: u64,
+    #[serde(default)]
+    pub retries: u8,
 }
 
 impl From<&ActionRoute> for ActionRoute {

--- a/uplink/src/collector/logging/mod.rs
+++ b/uplink/src/collector/logging/mod.rs
@@ -4,19 +4,19 @@ use std::{process::Command, time::Duration};
 
 use flume::Sender;
 use serde::Deserialize;
-use crate::{Config, Package, Payload, Stream};
 
 #[cfg(target_os = "linux")]
 mod journalctl;
 #[cfg(target_os = "android")]
 mod logcat;
 
+use crate::base::bridge::BridgeTx;
+use crate::base::ActionRoute;
+use crate::{Config, Package, Payload, Stream};
 #[cfg(target_os = "linux")]
 pub use journalctl::{new_journalctl, LogEntry};
 #[cfg(target_os = "android")]
 pub use logcat::{new_logcat, LogEntry};
-use crate::base::ActionRoute;
-use crate::base::bridge::BridgeTx;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -48,11 +48,7 @@ impl Drop for LoggerInstance {
 }
 
 impl LoggerInstance {
-    pub fn new(
-        config: Arc<Config>,
-        data_tx: Sender<Box<dyn Package>>,
-        bridge: BridgeTx,
-    ) -> Self {
+    pub fn new(config: Arc<Config>, data_tx: Sender<Box<dyn Package>>, bridge: BridgeTx) -> Self {
         let buf_size = config.logging.as_ref().and_then(|c| c.stream_size).unwrap_or(32);
 
         let log_stream = Stream::dynamic_with_size(
@@ -79,10 +75,14 @@ impl LoggerInstance {
             self.spawn_logger(new_logcat(config));
         }
 
-        let log_rx = self.bridge.register_action_route(ActionRoute {
-            name: "logging_config".to_string(),
-            timeout: 10,
-        }).await;
+        let log_rx = self
+            .bridge
+            .register_action_route(ActionRoute {
+                name: "logging_config".to_string(),
+                timeout: 10,
+                retries: 0,
+            })
+            .await;
 
         loop {
             let action = log_rx.recv()?;

--- a/uplink/src/collector/tunshell.rs
+++ b/uplink/src/collector/tunshell.rs
@@ -43,7 +43,7 @@ impl TunshellSession {
 
     #[tokio::main(flavor = "current_thread")]
     pub async fn start(self) {
-        let route = ActionRoute { name: "launch_shell".to_owned(), timeout: 10 };
+        let route = ActionRoute { name: "launch_shell".to_owned(), timeout: 10, retries: 0 };
         let actions_rx = self.bridge.register_action_route(route).await;
 
         while let Ok(action) = actions_rx.recv_async().await {


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->
Implement action retries in bridge and remove downloader's internal retry mechanism, enable user to configure the retries as follows in `config.toml`:
```toml
actions = [{ name = "update_firmware", timeout = 320, retries = 3 }]
```

### Why?
<!--Detailed description of why the changes had to be made-->

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
Send action for downloader that will fail and observe what happens when failure response is received from the app:
```
 2023-03-08T15:34:45.295590Z  INFO uplink::base::mqtt: Action = Action { device_id: None, action_id: "1234", kind: "process", name: "update_firmware", payload: "{\"url\": \"https://help.xyz\", \"file_name\": \"abc.jpg\"}" }

  2023-03-08T15:34:45.295673Z  INFO uplink::base::bridge: Received action: Action { device_id: None, action_id: "1234", kind: "process", name: "update_firmware", payload: "{\"url\": \"https://help.xyz\", \"file_name\": \"abc.jpg\"}" }

  2023-03-08T15:34:45.295706Z  INFO uplink::base::bridge: Action response = ActionResponse { action_id: "1234", device_id: None, sequence: 0, timestamp: 1678289685295, state: "Received", progress: 0, errors: [], done_response: None }

  2023-03-08T15:34:45.295716Z DEBUG uplink::base::bridge::stream: Sequence number anomaly! [0, 0

  2023-03-08T15:34:45.295723Z TRACE uplink::base::bridge::stream: Flushing stream name: action_status, topic: /tenants/demo/devices/1/action/status

  2023-03-08T15:34:45.295807Z TRACE uplink::base::serializer: Data received on stream: action_status; message count = 1; batching latency = 0

  2023-03-08T15:34:45.295844Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1/action/status with size = 105

  2023-03-08T15:34:45.295852Z  INFO uplink::base::bridge: Action response = ActionResponse { action_id: "1234", device_id: None, sequence: 1, timestamp: 1678289685295, state: "Downloading", progress: 0, errors: [], done_response: None }

  2023-03-08T15:34:45.295870Z TRACE uplink::base::bridge::stream: Flushing stream name: action_status, topic: /tenants/demo/devices/1/action/status

  2023-03-08T15:34:45.295882Z DEBUG uplink::base::mqtt: Outgoing = Publish(2)

  2023-03-08T15:34:45.295956Z TRACE uplink::base::serializer: Data received on stream: action_status; message count = 1; batching latency = 0

  2023-03-08T15:34:45.295970Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1/action/status with size = 108

  2023-03-08T15:34:45.295987Z DEBUG uplink::base::mqtt: Outgoing = Publish(3)

  2023-03-08T15:34:45.409491Z DEBUG uplink::base::mqtt: Incoming = PubAck(PubAck { pkid: 2 })

  2023-03-08T15:34:45.409562Z DEBUG uplink::base::mqtt: Incoming = PubAck(PubAck { pkid: 3 })

  2023-03-08T15:34:45.515793Z  INFO uplink::base::bridge: Action response = ActionResponse { action_id: "1234", device_id: None, sequence: 2, timestamp: 1678289685515, state: "Failed", progress: 100, errors: ["Error from reqwest: error sending request for url (https://help.xyz/): error trying to connect: dns error: failed to lookup address information: No address associated with hostname"], done_response: None }

  2023-03-08T15:34:45.515893Z TRACE uplink::base::bridge::stream: Flushing stream name: action_status, topic: /tenants/demo/devices/1/action/status

  2023-03-08T15:34:45.515933Z  WARN uplink::base::bridge: Action 1234 has 2 retries left

  2023-03-08T15:34:45.515949Z DEBUG uplink::base::bridge::stream: Sequence number anomaly! [0, 2

  2023-03-08T15:34:45.515972Z TRACE uplink::base::bridge::stream: Flushing stream name: action_status, topic: /tenants/demo/devices/1/action/status

  2023-03-08T15:34:45.516152Z TRACE uplink::base::serializer: Data received on stream: action_status; message count = 1; batching latency = 0

  2023-03-08T15:34:45.516197Z  INFO uplink::base::bridge: Action response = ActionResponse { action_id: "1234", device_id: None, sequence: 1, timestamp: 1678289685516, state: "Downloading", progress: 0, errors: [], done_response: None }

  2023-03-08T15:34:45.516227Z TRACE uplink::base::bridge::stream: Flushing stream name: action_status, topic: /tenants/demo/devices/1/action/status

  2023-03-08T15:34:45.516247Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1/action/status with size = 287

  2023-03-08T15:34:45.516292Z TRACE uplink::base::serializer: Data received on stream: action_status; message count = 1; batching latency = 0

  2023-03-08T15:34:45.516316Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1/action/status with size = 105

  2023-03-08T15:34:45.516337Z TRACE uplink::base::serializer: Data received on stream: action_status; message count = 1; batching latency = 0

  2023-03-08T15:34:45.516359Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1/action/status with size = 108

  2023-03-08T15:34:45.516526Z DEBUG uplink::base::mqtt: Outgoing = Publish(4)

  2023-03-08T15:34:45.516618Z DEBUG uplink::base::mqtt: Outgoing = Publish(5)

  2023-03-08T15:34:45.516646Z DEBUG uplink::base::mqtt: Outgoing = Publish(6)

  2023-03-08T15:34:45.551012Z DEBUG uplink::base::mqtt: Incoming = PubAck(PubAck { pkid: 4 })

  2023-03-08T15:34:45.585363Z DEBUG uplink::base::mqtt: Incoming = PubAck(PubAck { pkid: 5 })

  2023-03-08T15:34:45.585435Z DEBUG uplink::base::mqtt: Incoming = PubAck(PubAck { pkid: 6 })

  2023-03-08T15:34:45.785382Z  INFO uplink::base::bridge: Action response = ActionResponse { action_id: "1234", device_id: None, sequence: 2, timestamp: 1678289685785, state: "Failed", progress: 100, errors: ["Error from reqwest: error sending request for url (https://help.xyz/): error trying to connect: dns error: failed to lookup address information: No address associated with hostname"], done_response: None }

  2023-03-08T15:34:45.785473Z TRACE uplink::base::bridge::stream: Flushing stream name: action_status, topic: /tenants/demo/devices/1/action/status

  2023-03-08T15:34:45.785500Z  WARN uplink::base::bridge: Action 1234 has 1 retries left

  2023-03-08T15:34:45.785540Z DEBUG uplink::base::bridge::stream: Sequence number anomaly! [0, 2

  2023-03-08T15:34:45.785555Z TRACE uplink::base::bridge::stream: Flushing stream name: action_status, topic: /tenants/demo/devices/1/action/status

  2023-03-08T15:34:45.785607Z  INFO uplink::base::bridge: Action response = ActionResponse { action_id: "1234", device_id: None, sequence: 1, timestamp: 1678289685785, state: "Downloading", progress: 0, errors: [], done_response: None }

  2023-03-08T15:34:45.785629Z TRACE uplink::base::bridge::stream: Flushing stream name: action_status, topic: /tenants/demo/devices/1/action/status

  2023-03-08T15:34:45.785677Z TRACE uplink::base::serializer: Data received on stream: action_status; message count = 1; batching latency = 0

  2023-03-08T15:34:45.785748Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1/action/status with size = 287

  2023-03-08T15:34:45.785789Z TRACE uplink::base::serializer: Data received on stream: action_status; message count = 1; batching latency = 0

  2023-03-08T15:34:45.785811Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1/action/status with size = 105

  2023-03-08T15:34:45.785830Z TRACE uplink::base::serializer: Data received on stream: action_status; message count = 1; batching latency = 0

  2023-03-08T15:34:45.785851Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1/action/status with size = 108

  2023-03-08T15:34:45.786038Z DEBUG uplink::base::mqtt: Outgoing = Publish(7)

  2023-03-08T15:34:45.786124Z DEBUG uplink::base::mqtt: Outgoing = Publish(8)

  2023-03-08T15:34:45.786162Z DEBUG uplink::base::mqtt: Outgoing = Publish(9)

  2023-03-08T15:34:45.821174Z DEBUG uplink::base::mqtt: Incoming = PubAck(PubAck { pkid: 7 })

  2023-03-08T15:34:45.853556Z DEBUG uplink::base::mqtt: Incoming = PubAck(PubAck { pkid: 8 })

  2023-03-08T15:34:45.853587Z DEBUG uplink::base::mqtt: Incoming = PubAck(PubAck { pkid: 9 })

  2023-03-08T15:34:46.006650Z  INFO uplink::base::bridge: Action response = ActionResponse { action_id: "1234", device_id: None, sequence: 2, timestamp: 1678289686006, state: "Failed", progress: 100, errors: ["Error from reqwest: error sending request for url (https://help.xyz/): error trying to connect: dns error: failed to lookup address information: No address associated with hostname"], done_response: None }

  2023-03-08T15:34:46.006730Z TRACE uplink::base::bridge::stream: Flushing stream name: action_status, topic: /tenants/demo/devices/1/action/status

  2023-03-08T15:34:46.006754Z  WARN uplink::base::bridge: Action 1234 has 0 retries left

  2023-03-08T15:34:46.006764Z DEBUG uplink::base::bridge::stream: Sequence number anomaly! [0, 2

  2023-03-08T15:34:46.006775Z TRACE uplink::base::bridge::stream: Flushing stream name: action_status, topic: /tenants/demo/devices/1/action/status

  2023-03-08T15:34:46.006922Z TRACE uplink::base::serializer: Data received on stream: action_status; message count = 1; batching latency = 0

  2023-03-08T15:34:46.006985Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1/action/status with size = 287

  2023-03-08T15:34:46.007034Z TRACE uplink::base::serializer: Data received on stream: action_status; message count = 1; batching latency = 0

  2023-03-08T15:34:46.007055Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1/action/status with size = 105

  2023-03-08T15:34:46.007041Z  INFO uplink::base::bridge: Action response = ActionResponse { action_id: "1234", device_id: None, sequence: 1, timestamp: 1678289686006, state: "Downloading", progress: 0, errors: [], done_response: None }

  2023-03-08T15:34:46.007087Z TRACE uplink::base::bridge::stream: Flushing stream name: action_status, topic: /tenants/demo/devices/1/action/status

  2023-03-08T15:34:46.007198Z TRACE uplink::base::serializer: Data received on stream: action_status; message count = 1; batching latency = 0

  2023-03-08T15:34:46.007239Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1/action/status with size = 108

  2023-03-08T15:34:46.007264Z DEBUG uplink::base::mqtt: Outgoing = Publish(10)

  2023-03-08T15:34:46.007311Z DEBUG uplink::base::mqtt: Outgoing = Publish(11)

  2023-03-08T15:34:46.007327Z DEBUG uplink::base::mqtt: Outgoing = Publish(12)

  2023-03-08T15:34:46.040807Z DEBUG uplink::base::mqtt: Incoming = PubAck(PubAck { pkid: 10 })

  2023-03-08T15:34:46.074828Z DEBUG uplink::base::mqtt: Incoming = PubAck(PubAck { pkid: 11 })

  2023-03-08T15:34:46.074879Z DEBUG uplink::base::mqtt: Incoming = PubAck(PubAck { pkid: 12 })

  2023-03-08T15:34:46.161507Z  INFO uplink::base::bridge: Action response = ActionResponse { action_id: "1234", device_id: None, sequence: 2, timestamp: 1678289686161, state: "Failed", progress: 100, errors: ["Error from reqwest: error sending request for url (https://help.xyz/): error trying to connect: dns error: failed to lookup address information: No address associated with hostname"], done_response: None }

  2023-03-08T15:34:46.161551Z TRACE uplink::base::bridge::stream: Flushing stream name: action_status, topic: /tenants/demo/devices/1/action/status

  2023-03-08T15:34:46.161660Z TRACE uplink::base::serializer: Data received on stream: action_status; message count = 1; batching latency = 0

  2023-03-08T15:34:46.161703Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1/action/status with size = 287

  2023-03-08T15:34:46.161900Z DEBUG uplink::base::mqtt: Outgoing = Publish(13)

  2023-03-08T15:34:46.195035Z DEBUG uplink::base::mqtt: Incoming = PubAck(PubAck { pkid: 13 })
```


![Screenshot from 2023-03-08 21-50-52](https://user-images.githubusercontent.com/18750864/223769675-00b42e95-be72-4058-a894-84a429f8a04b.png)