### PR TITLE
fix: update backup-deserializer to support uplink v2.3

### DIFF
--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -48,6 +48,10 @@ impl Storage {
         Ok(())
     }
 
+    pub fn set_non_destructive_read(&mut self, switch: bool) {
+        self.persistence.as_mut().unwrap().non_destructive_read = switch;
+    }
+
     pub fn writer(&mut self) -> &mut BytesMut {
         &mut self.current_write_file
     }
@@ -193,6 +197,7 @@ struct Persistence {
     current_read_file_id: Option<u64>,
     // /// Deleted file id
     // deleted: Option<u64>,
+    non_destructive_read: bool,
 }
 
 impl Persistence {
@@ -207,6 +212,7 @@ impl Persistence {
             backlog_files,
             current_read_file_id: None,
             // deleted: None,
+            non_destructive_read: false,
         })
     }
 
@@ -219,6 +225,10 @@ impl Persistence {
 
     /// Removes a file with provided id
     fn remove(&self, id: u64) -> Result<(), Error> {
+        if self.non_destructive_read {
+            return Ok(());
+        }
+
         let path = self.path(id)?;
         fs::remove_file(path)?;
 

--- a/tools/deserialize-backup/Cargo.lock
+++ b/tools/deserialize-backup/Cargo.lock
@@ -105,23 +105,15 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 name = "deserialize-backup"
 version = "0.1.0"
 dependencies = [
- "disk",
+ "bytes",
  "human_bytes",
+ "lz4_flex",
  "rumqttc",
  "serde",
  "serde_json",
+ "storage",
  "structopt",
  "tabled",
- "thiserror",
-]
-
-[[package]]
-name = "disk"
-version = "0.1.0"
-dependencies = [
- "bytes",
- "log",
- "seahash",
  "thiserror",
 ]
 
@@ -320,6 +312,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "lz4_flex"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b8c72594ac26bfd34f2d99dfced2edfaddfe8a476e3ff2ca0eb293d925c4f83"
+dependencies = [
+ "twox-hash",
 ]
 
 [[package]]
@@ -636,6 +637,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "storage"
+version = "0.1.0"
+dependencies = [
+ "bytes",
+ "log",
+ "seahash",
+ "thiserror",
+]
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,6 +793,16 @@ dependencies = [
  "rustls",
  "tokio",
  "webpki",
+]
+
+[[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "static_assertions",
 ]
 
 [[package]]

--- a/tools/deserialize-backup/Cargo.toml
+++ b/tools/deserialize-backup/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-disk = { path = "../../disk" }
+bytes = "1"
+storage = { path = "../../storage" }
 human_bytes = "0.4"
 rumqttc = { git = "https://github.com/bytebeamio/rumqtt" }
 serde = { version = "1", features = ["derive"] }
@@ -12,3 +13,4 @@ serde_json = "1.0"
 structopt = "0.3"
 tabled = "0.11"
 thiserror = "1"
+lz4_flex = "0.10"

--- a/tools/deserialize-backup/Cargo.toml
+++ b/tools/deserialize-backup/Cargo.toml
@@ -5,12 +5,12 @@ edition = "2021"
 
 [dependencies]
 bytes = "1"
-storage = { path = "../../storage" }
 human_bytes = "0.4"
+lz4_flex = "0.10"
 rumqttc = { git = "https://github.com/bytebeamio/rumqtt" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
+storage = { path = "../../storage" }
 structopt = "0.3"
 tabled = "0.11"
 thiserror = "1"
-lz4_flex = "0.10"

--- a/tools/deserialize-backup/src/main.rs
+++ b/tools/deserialize-backup/src/main.rs
@@ -1,6 +1,8 @@
-use std::{collections::HashMap, string::FromUtf8Error};
+use std::{collections::HashMap, io::Read, string::FromUtf8Error};
 
+use bytes::Bytes;
 use human_bytes::human_bytes;
+use lz4_flex::frame::FrameDecoder;
 use rumqttc::{read, Packet};
 use serde::{Deserialize, Serialize};
 use structopt::StructOpt;
@@ -22,8 +24,10 @@ pub struct CommandLine {
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
+    #[error("Io error {0}")]
+    Io(#[from] std::io::Error),
     #[error("Disk error {0}")]
-    Disk(#[from] disk::Error),
+    Disk(#[from] storage::Error),
     #[error("From UTF8 error {0}")]
     FromUtf8(#[from] FromUtf8Error),
     #[error("Serde error {0}")]
@@ -35,16 +39,18 @@ pub struct Payload {
     timestamp: u64,
 }
 
+#[derive(Tabled)]
 struct Stream {
     count: usize,
     size: usize,
+    uncompressed_size: usize,
     start: u64,
     end: u64,
 }
 
 impl Default for Stream {
     fn default() -> Self {
-        Self { count: 0, size: 0, start: u64::MAX, end: 0 }
+        Self { count: 0, size: 0, uncompressed_size: 0, start: u64::MAX, end: 0 }
     }
 }
 
@@ -52,13 +58,16 @@ impl Default for Stream {
 struct Entry {
     stream_name: String,
     serialization_format: String,
+    compression_algo: String,
     count: usize,
     message_rate: String,
     data_size: String,
+    uncompressed_size: String,
     data_rate: String,
+    uncompressed_data_rate: String,
     start_timestamp: u64,
     end_timestamp: u64,
-    milliseconds: u64,
+    milliseconds: i64,
 }
 
 impl Entry {
@@ -66,17 +75,24 @@ impl Entry {
         let tokens: Vec<&str> = topic.split('/').collect();
         let stream_name = tokens[6].to_string();
         let serialization_format = tokens[7].to_string();
-        let milliseconds = stream.end - stream.start;
+        let compression_algo = tokens.get(8).map(|s| s.to_string()).unwrap_or_default();
+        let milliseconds = stream.end as i64 - stream.start as i64;
         let message_rate = format!("{} /s", (stream.count * 1000) as f32 / milliseconds as f32);
         let data_size = human_bytes(stream.size as f64);
+        let uncompressed_size = human_bytes(stream.uncompressed_size as f64);
         let data_rate = human_bytes((stream.size * 1000) as f32 / milliseconds as f32) + "/s";
+        let uncompressed_data_rate =
+            human_bytes((stream.uncompressed_size * 1000) as f32 / milliseconds as f32) + "/s";
 
         Self {
             stream_name,
             serialization_format,
             count: stream.count,
+            compression_algo,
             message_rate,
             data_size,
+            uncompressed_size,
+            uncompressed_data_rate,
             data_rate,
             start_timestamp: stream.start,
             end_timestamp: stream.end,
@@ -87,47 +103,64 @@ impl Entry {
 
 fn main() -> Result<(), Error> {
     let commandline: CommandLine = StructOpt::from_args();
-    // NOTE: max_file_size and max_file_count should not matter when reading non-destructively
-    let mut storage = disk::Storage::new(commandline.directory, 1048576, 3)?;
-    storage.non_destructive_read = true;
 
     let mut streams: HashMap<String, Stream> = HashMap::new();
+    let mut total = Stream::default();
+    let mut entries: Vec<Entry> = vec![];
 
-    'outer: loop {
-        loop {
-            match storage.reload_on_eof() {
-                // Done reading all the pending files
-                Ok(true) => break 'outer,
-                Ok(false) => break,
-                // Reload again on encountering a corrupted file
-                Err(e) => {
-                    eprintln!("Failed to reload from storage. Error = {e}");
-                    continue;
+    let dirs = std::fs::read_dir(commandline.directory)?;
+    for dir in dirs {
+        let dir = dir?;
+        // NOTE: max_file_size and max_file_count should not matter when reading non-destructively
+        let mut storage = storage::Storage::new(1048576);
+        storage.set_persistence(dir.path(), 3)?;
+        storage.set_non_destructive_read(true);
+
+        'outer: loop {
+            loop {
+                match storage.reload_on_eof() {
+                    // Done reading all the pending files
+                    Ok(true) => break 'outer,
+                    Ok(false) => break,
+                    // Reload again on encountering a corrupted file
+                    Err(e) => {
+                        eprintln!("Failed to reload from storage. Error = {e}");
+                        continue;
+                    }
                 }
             }
-        }
 
-        let publish = match read(storage.reader(), commandline.max_packet_size) {
-            Ok(Packet::Publish(publish)) => publish,
-            Ok(packet) => unreachable!("Unexpected packet: {:?}", packet),
-            Err(e) => {
-                eprintln!("Failed to read from storage. Error = {:?}", e);
-                break;
-            }
-        };
-        let stream = streams.entry(publish.topic.to_string()).or_default();
-        stream.size += publish.payload.len();
+            let mut publish = match read(storage.reader(), commandline.max_packet_size) {
+                Ok(Packet::Publish(publish)) => publish,
+                Ok(packet) => unreachable!("Unexpected packet: {:?}", packet),
+                Err(e) => {
+                    eprintln!("Failed to read from storage. Error = {:?}", e);
+                    break;
+                }
+            };
+            let stream = streams.entry(publish.topic.to_string()).or_default();
+            stream.size += publish.payload.len();
 
-        let payloads: Vec<Payload> = serde_json::from_slice(&publish.payload)?;
-        for payload in payloads {
-            let timestamp = payload.timestamp;
-            stream.count += 1;
-            if stream.start > timestamp {
-                stream.start = timestamp
+            if publish.topic.contains("/lz4") {
+                let mut decompressor = FrameDecoder::new(&*publish.payload);
+                let mut bytes = vec![];
+                decompressor.read_to_end(&mut bytes)?;
+                publish.payload = Bytes::from(bytes);
             }
 
-            if stream.end < timestamp {
-                stream.end = timestamp
+            stream.uncompressed_size += publish.payload.len();
+
+            let payloads: Vec<Payload> = serde_json::from_slice(&publish.payload)?;
+            for payload in payloads {
+                let timestamp = payload.timestamp;
+                stream.count += 1;
+                if stream.start > timestamp {
+                    stream.start = timestamp
+                }
+
+                if stream.end < timestamp {
+                    stream.end = timestamp
+                }
             }
         }
     }
@@ -138,8 +171,6 @@ fn main() -> Result<(), Error> {
         return Ok(());
     }
 
-    let mut total = Stream::default();
-    let mut entries: Vec<Entry> = vec![];
     for (topic, stream) in streams.iter() {
         let entry = Entry::new(topic, stream);
         total.count += stream.count;
@@ -160,12 +191,15 @@ fn main() -> Result<(), Error> {
     println!("{}", table);
     println!("NOTE: timestamps are relative to UNIX epoch and in milliseconds and message_rate is in units of points/second");
 
-    println!("\nAggregated values");
+    println!("\nAggregated values (Network Impact)");
     let mut table = Table::new(vec![Entry::new("//////total/jsonarray", &total)]);
     table
         .with(Style::rounded())
         .with(Disable::column(ByColumnName::new("stream_name")))
-        .with(Disable::column(ByColumnName::new("serialization_format")));
+        .with(Disable::column(ByColumnName::new("serialization_format")))
+        .with(Disable::column(ByColumnName::new("compression_algo")))
+        .with(Disable::column(ByColumnName::new("uncompressed_size")))
+        .with(Disable::column(ByColumnName::new("uncompressed_data_rate")));
     println!("{}", table);
 
     Ok(())


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->

### Why?
<!--Detailed description of why the changes had to be made-->

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
Run uplink with certain streams having persistence to disk turned on. Ensuring backlog gets written to disk  because of network issues, disconnect uplink and run the utility on the backlog files:
```
╭─────────────┬──────────────────────┬──────────────────┬───────┬──────────────┬───────────┬───────────────────┬───────────┬────────────────────────┬──────────────────────┬───────────────┬──────────────╮
│ stream_name │ serialization_format │ compression_algo │ count │ message_rate │ data_size │ uncompressed_size │ data_rate │ uncompressed_data_rate │ start_timestamp      │ end_timestamp │ milliseconds │
├─────────────┼──────────────────────┼──────────────────┼───────┼──────────────┼───────────┼───────────────────┼───────────┼────────────────────────┼──────────────────────┼───────────────┼──────────────┤
│ motor       │ jsonarray            │ lz4              │ 2650  │ 3.9685094 /s │ 309.1 KiB │ 636.8 KiB         │ 474 B/s   │ 976.5 B/s              │ 1684388639608        │ 1684389307365 │ 667757       │
│ gps         │ jsonarray            │                  │ 0     │ 0 /s         │ 0 B       │ 0 B               │ 0 B/s     │ 0 B/s                  │ 18446744073709551615 │ 0             │ 1            │
╰─────────────┴──────────────────────┴──────────────────┴───────┴──────────────┴───────────┴───────────────────┴───────────┴────────────────────────┴──────────────────────┴───────────────┴──────────────╯
NOTE: timestamps are relative to UNIX epoch and in milliseconds and message_rate is in units of points/second

Aggregated values (Network Impact)
╭───────┬──────────────┬───────────┬───────────┬─────────────────┬───────────────┬──────────────╮
│ count │ message_rate │ data_size │ data_rate │ start_timestamp │ end_timestamp │ milliseconds │
├───────┼──────────────┼───────────┼───────────┼─────────────────┼───────────────┼──────────────┤
│ 2650  │ 3.9685094 /s │ 309.1 KiB │ 474 B/s   │ 1684388639608   │ 1684389307365 │ 667757       │
╰───────┴──────────────┴───────────┴───────────┴─────────────────┴───────────────┴──────────────╯
```