### PR TITLE
feat: collector to push ping latency updates on `device_shadow` stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -815,6 +815,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "http"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1240,6 +1246,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "no-std-net"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65"
+
+[[package]]
 name = "nom"
 version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1433,6 +1445,48 @@ name = "pkg-config"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+
+[[package]]
+name = "pnet_base"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d3a993d49e5fd5d4d854d6999d4addca1f72d86c65adf224a36757161c02b6"
+dependencies = [
+ "no-std-net",
+]
+
+[[package]]
+name = "pnet_macros"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48dd52a5211fac27e7acb14cfc9f30ae16ae0e956b7b779c8214c74559cef4c3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn",
+]
+
+[[package]]
+name = "pnet_macros_support"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89de095dc7739349559913aed1ef6a11e73ceade4897dadc77c5e09de6740750"
+dependencies = [
+ "pnet_base",
+]
+
+[[package]]
+name = "pnet_packet"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc3b5111e697c39c8b9795b9fdccbc301ab696699e88b9ea5a4e4628978f495f"
+dependencies = [
+ "glob",
+ "pnet_base",
+ "pnet_macros",
+ "pnet_macros_support",
+]
 
 [[package]]
 name = "pollster"
@@ -2237,6 +2291,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "surge-ping"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d1d85515268a4d0c8dd43f79fae4001d0f47cdce006482b7917af4e3b9fcd79"
+dependencies = [
+ "hex",
+ "parking_lot",
+ "pnet_packet",
+ "rand 0.8.5",
+ "socket2",
+ "thiserror",
+ "tokio 1.22.0",
+ "tracing",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2848,6 +2918,7 @@ dependencies = [
  "signal-hook-tokio",
  "storage",
  "structopt",
+ "surge-ping",
  "sysinfo",
  "tar",
  "tempdir",

--- a/configs/config.toml
+++ b/configs/config.toml
@@ -177,5 +177,9 @@ port = 3333
 # min_level = 7
 # stream_size = 100
 
+# Configurations associated with in-built device-shadow collector
+#
+# Required Parameters
+# - interval: time in seconds after which device-shadow is pushed onto platform, default value is 60
 [device_shadow]
 interval = 30

--- a/configs/config.toml
+++ b/configs/config.toml
@@ -176,3 +176,6 @@ port = 3333
 # units = ["collector"]
 # min_level = 7
 # stream_size = 100
+
+[device_shadow]
+interval = 30

--- a/uplink/Cargo.toml
+++ b/uplink/Cargo.toml
@@ -39,6 +39,7 @@ flate2 = "1"
 tar = "0.4"
 signal-hook = "0.3"
 signal-hook-tokio = { version = "0.3", features = ["futures-v0_3"] }
+surge-ping = "0.7"
 
 [build-dependencies]
 vergen = { version = "7", features = ["git", "build", "time"] }

--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -18,7 +18,6 @@ pub mod mqtt;
 pub mod serializer;
 
 pub const DEFAULT_TIMEOUT: u64 = 60;
-const SHADOW_UPDATE_INTERVAL: u64 = 10;
 
 #[inline]
 fn default_timeout() -> u64 {
@@ -188,7 +187,7 @@ pub struct DeviceShadowConfig {
 
 impl Default for DeviceShadowConfig {
     fn default() -> Self {
-        Self { interval: SHADOW_UPDATE_INTERVAL }
+        Self { interval: DEFAULT_TIMEOUT }
     }
 }
 

--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -18,6 +18,7 @@ pub mod mqtt;
 pub mod serializer;
 
 pub const DEFAULT_TIMEOUT: u64 = 60;
+const SHADOW_UPDATE_INTERVAL: u64 = 10;
 
 #[inline]
 fn default_timeout() -> u64 {
@@ -180,6 +181,17 @@ impl From<&ActionRoute> for ActionRoute {
     }
 }
 
+#[derive(Clone, Debug, Deserialize)]
+pub struct DeviceShadowConfig {
+    pub interval: u64,
+}
+
+impl Default for DeviceShadowConfig {
+    fn default() -> Self {
+        Self { interval: SHADOW_UPDATE_INTERVAL }
+    }
+}
+
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct Config {
     pub project_id: String,
@@ -207,6 +219,8 @@ pub struct Config {
     pub system_stats: Stats,
     pub simulator: Option<SimulatorConfig>,
     pub ota_installer: Option<InstallerConfig>,
+    #[serde(default)]
+    pub device_shadow: DeviceShadowConfig,
     #[serde(default)]
     pub action_redirections: HashMap<String, String>,
     #[serde(default)]

--- a/uplink/src/collector/device_shadow.rs
+++ b/uplink/src/collector/device_shadow.rs
@@ -10,25 +10,25 @@ use crate::Payload;
 pub const UPLINK_VERSION: &str = env!("VERGEN_BUILD_SEMVER");
 
 #[derive(Debug, Serialize)]
-pub struct DeviceShadow {
+struct State {
     uplink_version: String,
     latency: u64,
 }
 
-pub struct DeviceShadowHandler {
+pub struct DeviceShadow {
     config: DeviceShadowConfig,
     bridge: BridgeTx,
     sequence: u32,
-    state: DeviceShadow,
+    state: State,
 }
 
-impl DeviceShadowHandler {
+impl DeviceShadow {
     pub fn new(config: DeviceShadowConfig, bridge: BridgeTx) -> Self {
         Self {
             config,
             bridge,
             sequence: 0,
-            state: DeviceShadow { uplink_version: UPLINK_VERSION.to_owned(), latency: 1000000 },
+            state: State { uplink_version: UPLINK_VERSION.to_owned(), latency: 1000000 },
         }
     }
 

--- a/uplink/src/collector/device_shadow.rs
+++ b/uplink/src/collector/device_shadow.rs
@@ -1,0 +1,75 @@
+use std::time::Duration;
+
+use log::{error, trace};
+use serde::Serialize;
+
+use crate::base::{bridge::BridgeTx, clock};
+use crate::Payload;
+
+pub const UPLINK_VERSION: &str = env!("VERGEN_BUILD_SEMVER");
+
+#[derive(Debug, Serialize)]
+pub struct DeviceShadow {
+    uplink_version: String,
+    latency: u64,
+}
+
+pub struct DeviceShadowHandler {
+    bridge: BridgeTx,
+    sequence: u32,
+    state: DeviceShadow,
+}
+
+impl DeviceShadowHandler {
+    pub fn new(bridge: BridgeTx) -> Self {
+        Self {
+            bridge,
+            sequence: 0,
+            state: DeviceShadow { uplink_version: UPLINK_VERSION.to_owned(), latency: 1000000 },
+        }
+    }
+
+    pub fn snapshot(&mut self) -> Result<Payload, serde_json::Error> {
+        self.sequence += 1;
+        let payload = serde_json::to_value(&self.state)?;
+
+        Ok(Payload {
+            stream: "device_shadow".to_owned(),
+            device_id: None,
+            sequence: self.sequence,
+            timestamp: clock() as u64,
+            payload,
+        })
+    }
+
+    #[tokio::main(flavor = "current_thread")]
+    pub async fn start(mut self) {
+        let ping_addr = "8.8.8.8".parse().unwrap();
+        let ping_payload = [0; 64];
+
+        let mut device_shadow_interval = tokio::time::interval(Duration::from_secs(10));
+
+        loop {
+            _ = device_shadow_interval.tick().await;
+            match surge_ping::ping(ping_addr, &ping_payload).await {
+                Ok((_, duration)) => {
+                    trace!("Ping took {:.3?}", duration);
+                    self.state.latency = duration.as_millis() as u64;
+                }
+                Err(e) => {
+                    error!("pinger: {e}");
+                    continue;
+                }
+            }
+
+            let payload = match self.snapshot() {
+                Ok(v) => v,
+                Err(e) => {
+                    error!("snapshot: {e}");
+                    continue;
+                }
+            };
+            self.bridge.send_payload(payload).await;
+        }
+    }
+}

--- a/uplink/src/collector/device_shadow.rs
+++ b/uplink/src/collector/device_shadow.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use log::{error, trace};
 use serde::Serialize;
 
+use crate::base::DeviceShadowConfig;
 use crate::base::{bridge::BridgeTx, clock};
 use crate::Payload;
 
@@ -15,14 +16,16 @@ pub struct DeviceShadow {
 }
 
 pub struct DeviceShadowHandler {
+    config: DeviceShadowConfig,
     bridge: BridgeTx,
     sequence: u32,
     state: DeviceShadow,
 }
 
 impl DeviceShadowHandler {
-    pub fn new(bridge: BridgeTx) -> Self {
+    pub fn new(config: DeviceShadowConfig, bridge: BridgeTx) -> Self {
         Self {
+            config,
             bridge,
             sequence: 0,
             state: DeviceShadow { uplink_version: UPLINK_VERSION.to_owned(), latency: 1000000 },
@@ -47,7 +50,8 @@ impl DeviceShadowHandler {
         let ping_addr = "8.8.8.8".parse().unwrap();
         let ping_payload = [0; 64];
 
-        let mut device_shadow_interval = tokio::time::interval(Duration::from_secs(10));
+        let mut device_shadow_interval =
+            tokio::time::interval(Duration::from_secs(self.config.interval));
 
         loop {
             _ = device_shadow_interval.tick().await;

--- a/uplink/src/collector/mod.rs
+++ b/uplink/src/collector/mod.rs
@@ -9,3 +9,4 @@ pub mod simulator;
 pub mod systemstats;
 pub mod tcpjson;
 pub mod tunshell;
+pub mod device_shadow;

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -49,7 +49,7 @@ use anyhow::Error;
 use base::bridge::stream::Stream;
 use base::monitor::Monitor;
 use base::Compression;
-use collector::device_shadow::DeviceShadowHandler;
+use collector::device_shadow::DeviceShadow;
 use collector::downloader::FileDownloader;
 use collector::installer::OTAInstaller;
 use collector::process::ProcessHandler;
@@ -393,8 +393,7 @@ impl Uplink {
         let file_downloader = FileDownloader::new(config.clone(), bridge_tx.clone())?;
         thread::spawn(move || file_downloader.start());
 
-        let device_shadow =
-            DeviceShadowHandler::new(config.device_shadow.clone(), bridge_tx.clone());
+        let device_shadow = DeviceShadow::new(config.device_shadow.clone(), bridge_tx.clone());
         thread::spawn(move || device_shadow.start());
 
         if let Some(config) = &config.ota_installer {

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -49,6 +49,7 @@ use anyhow::Error;
 use base::bridge::stream::Stream;
 use base::monitor::Monitor;
 use base::Compression;
+use collector::device_shadow::DeviceShadowHandler;
 use collector::downloader::FileDownloader;
 use collector::installer::OTAInstaller;
 use collector::process::ProcessHandler;
@@ -391,6 +392,9 @@ impl Uplink {
 
         let file_downloader = FileDownloader::new(config.clone(), bridge_tx.clone())?;
         thread::spawn(move || file_downloader.start());
+
+        let device_shadow = DeviceShadowHandler::new(bridge_tx.clone());
+        thread::spawn(move || device_shadow.start());
 
         if let Some(config) = &config.ota_installer {
             let ota_installer = OTAInstaller::new(config.clone(), bridge_tx.clone());

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -393,7 +393,8 @@ impl Uplink {
         let file_downloader = FileDownloader::new(config.clone(), bridge_tx.clone())?;
         thread::spawn(move || file_downloader.start());
 
-        let device_shadow = DeviceShadowHandler::new(bridge_tx.clone());
+        let device_shadow =
+            DeviceShadowHandler::new(config.device_shadow.clone(), bridge_tx.clone());
         thread::spawn(move || device_shadow.start());
 
         if let Some(config) = &config.ota_installer {


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->

### Why?
<!--Detailed description of why the changes had to be made-->
An in-built collector to push device shadow with ping latency and uplink version information has been a requirement for a while now.

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
Create table on clickhouse:
```
CREATE TABLE demo.device_shadow
(
    `id` String,
    `date` Date DEFAULT toDate(timestamp),
    `insert_timestamp` DateTime64(3) DEFAULT now64(),
    `timestamp` DateTime64(3),
    `sequence` UInt32,
    `Status` Nullable(String),
    `mode` Nullable(String),
    `firmware_version` Nullable(String),
    `config_version` Nullable(String),
    `distance_travelled` Nullable(Int64),
    `range` Nullable(Int64),
    `SOC` Nullable(Float64),
    `uplink_version` Nullable(String),
    `latency` Nullable(UInt64)
)
ENGINE = MergeTree
PARTITION BY date
ORDER BY id
SETTINGS index_granularity = 8192
```
NOTE: All we care about are `uplink_version` and `latency`.

With uplink running with device_id 615, we get the following result:
```
┌─id──┬───────date─┬────────insert_timestamp─┬───────────────timestamp─┬─sequence─┬─Status─┬─mode─┬─firmware_version─┬─config_version─┬─distance_travelled─┬─range─┬──SOC─┬─uplink_version─┬─latency─┐
│ 615 │ 2023-05-26 │ 2023-05-26 16:29:26.281 │ 2023-05-26 16:29:20.195 │        1 │ ᴺᵁᴸᴸ   │ ᴺᵁᴸᴸ │ ᴺᵁᴸᴸ             │ ᴺᵁᴸᴸ           │               ᴺᵁᴸᴸ │  ᴺᵁᴸᴸ │ ᴺᵁᴸᴸ │ 2.3.0          │      18 │
│ 615 │ 2023-05-26 │ 2023-05-26 16:29:31.412 │ 2023-05-26 16:29:30.195 │        2 │ ᴺᵁᴸᴸ   │ ᴺᵁᴸᴸ │ ᴺᵁᴸᴸ             │ ᴺᵁᴸᴸ           │               ᴺᵁᴸᴸ │  ᴺᵁᴸᴸ │ ᴺᵁᴸᴸ │ 2.3.0          │      17 │
│ 615 │ 2023-05-26 │ 2023-05-26 16:29:41.755 │ 2023-05-26 16:29:40.195 │        3 │ ᴺᵁᴸᴸ   │ ᴺᵁᴸᴸ │ ᴺᵁᴸᴸ             │ ᴺᵁᴸᴸ           │               ᴺᵁᴸᴸ │  ᴺᵁᴸᴸ │ ᴺᵁᴸᴸ │ 2.3.0          │      17 │
│ 615 │ 2023-05-26 │ 2023-05-26 16:29:52.063 │ 2023-05-26 16:29:50.203 │        4 │ ᴺᵁᴸᴸ   │ ᴺᵁᴸᴸ │ ᴺᵁᴸᴸ             │ ᴺᵁᴸᴸ           │               ᴺᵁᴸᴸ │  ᴺᵁᴸᴸ │ ᴺᵁᴸᴸ │ 2.3.0          │      24 │
│ 615 │ 2023-05-26 │ 2023-05-26 16:30:02.477 │ 2023-05-26 16:30:00.196 │        5 │ ᴺᵁᴸᴸ   │ ᴺᵁᴸᴸ │ ᴺᵁᴸᴸ             │ ᴺᵁᴸᴸ           │               ᴺᵁᴸᴸ │  ᴺᵁᴸᴸ │ ᴺᵁᴸᴸ │ 2.3.0          │      17 │
│ 615 │ 2023-05-26 │ 2023-05-26 16:30:12.867 │ 2023-05-26 16:30:10.194 │        6 │ ᴺᵁᴸᴸ   │ ᴺᵁᴸᴸ │ ᴺᵁᴸᴸ             │ ᴺᵁᴸᴸ           │               ᴺᵁᴸᴸ │  ᴺᵁᴸᴸ │ ᴺᵁᴸᴸ │ 2.3.0          │      16 │
└─────┴────────────┴─────────────────────────┴─────────────────────────┴──────────┴────────┴──────┴──────────────────┴────────────────┴────────────────────┴───────┴──────┴────────────────┴─────────┘
┌─id──┬───────date─┬────────insert_timestamp─┬───────────────timestamp─┬─sequence─┬─Status─┬─mode─┬─firmware_version─┬─config_version─┬─distance_travelled─┬─range─┬──SOC─┬─uplink_version─┬─latency─┐
│ 615 │ 2023-05-26 │ 2023-05-26 16:30:23.296 │ 2023-05-26 16:30:20.196 │        7 │ ᴺᵁᴸᴸ   │ ᴺᵁᴸᴸ │ ᴺᵁᴸᴸ             │ ᴺᵁᴸᴸ           │               ᴺᵁᴸᴸ │  ᴺᵁᴸᴸ │ ᴺᵁᴸᴸ │ 2.3.0          │      18 │
└─────┴────────────┴─────────────────────────┴─────────────────────────┴──────────┴────────┴──────┴──────────────────┴────────────────┴────────────────────┴───────┴──────┴────────────────┴─────────┘
```

