### PR TITLE
feat: add throughput values to serializer metrics

### DIFF
--- a/uplink/src/base/serializer/metrics.rs
+++ b/uplink/src/base/serializer/metrics.rs
@@ -31,6 +31,8 @@ pub struct SerializerMetrics {
     total_data_size: usize,
     #[serde(skip_serializing)]
     start_time: Instant,
+    /// Average data size saving by compression in percentage
+    pub avg_data_savings: f64,
 }
 
 impl SerializerMetrics {
@@ -49,6 +51,7 @@ impl SerializerMetrics {
             total_data_size: 0,
             avg_data_rate: 0.0,
             start_time: Instant::now(),
+            avg_data_savings: 0.0,
         }
     }
 
@@ -89,6 +92,8 @@ impl SerializerMetrics {
 
     pub fn add_sent_size(&mut self, size: usize) {
         self.sent_size += size;
+        self.avg_data_savings =
+            (self.total_data_size - self.sent_size) as f64 / self.total_data_size as f64;
     }
 
     pub fn add_data_size(&mut self, size: usize) {
@@ -110,5 +115,6 @@ impl SerializerMetrics {
         self.avg_data_rate = 0.0;
         self.total_data_size = 0;
         self.start_time = Instant::now();
+        self.avg_data_savings = 0.0;
     }
 }

--- a/uplink/src/base/serializer/metrics.rs
+++ b/uplink/src/base/serializer/metrics.rs
@@ -92,14 +92,18 @@ impl SerializerMetrics {
 
     pub fn add_sent_size(&mut self, size: usize) {
         self.sent_size += size;
-        self.avg_data_savings =
-            (self.total_data_size - self.sent_size) as f64 / self.total_data_size as f64;
     }
 
-    pub fn add_data_size(&mut self, size: usize) {
+    pub fn add_payload_size(&mut self, size: usize) {
         self.total_data_size += size;
         self.avg_data_rate =
             self.total_data_size as f64 / self.start_time.elapsed().as_secs() as f64;
+        self.avg_data_savings = if self.total_data_size != 0 {
+            (self.total_data_size as f64 - self.sent_size as f64) * 100.0
+                / self.total_data_size as f64
+        } else {
+            0.0
+        };
     }
 
     pub fn prepare_next(&mut self) {

--- a/uplink/src/base/serializer/mod.rs
+++ b/uplink/src/base/serializer/mod.rs
@@ -258,7 +258,7 @@ impl<C: MqttClient> Serializer<C> {
         let storage = self.storage_handler.select(&publish.topic);
         // Write failed publish to disk first, metrics don't matter
         match write_to_disk(publish, storage) {
-            Ok((_, Some(deleted))) => debug!("Lost segment = {deleted}"),
+            Ok(Some(deleted)) => debug!("Lost segment = {deleted}"),
             Ok(_) => {}
             Err(e) => error!("Crash loop: write error = {:?}", e),
         }
@@ -269,7 +269,7 @@ impl<C: MqttClient> Serializer<C> {
             let publish = construct_publish(data)?;
             let storage = self.storage_handler.select(&publish.topic);
             match write_to_disk(publish, storage) {
-                Ok((_, Some(deleted))) => debug!("Lost segment = {deleted}"),
+                Ok(Some(deleted)) => debug!("Lost segment = {deleted}"),
                 Ok(_) => {}
                 Err(e) => error!("Crash loop: write error = {:?}", e),
             }
@@ -295,15 +295,14 @@ impl<C: MqttClient> Serializer<C> {
                 data = self.collector_rx.recv_async() => {
                     let data = data?;
                     let publish = construct_publish(data)?;
+                    self.metrics.add_payload_size(publish.payload.len());
                     let storage = self.storage_handler.select(&publish.topic);
                     match write_to_disk(publish, storage) {
-                        Ok((s, Some(deleted))) => {
+                        Ok(Some(deleted)) => {
                             debug!("Lost segment = {deleted}");
                             self.metrics.increment_lost_segments();
-                            self.metrics.add_data_size(s);
                         }
-                        Ok((s, _)) => {
-                            self.metrics.add_data_size(s);
+                        Ok(_) => {
                         },
                         Err(e) => {
                             error!("Storage write error = {:?}", e);
@@ -385,16 +384,14 @@ impl<C: MqttClient> Serializer<C> {
                 data = self.collector_rx.recv_async() => {
                     let data = data?;
                     let publish = construct_publish(data)?;
+                    self.metrics.add_payload_size(publish.payload.len());
                     let storage = self.storage_handler.select(&publish.topic);
                     match write_to_disk(publish, storage) {
-                        Ok((s, Some(deleted))) => {
+                        Ok(Some(deleted)) => {
                             debug!("Lost segment = {deleted}");
                             self.metrics.increment_lost_segments();
-                            self.metrics.add_data_size(s);
                         }
-                        Ok((s, _)) => {
-                            self.metrics.add_data_size(s);
-                        },
+                        Ok(_) => {},
                         Err(e) => {
                             error!("Storage write error = {:?}", e);
                             self.metrics.increment_errors();
@@ -462,6 +459,7 @@ impl<C: MqttClient> Serializer<C> {
                     let data = data?;
                     let publish = construct_publish(data)?;
                     let payload_size = publish.payload.len();
+                    self.metrics.add_payload_size(payload_size);
                     debug!("publishing on {} with size = {}", publish.topic, payload_size);
                     match self.client.try_publish(publish.topic, QoS::AtLeastOnce, false, publish.payload) {
                         Ok(_) => {
@@ -542,18 +540,16 @@ fn construct_publish(data: Box<dyn Package>) -> Result<Publish, Error> {
 fn write_to_disk(
     mut publish: Publish,
     storage: &mut Storage,
-) -> Result<(usize, Option<u64>), storage::Error> {
+) -> Result<Option<u64>, storage::Error> {
     publish.pkid = 1;
     let buf = storage.writer();
-    let size_before = buf.len();
     if let Err(e) = publish.write(buf) {
         error!("Failed to fill disk buffer. Error = {:?}", e);
-        return Ok((0, None));
+        return Ok(None);
     }
-    let written = buf.len() - size_before;
 
     let deleted = storage.flush_on_overflow()?;
-    Ok((written, deleted))
+    Ok(deleted)
 }
 
 fn check_metrics(metrics: &mut SerializerMetrics, storage_handler: &StorageHandler) {


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->
Calculate both `avg_data_rate` in Bytes/second and `avg_data_savings` as percentage of data produced by device sent on wire

### Why?
<!--Detailed description of why the changes had to be made-->
Provides throughput metrics that might be helpful to figure out vitals with regards to the pipeline.

NOTE: theoretical gap between receiving data size produced by the device and data size written onto wire should be enough for a metrics flush leading to unintended effects on metrics information captured as snapshot. Practically this has not been noticed as of yet.

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
```
ALTER TABLE demo.uplink_serializer_metrics
    ADD COLUMN `avg_data_savings` Nullable(Float64);
ALTER TABLE demo.uplink_serializer_metrics
    ADD COLUMN `avg_data_rate` Nullable(Float64);
```
![Screenshot from 2023-05-16 15-24-13](https://github.com/bytebeamio/uplink/assets/18750864/0a73929c-271b-4628-9d70-7fc07e60e463)
