### PR TITLE
feat: `network_timeout` in config

### DIFF
--- a/configs/config.toml
+++ b/configs/config.toml
@@ -13,10 +13,13 @@ action_redirections = { "firmware_update" = "install_update", "send_file" = "loa
 #                 handled by uplink, at a time, requiring acknowledgedment.
 # - keep_alive: Number of seconds after which the MQTT client should ping
 #               the broker if there is no other data exchange.
+# - network_timeout: Number of seconds after which the MQTT client can timeout
+#                    while waiting for a network response.
 [mqtt]
 max_packet_size = 256000
 max_inflight = 100
 keep_alive = 30
+network_timeout = 30
 
 # TCP applications that detail applications which connect with uplink
 # Required Parameters

--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -126,6 +126,7 @@ pub struct MqttConfig {
     pub max_packet_size: usize,
     pub max_inflight: u16,
     pub keep_alive: u64,
+    pub network_timeout: u64,
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]

--- a/uplink/src/base/mqtt/mod.rs
+++ b/uplink/src/base/mqtt/mod.rs
@@ -59,7 +59,8 @@ impl Mqtt {
     ) -> Mqtt {
         // create a new eventloop and reuse it during every reconnection
         let options = mqttoptions(&config);
-        let (client, eventloop) = AsyncClient::new(options, 10);
+        let (client, mut eventloop) = AsyncClient::new(options, 10);
+        eventloop.network_options.set_connection_timeout(30);
         let mut actions_subscriptions = vec![config.actions_subscription.clone()];
         if let Some(sim_cfg) = &config.simulator {
             actions_subscriptions.extend_from_slice(&sim_cfg.actions_subscriptions);

--- a/uplink/src/base/mqtt/mod.rs
+++ b/uplink/src/base/mqtt/mod.rs
@@ -60,7 +60,7 @@ impl Mqtt {
         // create a new eventloop and reuse it during every reconnection
         let options = mqttoptions(&config);
         let (client, mut eventloop) = AsyncClient::new(options, 10);
-        eventloop.network_options.set_connection_timeout(30);
+        eventloop.network_options.set_connection_timeout(config.mqtt.network_timeout);
         let mut actions_subscriptions = vec![config.actions_subscription.clone()];
         if let Some(sim_cfg) = &config.simulator {
             actions_subscriptions.extend_from_slice(&sim_cfg.actions_subscriptions);


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->

### Why?
<!--Detailed description of why the changes had to be made-->

### Trials Performed
Use toxy proxy to slowdown connection, triggering timeout in 30s, timeout is observed.
```
[uplink/src/base/mqtt/mod.rs:88] Instant::now() = Instant {
    tv_sec: 42238,
    tv_nsec: 563240499,
}
[uplink/src/base/mqtt/mod.rs:141] start.elapsed() = 30.002141581s
  2023-04-04T13:35:26.598569Z ERROR uplink::base::mqtt:                        disconnected: reconnects = 1   publishes = 0   pubacks = 0   pingreqs = 0   pingresps = 0 
```