### PR TITLE
set file perms

### DIFF
--- a/uplink/src/collector/downloader.rs
+++ b/uplink/src/collector/downloader.rs
@@ -212,6 +212,9 @@ impl FileDownloader {
             }
         }
         let file = File::create(file_path)?;
+        #[cfg(unix)]
+        file.set_permissions(std::os::unix::fs::PermissionsExt::from_mode(0o666))?;
+
         let file_path = file_path.to_str().ok_or(Error::FilePathMissing)?.to_owned();
 
         Ok((file, file_path))


### PR DESCRIPTION

### Changes
Set permissions for downloaded files.

### Why?
Without this, the downloaded file will have different permissions on different devices.

### Trials Performed
Tested on client devices that permissions are set properly