### PR TITLE
fix: uplink logger success response, use bridge, stream config

### DIFF
--- a/uplink/src/collector/logging/mod.rs
+++ b/uplink/src/collector/logging/mod.rs
@@ -1,4 +1,3 @@
-use flume::Sender;
 use serde::Deserialize;
 
 use std::io::{BufRead, BufReader};
@@ -11,7 +10,7 @@ mod journalctl;
 mod logcat;
 
 use crate::base::{bridge::BridgeTx, ActionRoute};
-use crate::{Config, Package, Payload, Stream};
+use crate::{ActionResponse, Config};
 #[cfg(target_os = "linux")]
 pub use journalctl::{new_journalctl, LogEntry};
 #[cfg(target_os = "android")]
@@ -27,7 +26,6 @@ pub enum Error {
 
 pub struct LoggerInstance {
     config: Arc<Config>,
-    log_stream: Stream<Payload>,
     kill_switch: Arc<Mutex<bool>>,
     bridge: BridgeTx,
 }
@@ -47,19 +45,10 @@ impl Drop for LoggerInstance {
 }
 
 impl LoggerInstance {
-    pub fn new(config: Arc<Config>, data_tx: Sender<Box<dyn Package>>, bridge: BridgeTx) -> Self {
-        let buf_size = config.logging.as_ref().and_then(|c| c.stream_size).unwrap_or(32);
-
-        let log_stream = Stream::dynamic_with_size(
-            "logs",
-            &config.project_id,
-            &config.device_id,
-            buf_size,
-            data_tx,
-        );
+    pub fn new(config: Arc<Config>, bridge: BridgeTx) -> Self {
         let kill_switch = Arc::new(Mutex::new(true));
 
-        Self { config, log_stream, kill_switch, bridge }
+        Self { config, kill_switch, bridge }
     }
 
     /// On an android system, starts a logcat instance and a journalctl instance for a linux system that
@@ -107,7 +96,7 @@ impl LoggerInstance {
     // Spawn a thread to run the logger command
     fn spawn_logger(&mut self, mut logger: Command) {
         let kill_switch = self.kill_switch.clone();
-        let mut log_stream = self.log_stream.clone();
+        let bridge = self.bridge.clone();
 
         std::thread::spawn(move || {
             std::thread::sleep(Duration::from_micros(1_000_000));
@@ -155,7 +144,7 @@ impl LoggerInstance {
                     }
                 };
                 log::trace!("Log entry {:?}", payload);
-                log_stream.push(payload).unwrap();
+                bridge.send_payload_sync(payload);
                 log_index += 1;
             }
         });

--- a/uplink/src/collector/logging/mod.rs
+++ b/uplink/src/collector/logging/mod.rs
@@ -93,6 +93,9 @@ impl LoggerInstance {
             self.spawn_logger(new_journalctl(&config));
             #[cfg(target_os = "android")]
             self.spawn_logger(new_logcat(&config));
+
+            let response = ActionResponse::success(&action.action_id);
+            self.bridge.send_action_response(response).await;
         }
     }
 

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -93,6 +93,10 @@ pub mod config {
     topic = "/tenants/{tenant_id}/devices/{device_id}/events/device_shadow/jsonarray"
     buf_size = 1
 
+    [streams.logs]
+    topic = "/tenants/{tenant_id}/devices/{device_id}/events/logs/jsonarray"
+    buf_size = 32
+
     [system_stats]
     enabled = true
     process_names = ["uplink"]
@@ -338,11 +342,7 @@ impl Uplink {
 
         #[cfg(any(target_os = "linux", target_os = "android"))]
         {
-            let logger = collector::logging::LoggerInstance::new(
-                config.clone(),
-                self.data_tx.clone(),
-                bridge_tx.clone(),
-            );
+            let logger = collector::logging::LoggerInstance::new(config.clone(), bridge_tx.clone());
             thread::spawn(move || logger.start());
         }
 

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -168,6 +168,16 @@ pub mod config {
             }
         }
 
+        let stream_config =
+            config.streams.entry("logs".to_string()).or_insert_with(|| StreamConfig {
+                topic: format!("/tenants/{tenant_id}/devices/{device_id}/events/logs/jsonarray"),
+                buf_size: 32,
+                flush_period: DEFAULT_TIMEOUT,
+            });
+        if let Some(buf_size) = config.logging.as_ref().and_then(|c| c.stream_size) {
+            stream_config.buf_size = buf_size;
+        }
+
         let action_topic_template = "/tenants/{tenant_id}/devices/{device_id}/actions";
         let mut device_action_topic = action_topic_template.to_string();
         replace_topic_placeholders(&mut device_action_topic, tenant_id, device_id);


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
- Send success response on `logging_config` action completion
- Use bridge to forward logger data
- Configuration of uplink logger should manipulate logger

### Why?
<!--Detailed description of why the changes had to be made-->
uplink's built-in logger doesn't respond with a success notification, nor does it use the bridge to send it's updates, both of which are wrong behavior and needs to be changed,

### Trials Performed
Sent an action from platform to start forwarding systemd logs, it replied back with a success. Uplink was configured with following config: 
```
[logging]
tags = []
min_level = 0
stream_size = 10
```

![Screenshot from 2023-04-19 12-04-09](https://user-images.githubusercontent.com/18750864/233041387-2efc49df-eb3c-46a8-878b-998457f716e1.png)

![Screenshot from 2023-04-19 15-29-21](https://user-images.githubusercontent.com/18750864/233041433-ff7160ce-44e7-4554-98ca-0e13f461d890.png)

```
  2023-04-19T09:55:21.270009Z TRACE uplink::base::bridge::stream: Flushing stream name: logs, topic: /tenants/demo/devices/615/events/logs/jsonarray

  2023-04-19T09:55:21.270040Z TRACE uplink::base::serializer: Data received on stream: logs; message count = 10; batching latency = 0
```

NOTE: it is not possible to configure stream size on uplink remotely as of right now and it will require a separate issue and a brainstorm.
NOTE: JSON shouldn't contain oxford comma, as showing in screenshot above, otherwise it works.