### PR TITLE
fix: tracing filter

### DIFF
--- a/uplink/src/main.rs
+++ b/uplink/src/main.rs
@@ -29,9 +29,9 @@ fn initialize_logging(commandline: &CommandLine) -> ReloadHandle {
     };
 
     let levels =
-        match commandline.modules.clone().into_iter().reduce(|acc, e| format!("{acc},{e}={level}"))
+        match commandline.modules.clone().into_iter().reduce(|e, acc| format!("{e}={level},{acc}"))
         {
-            Some(f) => f,
+            Some(f) => format!("{f}={level}"),
             _ => format!("uplink={level},disk={level}"),
         };
 


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->
Fixes the tracing filter created from the provided

### Why?
<!--Detailed description of why the changes had to be made-->
currently the filter is being set wrongly(missing level for certain modules):
```
$ cargo run -- -c configs/config.toml -a configs/noauth.json -v -m uplink -m rumqttc
   Compiling uplink v2.1.0 (/home/devdutt/bytebeam/uplink/uplink)
    Finished dev [optimized + debuginfo] target(s) in 2.29s
     Running `target/debug/uplink -c configs/config.toml -a configs/noauth.json -v -m uplink -m rumqttc`
[uplink/src/main.rs:44] levels = "uplink=info,rumqttc"
```

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
```
# Default module list
$ cargo run -- -c configs/config.toml -a configs/noauth.json -v
   Compiling uplink v2.1.0 (/home/devdutt/bytebeam/uplink/uplink)
    Finished dev [optimized + debuginfo] target(s) in 2.16s
     Running `target/debug/uplink -c configs/config.toml -a configs/noauth.json -v`
[uplink/src/main.rs:44] levels = "uplink=info,disk=info"
...
# single module defined
$ cargo run -- -c configs/config.toml -a configs/noauth.json -v -m uplink::base::serializer
    Finished dev [optimized + debuginfo] target(s) in 0.12s
     Running `target/debug/uplink -c configs/config.toml -a configs/noauth.json -v -m 'uplink::base::serializer'`
[uplink/src/main.rs:44] levels = "uplink::base::serializer=info"
...
# multiple modules defined
$ cargo run -- -c configs/config.toml -a configs/noauth.json -v -m uplink::base::mqtt -m disk
    Finished dev [optimized + debuginfo] target(s) in 0.12s
     Running `target/debug/uplink -c configs/config.toml -a configs/noauth.json -v -m 'uplink::base::mqtt' -m disk`
[uplink/src/main.rs:44] levels = "uplink::base::mqtt=info,disk=info"
```