### PR TITLE
fix: use compressed stream topic as is from config

### DIFF
--- a/configs/config.toml
+++ b/configs/config.toml
@@ -91,7 +91,7 @@ buf_size = 1
 persistance = false
 
 [streams.imu]
-topic = "/tenants/{tenant_id}/devices/{device_id}/events/imu/jsonarray"
+topic = "/tenants/{tenant_id}/devices/{device_id}/events/imu/jsonarray/lz4"
 buf_size = 100
 compression = "Lz4"
 

--- a/uplink/src/base/serializer/mod.rs
+++ b/uplink/src/base/serializer/mod.rs
@@ -506,11 +506,10 @@ async fn send_publish<C: MqttClient>(
     Ok(client)
 }
 
-fn lz4_compress(payload: &mut Vec<u8>, topic: &mut String) -> Result<(), Error> {
+fn lz4_compress(payload: &mut Vec<u8>) -> Result<(), Error> {
     let mut compressor = FrameEncoder::new(vec![]);
     compressor.write_all(payload)?;
     *payload = compressor.finish()?;
-    topic.push_str("/lz4");
 
     Ok(())
 }
@@ -522,11 +521,11 @@ fn construct_publish(data: Box<dyn Package>) -> Result<Publish, Error> {
     let batch_latency = data.latency();
     trace!("Data received on stream: {stream}; message count = {point_count}; batching latency = {batch_latency}");
 
-    let mut topic = data.topic().to_string();
+    let topic = data.topic().to_string();
     let mut payload = data.serialize()?;
 
     if let Compression::Lz4 = data.compression() {
-        lz4_compress(&mut payload, &mut topic)?;
+        lz4_compress(&mut payload)?;
     }
 
     Ok(Publish::new(topic, QoS::AtLeastOnce, payload))


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->
Do not change topic onto which data is to be pushed to broker, users to ensure config contains necessary suffixes

### Why?

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->

Using `config.toml` with uplink:
```
  2023-05-10T15:36:46.310382Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/615/events/imu/jsonarray/lz4 with size = 17866
```

Confirmed presence of data in clickhouse from dashboard