### PR TITLE
feat: trigger shutdown procedures on sigterm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2140,6 +2140,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-tokio"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213241f76fb1e37e27de3b6aa1b068a2c333233b59cca6634f634b80a27ecf1e"
+dependencies = [
+ "futures-core",
+ "libc",
+ "signal-hook",
+ "tokio 1.22.0",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2823,6 +2835,8 @@ dependencies = [
  "rumqttc",
  "serde",
  "serde_json",
+ "signal-hook",
+ "signal-hook-tokio",
  "structopt",
  "sysinfo",
  "tar",

--- a/uplink/Cargo.toml
+++ b/uplink/Cargo.toml
@@ -36,6 +36,8 @@ pretty-bytes = "0.2.2"
 regex = "1.7.1"
 flate2 = "1"
 tar = "0.4"
+signal-hook = "0.3"
+signal-hook-tokio = { version = "0.3", features = ["futures-v0_3"] }
 
 [build-dependencies]
 vergen = { version = "7", features = ["git", "build", "time"] }

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -326,6 +326,7 @@ impl Uplink {
             let rt = tokio::runtime::Builder::new_current_thread()
                 .thread_name("bridge")
                 .enable_time()
+                .enable_io()
                 .build()
                 .unwrap();
 

--- a/uplink/src/main.rs
+++ b/uplink/src/main.rs
@@ -5,6 +5,7 @@ use std::thread;
 
 use anyhow::Error;
 
+use log::info;
 use structopt::StructOpt;
 use tokio::task::JoinSet;
 
@@ -155,6 +156,7 @@ fn main() -> Result<(), Error> {
         }
 
         uplink.resolve_on_shutdown().await.unwrap();
+        info!("Uplink shutting down");
     });
 
     Ok(())


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->
Add the ability to trigger uplink shutdown, i.e. persisting current action on detecting a SIGTERM

### Why?
<!--Detailed description of why the changes had to be made-->

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
Trigger shutdown with SIGINT/SIGTERM during action run on uplink
```
^C  2023-04-29T13:33:33.124109Z  INFO uplink::base::bridge: Storing current action in persistence; path: /tmp/uplink/current_action

  2023-04-29T13:33:33.124246Z  INFO uplink: Uplink shutting down
```
restart uplink once it has stopped:
```
  2023-04-29T13:34:55.805410Z  INFO uplink::base::bridge: Loading saved action from persistence; action_id: 389
```
