### PR TITLE
fix: optionalize installer

### DIFF
--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -166,7 +166,7 @@ pub struct Config {
     pub downloader: DownloaderConfig,
     pub system_stats: Stats,
     pub simulator: Option<SimulatorConfig>,
-    pub ota_installer: InstallerConfig,
+    pub ota_installer: Option<InstallerConfig>,
     #[serde(default)]
     pub action_redirections: HashMap<String, String>,
     #[serde(default)]

--- a/uplink/src/collector/installer.rs
+++ b/uplink/src/collector/installer.rs
@@ -1,4 +1,4 @@
-use std::{fs::File, path::PathBuf, sync::Arc};
+use std::{fs::File, path::PathBuf};
 
 use log::{debug, error, warn};
 use tar::Archive;
@@ -6,7 +6,7 @@ use tokio::process::Command;
 
 use super::downloader::DownloadFile;
 use crate::base::{bridge::BridgeTx, InstallerConfig};
-use crate::{Action, ActionResponse, Config};
+use crate::{Action, ActionResponse};
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -26,8 +26,7 @@ pub struct OTAInstaller {
 }
 
 impl OTAInstaller {
-    pub fn new(config: Arc<Config>, bridge_tx: BridgeTx) -> Self {
-        let config = config.ota_installer.clone();
+    pub fn new(config: InstallerConfig, bridge_tx: BridgeTx) -> Self {
         Self { config, bridge_tx }
     }
 

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -95,9 +95,7 @@ pub mod config {
         pub modules: Vec<String>,
     }
 
-    const DEFAULT_CONFIG: &str = r#"
-    action_redirections = { "update_firmware" = "install_firmware" }
-    
+    const DEFAULT_CONFIG: &str = r#"    
     [mqtt]
     max_packet_size = 256000
     max_inflight = 100
@@ -109,7 +107,7 @@ pub mod config {
 
     # Downloader config
     [downloader]
-    actions = [{ name = "update_firmware", timeout = 60 }, { name = "send_file", timeout = 60 }]
+    actions = []
     path = "/var/tmp/ota-file"
 
     [stream_metrics]
@@ -144,14 +142,6 @@ pub mod config {
     enabled = true
     process_names = ["uplink"]
     update_period = 30
-
-    [tcpapps.1]
-    port = 5555
-
-    [ota_installer]
-    path = "/var/tmp/ota"
-    actions = []
-    uplink_port = 5555
 "#;
 
     /// Reads config file to generate config struct and replaces places holders
@@ -390,8 +380,10 @@ impl Uplink {
         let file_downloader = FileDownloader::new(config.clone(), bridge_tx.clone())?;
         thread::spawn(move || file_downloader.start());
 
-        let ota_installer = OTAInstaller::new(config.clone(), bridge_tx.clone());
-        thread::spawn(move || ota_installer.start());
+        if let Some(config) = &config.ota_installer {
+            let ota_installer = OTAInstaller::new(config.clone(), bridge_tx.clone());
+            thread::spawn(move || ota_installer.start());
+        }
 
         #[cfg(any(target_os = "linux", target_os = "android"))]
         {

--- a/uplink/src/main.rs
+++ b/uplink/src/main.rs
@@ -94,10 +94,9 @@ fn banner(commandline: &CommandLine, config: &Arc<Config>) {
         "    downloader:\n\tpath: {}\n\tactions: {:?}",
         config.downloader.path, config.downloader.actions
     );
-    println!(
-        "    installer:\n\tpath: {}\n\tactions: {:?}",
-        config.ota_installer.path, config.ota_installer.actions
-    );
+    if let Some(installer) = &config.ota_installer {
+        println!("    installer:\n\tpath: {}\n\tactions: {:?}", installer.path, installer.actions);
+    }
     if config.system_stats.enabled {
         println!("    processes: {:?}", config.system_stats.process_names);
     }


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->

### Why?
Not all users want to trigger ota_installer when a firmware update completes downloading, keep this feature opt-in and clean-up DEFAULT_CONFIG

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->