### PR TITLE
fix: ensure updater is executable

### DIFF
--- a/uplink/src/collector/installer.rs
+++ b/uplink/src/collector/installer.rs
@@ -78,6 +78,13 @@ impl OTAInstaller {
         let updater_path = PathBuf::from(self.config.path.clone()).join("updater");
         debug!("Running updater: {}/updater", self.config.path);
 
+        // Ensure updater has execution rights
+        #[cfg(unix)]
+        {
+            let file = File::open(&updater_path)?;
+            file.set_permissions(std::os::unix::fs::PermissionsExt::from_mode(0o777))?;
+        }
+
         let mut cmd = Command::new(updater_path.as_path());
         cmd.arg(&action.action_id).arg(self.config.uplink_port.to_string());
         cmd.spawn()?;


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->

### Why?
```
  2023-06-06T21:02:04.785357Z ERROR uplink::collector::installer: Error installing ota update: File io Error: Permission denied (os error 13)

  2023-06-06T21:02:04.785408Z  INFO uplink::base::bridge: Action response = ActionResponse { action_id: "719", device_id: None, sequence: 0, timestamp: 1686085324785, state: "Failed", progress: 100, errors: ["File io Error: Permission denied (os error 13)"], done_response: None }
```

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
1. Create shell script `updater`, that prints "Hello, World!" to stdout
2. Compile a tar file  containing aforementioned `updater` script
3. Create and push download and install action from platform ("send_file" => "load_file" in this case)
```
  2023-06-06T21:07:19.317582Z  INFO uplink::collector::downloader: Downloading from https://firmware.stage.bytebeam.io/api/v1/file/ca74b7ef-c0a7-49c5-b321-593ba67512e5/artifact into /tmp/download/send_file/update.tar

  2023-06-06T21:07:19.317758Z  INFO uplink::base::bridge: Action response = ActionResponse { action_id: "720", device_id: None, sequence: 2, timestamp: 1686085639317, state: "Downloading", progress: 77, errors: [], done_response: None }

  2023-06-06T21:07:19.317795Z TRACE uplink::base::bridge::stream: Flushing stream name: action_status, topic: /tenants/demo/devices/1001/action/status

  2023-06-06T21:07:19.317811Z  INFO uplink::collector::downloader: Firmware downloaded successfully

  2023-06-06T21:07:19.317814Z  INFO uplink::base::bridge: Action response = ActionResponse { action_id: "720", device_id: None, sequence: 3, timestamp: 1686085639317, state: "Downloading", progress: 99, errors: [], done_response: None }

  2023-06-06T21:07:19.317821Z TRACE uplink::base::bridge::stream: Flushing stream name: action_status, topic: /tenants/demo/devices/1001/action/status

  2023-06-06T21:07:19.317832Z TRACE uplink::base::serializer: Data received on stream: action_status; message count = 1; batching latency = 0

  2023-06-06T21:07:19.317871Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/action/status with size = 108

  2023-06-06T21:07:19.317887Z TRACE uplink::base::serializer: Data received on stream: action_status; message count = 1; batching latency = 0

  2023-06-06T21:07:19.317891Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/action/status with size = 108

  2023-06-06T21:07:19.317915Z  INFO uplink::base::bridge: Action response = ActionResponse { action_id: "720", device_id: None, sequence: 4, timestamp: 1686085639317, state: "Downloaded", progress: 100, errors: [], done_response: Some(Action { device_id: None, action_id: "720", kind: "process", name: "send_file", payload: "{\"url\":\"https://firmware.stage.bytebeam.io/api/v1/file/ca74b7ef-c0a7-49c5-b321-593ba67512e5/artifact\",\"content_length\":10240,\"file_name\":\"update.tar\",\"download_path\":\"/tmp/download/send_file/update.tar\"}" }) }

  2023-06-06T21:07:19.317933Z TRACE uplink::base::bridge::stream: Flushing stream name: action_status, topic: /tenants/demo/devices/1001/action/status

  2023-06-06T21:07:19.317965Z DEBUG rumqttc::state: Publish. Topic = /tenants/demo/devices/1001/action/status, Pkid = 7, Payload Size = 108

  2023-06-06T21:07:19.317974Z DEBUG uplink::collector::installer: Extracting tar from:/tmp/download/send_file/update.tar; to: /tmp/ota

  2023-06-06T21:07:19.318004Z  WARN uplink::collector::installer: Cleaning up /tmp/ota

  2023-06-06T21:07:19.318041Z TRACE uplink::base::serializer: Data received on stream: action_status; message count = 1; batching latency = 0

  2023-06-06T21:07:19.318049Z DEBUG uplink::base::mqtt: Outgoing = Publish(7)

  2023-06-06T21:07:19.318057Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/action/status with size = 108

  2023-06-06T21:07:19.318062Z DEBUG rumqttc::state: Publish. Topic = /tenants/demo/devices/1001/action/status, Pkid = 8, Payload Size = 108

  2023-06-06T21:07:19.318081Z DEBUG uplink::base::mqtt: Outgoing = Publish(8)

  2023-06-06T21:07:19.318088Z DEBUG rumqttc::state: Publish. Topic = /tenants/demo/devices/1001/action/status, Pkid = 9, Payload Size = 108

  2023-06-06T21:07:19.318099Z DEBUG uplink::base::mqtt: Outgoing = Publish(9)

  2023-06-06T21:07:19.318422Z DEBUG uplink::collector::installer: Running updater: /tmp/ota/updater

Hello, World!
```