### PR TITLE
fix: don't remove files, improve downloader error

### DIFF
--- a/uplink/src/collector/downloader.rs
+++ b/uplink/src/collector/downloader.rs
@@ -155,14 +155,13 @@ impl FileDownloader {
         self.bridge_tx.send_action_response(status).await;
 
         // Extract url information from action payload
-        let mut update = serde_json::from_str::<DownloadFile>(&action.payload)?;
-        match update {
+        let mut update = match serde_json::from_str::<DownloadFile>(&action.payload)? {
             DownloadFile { file_name, .. } if file_name.is_empty() => {
                 return Err(Error::EmptyFileName)
             }
             // DownloadFile { content_length: 0, .. } => return Err(Error::EmptyFile),
-            _ => {}
-        }
+            u => u,
+        };
 
         let url = update.url.clone();
 

--- a/uplink/src/collector/downloader.rs
+++ b/uplink/src/collector/downloader.rs
@@ -160,7 +160,7 @@ impl FileDownloader {
             DownloadFile { file_name, .. } if file_name.is_empty() => {
                 return Err(Error::EmptyFileName)
             }
-            DownloadFile { content_length: 0, .. } => return Err(Error::EmptyFile),
+            // DownloadFile { content_length: 0, .. } => return Err(Error::EmptyFile),
             _ => {}
         }
 

--- a/uplink/src/collector/downloader.rs
+++ b/uplink/src/collector/downloader.rs
@@ -196,8 +196,8 @@ impl FileDownloader {
         let mut file_path = download_path.to_owned();
         file_path.push(file_name);
         let file_path = file_path.as_path();
-        if metadata(&file_path)?.is_dir() {
-            remove_dir_all(&file_path)?;
+        if metadata(file_path)?.is_dir() {
+            remove_dir_all(file_path)?;
         }
         let file = File::create(file_path)?;
         let file_path = file_path.to_str().ok_or(Error::FilePathMissing)?.to_owned();

--- a/uplink/src/collector/downloader.rs
+++ b/uplink/src/collector/downloader.rs
@@ -195,8 +195,11 @@ impl FileDownloader {
         let mut file_path = download_path.to_owned();
         file_path.push(file_name);
         let file_path = file_path.as_path();
-        if metadata(file_path)?.is_dir() {
-            remove_dir_all(file_path)?;
+        // NOTE: if file_path is occupied by a directory due to previous working of uplink, remove it
+        if let Ok(f) = metadata(file_path) {
+            if f.is_dir() {
+                remove_dir_all(file_path)?;
+            }
         }
         let file = File::create(file_path)?;
         let file_path = file_path.to_str().ok_or(Error::FilePathMissing)?.to_owned();


### PR DESCRIPTION
Closes #199 

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->

### Why?
<!--Detailed description of why the changes had to be made-->

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
Run against "send_file" and "update_firmware" actions from platform, it has been observed that files downloaded by previous actions don't get deleted if they don't have the same `file_name`. If a file with the same name exists on path, it is replaced by the new file, if there is a directory, it is deleted along with all it's contents and replaced with the file, if there exists nothing, the file and all its parent directories are created by the downloader.

Actions that contain empty `file_name` and `content_length == 0` are both notified to the platform appropriately as well, which was confirmed with a custom actions generator as it is not possible to reproduce on platform.