### PR TITLE
feat: log processes by unit name in journalctl

### DIFF
--- a/configs/config.toml
+++ b/configs/config.toml
@@ -158,3 +158,18 @@ port = 3333
 # [simulator]
 # num_devices = 10
 # gps_paths = "./paths/"
+
+# Configuration of logger, journalctl in the case of linux. As configured, uplink will 
+# push log lines in batches of size
+# 
+# Required Parameters
+# - tags: syslog identifiers for the processes to be logged
+# - units: names of the systemd units that are to be logged
+# - min_level: priority level by number(7 is Debug, 0 is Emergency)
+# - stream_size: maximum number of log line before the log stream is flushed
+# 
+# [logging]
+# tags = ["systemd"]
+# units = ["collector"]
+# min_level = 7
+# stream_size = 100

--- a/configs/config.toml
+++ b/configs/config.toml
@@ -163,8 +163,8 @@ port = 3333
 # push log lines in batches of size
 # 
 # Required Parameters
-# - tags: syslog identifiers for the processes to be logged
-# - units: names of the systemd units that are to be logged
+# - tags: syslog identifiers for the processes to be logged, e.g. systemd, sshd, kernel
+# - units: names of the systemd units that are to be logged, e.g. collector.service, app.service
 # - min_level: priority level by number(7 is Debug, 0 is Emergency)
 # - stream_size: maximum number of log line before the log stream is flushed
 # 


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->

### Why?
<!--Detailed description of why the changes had to be made-->

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
```
[logging]
units = ["wpa_supplicant"]
min_level = 7
stream_size = 1
```
```
  2023-05-06T08:34:28.256328Z TRACE uplink::base::serializer: Data received on stream: logs; message count = 1; batching latency = 0

  2023-05-06T08:34:28.256365Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/615/events/logs/jsonarray with size = 1343

  2023-05-06T08:34:28.256482Z TRACE uplink::base::serializer: Data received on stream: logs; message count = 1; batching latency = 0

  2023-05-06T08:34:28.256489Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/615/events/logs/jsonarray with size = 1323

 2023-05-06T08:34:28.256779Z TRACE uplink::base::serializer: Data received on stream: logs; message count = 1; batching latency = 0

  2023-05-06T08:34:28.256806Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/615/events/logs/jsonarray with size = 1407

  2023-05-06T08:34:28.257062Z TRACE uplink::base::serializer: Data received on stream: logs; message count = 1; batching latency = 0

  2023-05-06T08:34:28.257081Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/615/events/logs/jsonarray with size = 1391

  2023-05-06T08:34:28.257396Z TRACE uplink::base::serializer: Data received on stream: logs; message count = 1; batching latency = 0

  2023-05-06T08:34:28.257408Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/615/events/logs/jsonarray with size = 1291

  2023-05-06T08:34:28.257755Z TRACE uplink::base::serializer: Data received on stream: logs; message count = 1; batching latency = 0

  2023-05-06T08:34:28.257775Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/615/events/logs/jsonarray with size = 1304

  2023-05-06T08:34:28.258039Z TRACE uplink::base::serializer: Data received on stream: logs; message count = 1; batching latency = 0

  2023-05-06T08:34:28.258068Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/615/events/logs/jsonarray with size = 1371

 2023-05-06T08:34:28.258292Z TRACE uplink::base::serializer: Data received on stream: logs; message count = 1; batching latency = 0

 2023-05-06T08:34:28.258306Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/615/events/logs/jsonarray with size = 1383

   2023-05-06T08:34:28.258493Z TRACE uplink::base::serializer: Data received on stream: logs; message count = 1; batching latency = 0

  2023-05-06T08:34:28.258509Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/615/events/logs/jsonarray with size = 1361

  2023-05-06T08:34:28.258749Z TRACE uplink::base::serializer: Data received on stream: logs; message count = 1; batching latency = 0

  2023-05-06T08:34:28.258764Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/615/events/logs/jsonarray with size = 1362
```
![Screenshot from 2023-05-06 14-07-04](https://user-images.githubusercontent.com/18750864/236613353-396ee6cc-960b-42d4-ad72-c61629eeb6a5.png)

