### PR TITLE
fix: bridge failure to shutdown on file permission denied

### DIFF
--- a/uplink/src/base/bridge/mod.rs
+++ b/uplink/src/base/bridge/mod.rs
@@ -267,7 +267,6 @@ impl Bridge {
             None => return Ok(()),
         };
         let mut path = self.config.persistence_path.clone();
-        fs::create_dir_all(&path)?;
         path.push("current_action");
         info!("Storing current action in persistence; path: {}", path.display());
         current_action.write_to_disk(path)?;

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -158,6 +158,14 @@ pub mod config {
 
         let mut config: Config = config.try_deserialize()?;
 
+        // Create directory at persistence_path if it doesn't already exist
+        fs::create_dir_all(&config.persistence_path).map_err(|_| {
+            anyhow::Error::msg(format!(
+                "Permission denied for creating persistence directory at \"{}\"",
+                config.persistence_path.display()
+            ))
+        })?;
+
         // replace placeholders with device/tenant ID
         let tenant_id = config.project_id.trim();
         let device_id = config.device_id.trim();

--- a/uplink/src/main.rs
+++ b/uplink/src/main.rs
@@ -68,6 +68,7 @@ fn banner(commandline: &CommandLine, config: &Arc<Config>) {
     println!("    project_id: {}", config.project_id);
     println!("    device_id: {}", config.device_id);
     println!("    remote: {}:{}", config.broker, config.port);
+    println!("    persistence_path: {}", config.persistence_path.display());
     if !config.action_redirections.is_empty() {
         println!("    action redirections:");
         for (action, redirection) in config.action_redirections.iter() {


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->
`create_dir_all` in initialization code ensures failure happens before uplink starts operation.

### Why?
```
  2023-06-07T07:42:37.707400Z  INFO uplink::base::bridge: Action response = ActionResponse { action_id: "739", device_id: None, sequence: 1, timestamp: 1686123757707, state: "Downloading", progress: 0, errors: [], done_response: None }

  2023-06-07T07:42:37.707405Z TRACE uplink::base::bridge::stream: Flushing stream name: action_status, topic: /tenants/demo/devices/1001/action/status

  2023-06-07T07:42:37.707566Z TRACE uplink::base::serializer: Data received on stream: action_status; message count = 1; batching latency = 0

  2023-06-07T07:42:37.707602Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/action/status with size = 104

  2023-06-07T07:42:37.707619Z TRACE uplink::base::serializer: Data received on stream: action_status; message count = 1; batching latency = 0

  2023-06-07T07:42:37.707625Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/action/status with size = 107

  2023-06-07T07:42:37.707688Z DEBUG rumqttc::state: Publish. Topic = /tenants/demo/devices/1001/action/status, Pkid = 6, Payload Size = 104

  2023-06-07T07:42:37.707737Z DEBUG uplink::base::mqtt: Outgoing = Publish(6)

  2023-06-07T07:42:37.707746Z DEBUG rumqttc::state: Publish. Topic = /tenants/demo/devices/1001/action/status, Pkid = 7, Payload Size = 107

  2023-06-07T07:42:37.707755Z DEBUG uplink::base::mqtt: Outgoing = Publish(7)

  2023-06-07T07:42:37.823008Z DEBUG uplink::base::mqtt: Incoming = PubAck(PubAck { pkid: 6 })

  2023-06-07T07:42:37.823054Z DEBUG uplink::base::mqtt: Incoming = PubAck(PubAck { pkid: 7 })

^C  2023-06-07T07:42:39.284751Z ERROR uplink: Bridge stopped!! Error = Io(Os { code: 13, kind: PermissionDenied, message: "Permission denied" })

  2023-06-07T07:42:39.447791Z  INFO uplink::collector::downloader: Downloading from https://firmware.stage.bytebeam.io/api/v1/file/c5f2320a-9eb2-4cc6-82a1-f6b32571df19/artifact into /tmp/download/send_file/update.tar

thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: "SendError(..)"', uplink/src/base/bridge/mod.rs:514:48
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
  2023-06-07T07:42:40.323872Z  INFO uplink::base::serializer:            normal: batches = 2   errors = 0 lost = 0 disk_files = 0   write_memory = 0 B read_memory = 0 B

  2023-06-07T07:42:40.324052Z DEBUG rumqttc::state: Publish. Topic = /tenants/demo/devices/1001/events/uplink_serializer_metrics/jsonarray, Pkid = 8, Payload Size = 163

  2023-06-07T07:42:40.324141Z DEBUG uplink::base::mqtt: Outgoing = Publish(8)

  2023-06-07T07:42:40.355097Z DEBUG uplink::base::mqtt: Incoming = PubAck(PubAck { pkid: 8 })

  2023-06-07T07:43:00.341700Z TRACE uplink::collector::device_shadow: Ping took 17.508ms

thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: "SendError(..)"', uplink/src/base/bridge/mod.rs:504:48
```

### Trials Performed
1. Start uplink with persistence(un-permitted/permitted) directory, ensure no streams are configured (uplink should fail here if un-permitted)
> `Error: Permission denied for creating persistence directory at "/var/lib/uplink"`
2. Trigger action from platform
3. Shutdown uplink before action finishes
4. Uplink should shutdown without error, writing action details to `current_action` file in `persistence_path`