### PR TITLE
feat: allow configuring compressibility per-stream

### DIFF
--- a/configs/config.toml
+++ b/configs/config.toml
@@ -5,10 +5,6 @@ processes = [{ name = "echo", timeout = 10 }]
 
 action_redirections = { "firmware_update" = "install_update", "send_file" = "load_file" }
 
-# Uplink supports compressing the data payload with the lz4 scheme, this
-# feature can be enabled by including the following configuration detail.
-enable_compression = true
-
 # MQTT client configuration
 # 
 # Required Parameters

--- a/configs/config.toml
+++ b/configs/config.toml
@@ -78,6 +78,8 @@ max_file_count = 3
 #   unconfigured, stream will be created dynamically.
 # - flush-period(optional): Duration in seconds after a data point enters the stream
 #   and WILL be flushed by collector. Defaults to 60s in case not configured.
+# - is_compressible(optional): a boolean to determine if serializer should compress
+#   data on the stream for transit. Defaults to false.
 #
 # In the following config for the device_shadow stream we set buf_size to 1. streams is
 # internally constructed as a map of Name -> Config

--- a/configs/config.toml
+++ b/configs/config.toml
@@ -78,14 +78,20 @@ max_file_count = 3
 #   unconfigured, stream will be created dynamically.
 # - flush-period(optional): Duration in seconds after a data point enters the stream
 #   and WILL be flushed by collector. Defaults to 60s in case not configured.
-# - is_compressible(optional): a boolean to determine if serializer should compress
-#   data on the stream for transit. Defaults to false.
+# - compression(optional): an enum values to determine what compression the serializer
+#   should perform on the data transiting through the stream. Currently supported
+#   compression schemes are Lz4 and Disabled. Defaults to Disabled.
 #
 # In the following config for the device_shadow stream we set buf_size to 1. streams is
 # internally constructed as a map of Name -> Config
 [streams.device_shadow]
 topic = "/tenants/{tenant_id}/devices/{device_id}/device_shadow/jsonarray"
 buf_size = 1
+
+[streams.imu]
+topic = "/tenants/{tenant_id}/devices/{device_id}/events/imu/jsonarray"
+buf_size = 100
+compression = "Lz4"
 
 # Built-in streams: action status is a special case of stream and should be configured separately,
 # outside of the streams map. The action_status stream is used to push progress of Actions in

--- a/uplink/src/base/bridge/mod.rs
+++ b/uplink/src/base/bridge/mod.rs
@@ -15,6 +15,8 @@ use crate::{collector::utils::Streams, Action, ActionResponse, Config};
 pub use metrics::StreamMetrics;
 use stream::Stream;
 
+use super::Compression;
+
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("Receiver error {0}")]
@@ -46,7 +48,7 @@ pub trait Package: Send + Debug {
     fn is_empty(&self) -> bool {
         self.len() == 0
     }
-    fn is_compressible(&self) -> bool;
+    fn compression(&self) -> Compression;
 }
 
 // TODO Don't do any deserialization on payload. Read it a Vec<u8> which is in turn a json

--- a/uplink/src/base/bridge/mod.rs
+++ b/uplink/src/base/bridge/mod.rs
@@ -46,6 +46,7 @@ pub trait Package: Send + Debug {
     fn is_empty(&self) -> bool {
         self.len() == 0
     }
+    fn is_compressible(&self) -> bool;
 }
 
 // TODO Don't do any deserialization on payload. Read it a Vec<u8> which is in turn a json

--- a/uplink/src/base/bridge/stream.rs
+++ b/uplink/src/base/bridge/stream.rs
@@ -33,6 +33,7 @@ pub struct Stream<T> {
     buffer: Buffer<T>,
     tx: Sender<Box<dyn Package>>,
     pub metrics: StreamMetrics,
+    is_compressible: bool,
 }
 
 impl<T> Stream<T>
@@ -45,10 +46,11 @@ where
         topic: S,
         max_buffer_size: usize,
         tx: Sender<Box<dyn Package>>,
+        is_compressible: bool,
     ) -> Stream<T> {
         let name = Arc::new(stream.into());
         let topic = Arc::new(topic.into());
-        let buffer = Buffer::new(name.clone(), topic.clone());
+        let buffer = Buffer::new(name.clone(), topic.clone(), is_compressible);
         let flush_period = Duration::from_secs(DEFAULT_TIMEOUT);
         let metrics = StreamMetrics::new(&name, max_buffer_size);
 
@@ -62,6 +64,7 @@ where
             buffer,
             tx,
             metrics,
+            is_compressible,
         }
     }
 
@@ -70,7 +73,8 @@ where
         config: &StreamConfig,
         tx: Sender<Box<dyn Package>>,
     ) -> Stream<T> {
-        let mut stream = Stream::new(name, &config.topic, config.buf_size, tx);
+        let mut stream =
+            Stream::new(name, &config.topic, config.buf_size, tx, config.is_compressible);
         stream.flush_period = Duration::from_secs(config.flush_period);
         stream
     }
@@ -94,7 +98,7 @@ where
             + &stream
             + "/jsonarray";
 
-        Stream::new(stream, topic, max_buffer_size, tx)
+        Stream::new(stream, topic, max_buffer_size, tx, false)
     }
 
     pub fn dynamic<S: Into<String>>(
@@ -147,7 +151,7 @@ where
         let topic = self.topic.clone();
         trace!("Flushing stream name: {}, topic: {}", name, topic);
 
-        mem::replace(&mut self.buffer, Buffer::new(name, topic))
+        mem::replace(&mut self.buffer, Buffer::new(name, topic, self.is_compressible))
     }
 
     /// Triggers flush and async channel send if not empty
@@ -218,16 +222,18 @@ pub struct Buffer<T> {
     pub buffer: Vec<T>,
     pub anomalies: String,
     pub anomaly_count: usize,
+    pub is_compressible: bool,
 }
 
 impl<T> Buffer<T> {
-    pub fn new(stream: Arc<String>, topic: Arc<String>) -> Buffer<T> {
+    pub fn new(stream: Arc<String>, topic: Arc<String>, is_compressible: bool) -> Buffer<T> {
         Buffer {
             stream,
             topic,
             buffer: vec![],
             anomalies: String::with_capacity(100),
             anomaly_count: 0,
+            is_compressible,
         }
     }
 
@@ -292,6 +298,10 @@ where
     fn latency(&self) -> u64 {
         0
     }
+
+    fn is_compressible(&self) -> bool {
+        self.is_compressible
+    }
 }
 
 impl<T> Clone for Stream<T> {
@@ -303,9 +313,14 @@ impl<T> Clone for Stream<T> {
             topic: self.topic.clone(),
             last_sequence: 0,
             last_timestamp: 0,
-            buffer: Buffer::new(self.buffer.stream.clone(), self.buffer.topic.clone()),
+            buffer: Buffer::new(
+                self.buffer.stream.clone(),
+                self.buffer.topic.clone(),
+                self.is_compressible,
+            ),
             metrics: StreamMetrics::new(&self.name, self.max_buffer_size),
             tx: self.tx.clone(),
+            is_compressible: self.is_compressible,
         }
     }
 }

--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -34,6 +34,8 @@ pub struct StreamConfig {
     /// Duration(in seconds) that bridge collector waits from
     /// receiving first element, before the stream gets flushed.
     pub flush_period: u64,
+    #[serde(default)]
+    pub is_compressible: bool,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -26,6 +26,13 @@ fn default_file_count() -> usize {
     3
 }
 
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, Default)]
+pub enum Compression {
+    #[default]
+    Disabled,
+    Lz4,
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct StreamConfig {
     pub topic: String,
@@ -35,7 +42,7 @@ pub struct StreamConfig {
     /// receiving first element, before the stream gets flushed.
     pub flush_period: u64,
     #[serde(default)]
-    pub is_compressible: bool,
+    pub compression: Compression,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -181,6 +181,4 @@ pub struct Config {
     pub ignore_actions_if_no_clients: bool,
     #[cfg(any(target_os = "linux", target_os = "android"))]
     pub logging: Option<LoggerConfig>,
-    #[serde(default)]
-    pub enable_compression: bool,
 }

--- a/uplink/src/base/serializer/mod.rs
+++ b/uplink/src/base/serializer/mod.rs
@@ -505,7 +505,7 @@ async fn send_publish<C: MqttClient>(
     Ok(client)
 }
 
-fn compress(payload: &mut Vec<u8>, topic: &mut String) -> Result<(), Error> {
+fn lz4_compress(payload: &mut Vec<u8>, topic: &mut String) -> Result<(), Error> {
     let mut compressor = FrameEncoder::new(vec![]);
     compressor.write_all(payload)?;
     *payload = compressor.finish()?;
@@ -525,7 +525,7 @@ fn construct_publish(data: Box<dyn Package>) -> Result<Publish, Error> {
     let mut payload = data.serialize()?;
 
     if let Compression::Lz4 = data.compression() {
-        compress(&mut payload, &mut topic)?;
+        lz4_compress(&mut payload, &mut topic)?;
     }
 
     Ok(Publish::new(topic, QoS::AtLeastOnce, payload))

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -6,6 +6,7 @@ use anyhow::Error;
 
 use base::bridge::stream::Stream;
 use base::monitor::Monitor;
+use base::Compression;
 use collector::downloader::FileDownloader;
 use collector::installer::OTAInstaller;
 use collector::process::ProcessHandler;
@@ -18,8 +19,8 @@ pub mod base;
 pub mod collector;
 
 pub mod config {
+    use crate::base::{Compression, StreamConfig, DEFAULT_TIMEOUT};
     pub use crate::base::{Config, Persistence, Stats};
-    use crate::base::{StreamConfig, DEFAULT_TIMEOUT};
     use config::{Environment, File, FileFormat};
     use std::fs;
     use structopt::StructOpt;
@@ -159,7 +160,7 @@ pub mod config {
                     ),
                     buf_size: config.system_stats.stream_size.unwrap_or(100),
                     flush_period: DEFAULT_TIMEOUT,
-                    is_compressible: true,
+                    compression: Compression::Disabled,
                 };
                 config.streams.insert(stream_name.to_owned(), stream_config);
             }
@@ -245,8 +246,13 @@ impl Uplink {
         let (serializer_metrics_tx, serializer_metrics_rx) = bounded(10);
 
         let action_status_topic = &config.action_status.topic;
-        let action_status =
-            Stream::new("action_status", action_status_topic, 1, data_tx.clone(), false);
+        let action_status = Stream::new(
+            "action_status",
+            action_status_topic,
+            1,
+            data_tx.clone(),
+            Compression::Disabled,
+        );
         Ok(Uplink {
             config,
             action_rx,

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -159,6 +159,7 @@ pub mod config {
                     ),
                     buf_size: config.system_stats.stream_size.unwrap_or(100),
                     flush_period: DEFAULT_TIMEOUT,
+                    is_compressible: true,
                 };
                 config.streams.insert(stream_name.to_owned(), stream_config);
             }
@@ -244,7 +245,8 @@ impl Uplink {
         let (serializer_metrics_tx, serializer_metrics_rx) = bounded(10);
 
         let action_status_topic = &config.action_status.topic;
-        let action_status = Stream::new("action_status", action_status_topic, 1, data_tx.clone());
+        let action_status =
+            Stream::new("action_status", action_status_topic, 1, data_tx.clone(), false);
         Ok(Uplink {
             config,
             action_rx,


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->
Compression can be opted between "Lz4" and "Disabled" right now, where Disabled is the default option

### Why?
The user should be able to choose if compression should be used on a particular stream or not

### Trials Performed
1. Start uplink with following config
```
[streams.imu]
topic = "/tenants/{tenant_id}/devices/{device_id}/events/imu/jsonarray"
buf_size = 100
compression = "Lz4"
```
2. Attach simulator generating data on multiple streams, including imu
<details>
<summary>uplink logs</summary>
<pre>
```
[2m2023-04-21T18:59:44.714330Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 12 })[0m

  [2m2023-04-21T18:59:44.776613Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/615/events/imu/jsonarray/lz4 with size = 17867[0m

  [2m2023-04-21T18:59:44.776703Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/615/events/device_shadow/jsonarray with size = 190[0m

  [2m2023-04-21T18:59:44.777180Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(13)[0m

  [2m2023-04-21T18:59:44.777269Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(14)[0m

  [2m2023-04-21T18:59:44.857582Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 13 })[0m

  [2m2023-04-21T18:59:44.857671Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 14 })[0m

  [2m2023-04-21T18:59:44.878279Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/615/events/device_shadow/jsonarray with size = 189[0m

  [2m2023-04-21T18:59:44.878665Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(15)[0m

  [2m2023-04-21T18:59:44.918004Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 15 })[0m

  [2m2023-04-21T18:59:44.979271Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/615/events/device_shadow/jsonarray with size = 190[0m

  [2m2023-04-21T18:59:44.979516Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(16)[0m

  [2m2023-04-21T18:59:45.019995Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 16 })[0m

  [2m2023-04-21T18:59:45.080568Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/615/events/device_shadow/jsonarray with size = 190[0m

  [2m2023-04-21T18:59:45.080921Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(17)[0m

  [2m2023-04-21T18:59:45.121334Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 17 })[0m

  [2m2023-04-21T18:59:45.182280Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/615/events/device_shadow/jsonarray with size = 189[0m

  [2m2023-04-21T18:59:45.182429Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(18)[0m

  [2m2023-04-21T18:59:45.228928Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 18 })[0m

  [2m2023-04-21T18:59:45.285300Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/615/events/device_shadow/jsonarray with size = 188[0m

  [2m2023-04-21T18:59:45.285685Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(19)[0m

  [2m2023-04-21T18:59:45.329376Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 19 })[0m

  [2m2023-04-21T18:59:45.387685Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/615/events/device_shadow/jsonarray with size = 189[0m

  [2m2023-04-21T18:59:45.388032Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(20)[0m

  [2m2023-04-21T18:59:45.426989Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 20 })[0m

  [2m2023-04-21T18:59:45.489981Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/615/events/device_shadow/jsonarray with size = 189[0m

  [2m2023-04-21T18:59:45.490367Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(21)[0m

  [2m2023-04-21T18:59:45.529570Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 21 })[0m

  [2m2023-04-21T18:59:45.591943Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/615/events/device_shadow/jsonarray with size = 189[0m

  [2m2023-04-21T18:59:45.592377Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(22)[0m

  [2m2023-04-21T18:59:45.631529Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 22 })[0m

  [2m2023-04-21T18:59:45.694509Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/615/events/device_shadow/jsonarray with size = 190[0m

  [2m2023-04-21T18:59:45.694910Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(23)[0m

  [2m2023-04-21T18:59:45.734906Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 23 })[0m

  [2m2023-04-21T18:59:45.796425Z[0m [34mDEBUG[0m [1;34muplink::base::serializer[0m[34m: [34mpublishing on /tenants/demo/devices/615/events/device_shadow/jsonarray with size = 190[0m

  [2m2023-04-21T18:59:45.796896Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mOutgoing = Publish(24)[0m

  [2m2023-04-21T18:59:45.836732Z[0m [34mDEBUG[0m [1;34muplink::base::mqtt[0m[34m: [34mIncoming = PubAck(PubAck { pkid: 24 })[0m

```
</pre>
</details>

It is noticed that only imu stream's topic has lz4 suffix, it can also be observed that by using an lz4 decompression utility, the contents of this payload can be expanded for further deserialization. This gives us a guarantee that compressibilty can be configured per-stream.