### PR TITLE
feat: global uplink `persistence_path` in config

### DIFF
--- a/configs/config.toml
+++ b/configs/config.toml
@@ -5,6 +5,9 @@ processes = [{ name = "echo", timeout = 10 }]
 
 action_redirections = { "firmware_update" = "install_update", "send_file" = "load_file" }
 
+# Location on disk for persisted streams to write backlogs into, also used to write
+persistence_path = "/tmp/uplink/"
+
 # MQTT client configuration
 # 
 # Required Parameters
@@ -95,7 +98,7 @@ compression = "Lz4"
 [streams.gps]
 topic = "/tenants/{tenant_id}/devices/{device_id}/events/gps/jsonarray"
 buf_size = 10
-persistence = { path = "/tmp/uplink/", max_file_size = 1048576, max_file_count = 10 }
+persistence = { max_file_size = 1048576, max_file_count = 10 }
 
 # NOTE: While it is possible to configure persistence to be disabled, including only max_file_count
 # without path causes non-persistence. Configuring only the persistence path is allowed and the other
@@ -104,7 +107,7 @@ persistence = { path = "/tmp/uplink/", max_file_size = 1048576, max_file_count =
 topic = "/tenants/{tenant_id}/devices/{device_id}/events/motor/jsonarray/lz4"
 buf_size = 50
 compression = "Lz4"
-persistence = { path = "/tmp/uplink/" }
+persistence = { max_file_count = 3 }
 
 # Built-in streams: action status is a special case of stream and should be configured separately,
 # outside of the streams map. The action_status stream is used to push progress of Actions in

--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -28,8 +28,8 @@ fn default_file_size() -> usize {
     104857600 // 100MB
 }
 
-fn default_file_count() -> usize {
-    3
+fn default_persistence_path() -> PathBuf {
+    PathBuf::from("/var/lib/uplink")
 }
 
 pub fn clock() -> u128 {
@@ -73,21 +73,14 @@ impl Default for StreamConfig {
 pub struct Persistence {
     #[serde(default = "default_file_size")]
     pub max_file_size: usize,
-    #[serde(flatten)]
-    pub disk: Option<Disk>,
+    #[serde(default)]
+    pub max_file_count: usize,
 }
 
 impl Default for Persistence {
     fn default() -> Self {
-        Persistence { max_file_size: default_file_size(), disk: None }
+        Persistence { max_file_size: default_file_size(), max_file_count: 0 }
     }
-}
-
-#[derive(Debug, Clone, Deserialize)]
-pub struct Disk {
-    pub path: PathBuf,
-    #[serde(default = "default_file_count")]
-    pub max_file_count: usize,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -203,6 +196,8 @@ pub struct Config {
     #[serde(skip)]
     pub actions_subscription: String,
     pub streams: HashMap<String, StreamConfig>,
+    #[serde(default = "default_persistence_path")]
+    pub persistence_path: PathBuf,
     pub action_status: StreamConfig,
     pub stream_metrics: StreamMetricsConfig,
     pub serializer_metrics: SerializerMetricsConfig,


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->
1. Move `persistence_path` config to global level.
2. Rewrite persistence to disk to be enabled only when `max_file_count > 0` where 0 is default value.
i.e. requires config to contain the following to enable on-disk persistence:
```
[streams.{stream_name}]
...
persistence = { max_file_count = 10 } # enables on-disk persistence with max-file-count being 10, max_file_size is default value, 100MB. Path is taken from global value or default "/var/lib/uplink"
```

### Why?
<!--Detailed description of why the changes had to be made-->
Ease of config for user

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
Run uplink with updated config.toml and verify write to disk on network disconnect for streams motor and gps. Ensure data is written onto network on reconnection.
```
INFO uplink::base::serializer:              slow: batches = 1530 errors = 0 lost = 2 disk_files = 4   write_memory = 8.58 MB read_memory = 0 B
INFO uplink::base::serializer: Switching to normal mode!!
INFO uplink::base::serializer:            normal: batches = 157 errors = 0 lost = 0 disk_files = 0   write_memory = 0 B read_memory = 0 B
```