### PR TITLE
fix: clear current action only if it triggered error

### DIFF
--- a/uplink/src/base/bridge/mod.rs
+++ b/uplink/src/base/bridge/mod.rs
@@ -299,7 +299,10 @@ impl Bridge {
             error!("Failed to send status. Error = {:?}", e);
         }
 
-        self.clear_current_action();
+        match self.current_action.as_ref() {
+            Some(c) if c.id == action.action_id => self.clear_current_action(),
+            _ => {}
+        }
     }
 }
 

--- a/uplink/src/base/bridge/mod.rs
+++ b/uplink/src/base/bridge/mod.rs
@@ -299,6 +299,7 @@ impl Bridge {
             error!("Failed to send status. Error = {:?}", e);
         }
 
+        // Clear current action only if the error being forwarded was triggered by it
         match self.current_action.as_ref() {
             Some(c) if c.id == action.action_id => self.clear_current_action(),
             _ => {}


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->

### Why?
<!--Detailed description of why the changes had to be made-->
An action that comes in while another is being processed

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
1. Trigger Action 1 from platform.
2. Ensure Action 1 runs on uplink and isn't compete/timedout during the run of this experiment, i.e. set timeout to be large and ensure handler doesn't send completion response.
3. Trigger Action 2 from platform. Failure response received on platform, but action responses from Action 1 aren't dropped anymore.
```   2023-04-29T13:54:08.290683Z  INFO uplink::base::bridge: Action response = ActionResponse { action_id: "391", device_id: None, sequence: 6, timestamp: 1682776448290, state: "Downloading", progress: 5, errors: [], done_response: None }

  2023-04-29T13:54:08.290843Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/615/action/status with size = 107

  2023-04-29T13:54:08.291091Z DEBUG uplink::base::mqtt: Outgoing = Publish(27)

  2023-04-29T13:54:08.383342Z DEBUG uplink::base::mqtt: Incoming = PubAck(PubAck { pkid: 27 })

  2023-04-29T13:54:09.488135Z  INFO uplink::base::bridge: Action response = ActionResponse { action_id: "391", device_id: None, sequence: 7, timestamp: 1682776449488, state: "Downloading", progress: 6, errors: [], done_response: None }

  2023-04-29T13:54:09.488292Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/615/action/status with size = 107

  2023-04-29T13:54:09.488452Z DEBUG uplink::base::mqtt: Outgoing = Publish(28)

  2023-04-29T13:54:09.585047Z DEBUG uplink::base::mqtt: Incoming = PubAck(PubAck { pkid: 28 })

  2023-04-29T13:54:10.911261Z  INFO uplink::base::bridge: Action response = ActionResponse { action_id: "391", device_id: None, sequence: 8, timestamp: 1682776450911, state: "Downloading", progress: 7, errors: [], done_response: None }

  2023-04-29T13:54:10.911463Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/615/action/status with size = 107

  2023-04-29T13:54:10.911836Z DEBUG uplink::base::mqtt: Outgoing = Publish(29)

  2023-04-29T13:54:10.962408Z DEBUG uplink::base::mqtt: Incoming = PubAck(PubAck { pkid: 29 })

  2023-04-29T13:54:11.771055Z DEBUG uplink::base::mqtt: Outgoing = PubAck(2)

  2023-04-29T13:54:11.771121Z  INFO uplink::base::mqtt: Action = Action { device_id: None, action_id: "392", kind: "process", name: "send_file", payload: "{\"file_name\":\"Screenshot from 2023-04-27 10-28-07.png\",\"content-length\":72299,\"id\":\"a1786ec2-eb06-4a6d-b26c-b6d7ff66771a\",\"url\":\"https://firmware.stage.bytebeam.io/api/v1/file/a1786ec2-eb06-4a6d-b26c-b6d7ff66771a/artifact\"}" }

  2023-04-29T13:54:11.771232Z  INFO uplink::base::bridge: Received action: Action { device_id: None, action_id: "392", kind: "process", name: "send_file", payload: "{\"file_name\":\"Screenshot from 2023-04-27 10-28-07.png\",\"content-length\":72299,\"id\":\"a1786ec2-eb06-4a6d-b26c-b6d7ff66771a\",\"url\":\"https://firmware.stage.bytebeam.io/api/v1/file/a1786ec2-eb06-4a6d-b26c-b6d7ff66771a/artifact\"}" }

  2023-04-29T13:54:11.771291Z  WARN uplink::base::bridge: Another action is currently occupying uplink; action_id = 391

  2023-04-29T13:54:11.771313Z DEBUG uplink::base::bridge::stream: Sequence number anomaly! [0, 8

  2023-04-29T13:54:11.771399Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/615/action/status with size = 149

  2023-04-29T13:54:11.771619Z DEBUG uplink::base::mqtt: Outgoing = Publish(30)

  2023-04-29T13:54:11.919887Z DEBUG uplink::base::mqtt: Incoming = PubAck(PubAck { pkid: 30 })

  2023-04-29T13:54:12.059985Z  INFO uplink::base::bridge: Action response = ActionResponse { action_id: "391", device_id: None, sequence: 9, timestamp: 1682776452059, state: "Downloading", progress: 8, errors: [], done_response: None }
```