### PR TITLE
feat: prometheus collector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,6 +31,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,6 +249,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "num-traits",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "clap"
 version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,9 +367,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.14"
+version = "0.9.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
+checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
 dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
@@ -353,9 +380,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -378,9 +405,9 @@ dependencies = [
 
 [[package]]
 name = "crossterm_winapi"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ae1b35a484aa10e07fe0638d02301c5ad24de82d310ccbd2f3693da5f09bf1c"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi 0.3.9",
 ]
@@ -915,6 +942,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "idna"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -988,6 +1038,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
 
 [[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1004,9 +1063,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.63"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f37a4a5928311ac501dee68b3c7613a1037d0edb30c8e5427bd832d55d1b790"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1075,9 +1134,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
+checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
 name = "lz4_flex"
@@ -1111,9 +1170,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
 ]
@@ -1290,6 +1349,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
 dependencies = [
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1585,6 +1653,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prometheus-parse"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c2aa5feb83bf4b2c8919eaf563f51dbab41183de73ba2353c0e03cd7b6bd892"
+dependencies = [
+ "chrono",
+ "itertools",
+ "once_cell",
+ "regex",
 ]
 
 [[package]]
@@ -1907,9 +1987,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.19"
+version = "0.37.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
+checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
 dependencies = [
  "bitflags",
  "errno 0.3.1",
@@ -2965,6 +3045,7 @@ dependencies = [
  "log",
  "lz4_flex",
  "pretty-bytes",
+ "prometheus-parse",
  "rand 0.8.5",
  "regex",
  "reqwest",
@@ -3080,9 +3161,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -3090,9 +3171,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
  "log",
@@ -3105,9 +3186,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.36"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1985d03709c53167ce907ff394f5316aa22cb4e12761295c5dc57dacb6297e"
+checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -3117,9 +3198,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3127,9 +3208,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3140,9 +3221,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "wasm-streams"
@@ -3159,9 +3240,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.63"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bdd9ef4e984da1187bf8110c5cf5b845fbc87a23602cdf912386a76fcd3a7c2"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3259,6 +3340,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"

--- a/uplink/Cargo.toml
+++ b/uplink/Cargo.toml
@@ -40,6 +40,7 @@ tar = "0.4"
 signal-hook = "0.3"
 signal-hook-tokio = { version = "0.3", features = ["futures-v0_3"] }
 surge-ping = "0.8"
+prometheus-parse = "0.2.4"
 
 [build-dependencies]
 vergen = { version = "7", features = ["git", "build", "time"] }

--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -193,6 +193,7 @@ impl Default for DeviceShadowConfig {
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct PrometheusConfig {
+    pub stream_name: String,
     pub endpoint: String,
     pub interval: u64,
 }

--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -191,6 +191,12 @@ impl Default for DeviceShadowConfig {
     }
 }
 
+#[derive(Clone, Debug, Deserialize)]
+pub struct PrometheusConfig {
+    pub endpoint: String,
+    pub interval: u64,
+}
+
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct Config {
     pub project_id: String,
@@ -218,6 +224,7 @@ pub struct Config {
     pub system_stats: Stats,
     pub simulator: Option<SimulatorConfig>,
     pub ota_installer: Option<InstallerConfig>,
+    pub prometheus: Option<PrometheusConfig>,
     #[serde(default)]
     pub device_shadow: DeviceShadowConfig,
     #[serde(default)]

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -60,6 +60,7 @@ use log::error;
 
 pub mod base;
 pub mod collector;
+mod prometheus;
 
 pub mod config {
     use crate::base::{bridge::stream::MAX_BUFFER_SIZE, StreamConfig};
@@ -277,6 +278,7 @@ use base::mqtt::Mqtt;
 use base::serializer::{Serializer, SerializerMetrics};
 pub use base::{ActionRoute, Config};
 pub use collector::{simulator, tcpjson::TcpJson};
+use prometheus::Prometheus;
 pub use storage::Storage;
 
 pub struct Uplink {
@@ -439,6 +441,11 @@ impl Uplink {
             self.serializer_metrics_rx.clone(),
             mqtt_metrics_rx,
         );
+
+        if let Some(config) = self.config.prometheus.clone() {
+            let prometheus = Prometheus::new(config);
+            thread::spawn(|| prometheus.start());
+        }
 
         // Metrics monitor thread
         thread::spawn(|| {

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -443,7 +443,7 @@ impl Uplink {
         );
 
         if let Some(config) = self.config.prometheus.clone() {
-            let prometheus = Prometheus::new(config);
+            let prometheus = Prometheus::new(config, bridge_tx.clone());
             thread::spawn(|| prometheus.start());
         }
 

--- a/uplink/src/prometheus.rs
+++ b/uplink/src/prometheus.rs
@@ -5,7 +5,10 @@ use prometheus_parse::Scrape;
 use reqwest::{Client, Method};
 use serde_json::{Map, Number, Value};
 
-use crate::base::PrometheusConfig;
+use crate::base::{
+    bridge::{BridgeTx, Payload},
+    clock, PrometheusConfig,
+};
 
 #[derive(Debug, thiserror::Error)]
 enum Error {
@@ -18,48 +21,62 @@ enum Error {
 pub struct Prometheus {
     config: PrometheusConfig,
     client: Client,
+    tx: BridgeTx,
 }
 
 impl Prometheus {
-    pub fn new(config: PrometheusConfig) -> Self {
-        Self { client: Client::new(), config }
+    pub fn new(config: PrometheusConfig, tx: BridgeTx) -> Self {
+        Self { client: Client::new(), config, tx }
     }
 
     #[tokio::main]
     pub async fn start(self) {
+        let mut sequence = 0;
         loop {
-            if let Err(e) = self.query().await {
-                error!("{e}")
+            match self.query().await {
+                Ok(payload) => {
+                    sequence += 1;
+                    let payload = Payload {
+                        stream: self.config.stream_name.clone(),
+                        device_id: None,
+                        sequence,
+                        timestamp: clock() as u64,
+                        payload,
+                    };
+                    self.tx.send_payload(payload).await
+                }
+                Err(e) => error!("{e}"),
             }
 
             tokio::time::sleep(Duration::from_secs(self.config.interval)).await;
         }
     }
 
-    async fn query(&self) -> Result<(), Error> {
+    async fn query(&self) -> Result<Value, Error> {
         let resp = self.client.request(Method::GET, &self.config.endpoint).send().await?;
         let lines: Vec<_> = resp.text().await?.lines().map(|s| Ok(s.to_owned())).collect();
         let metrics = Scrape::parse(lines.into_iter())?;
 
         let mut json = Map::new();
         for sample in metrics.samples {
-            let count = match sample.value {
+            let num = match sample.value {
                 prometheus_parse::Value::Counter(c) => c,
+                prometheus_parse::Value::Gauge(g) => g,
                 v => {
                     warn!("Unexpected value: {v:?}");
                     continue;
                 }
             };
-            let count = match Number::from_f64(count) {
+            let num = match Number::from_f64(num) {
                 Some(c) => c,
                 _ => {
-                    warn!("Couldn't parse number: {count}");
+                    warn!("Couldn't parse number: {num}");
                     continue;
                 }
             };
-            json.insert(sample.metric, Value::Number(count));
+            json.insert(sample.metric, Value::Number(num));
         }
 
-        Ok(())
+        Ok(Value::Object(json))
     }
 }

--- a/uplink/src/prometheus.rs
+++ b/uplink/src/prometheus.rs
@@ -1,0 +1,65 @@
+use std::time::Duration;
+
+use log::{error, warn};
+use prometheus_parse::Scrape;
+use reqwest::{Client, Method};
+use serde_json::{Map, Number, Value};
+
+use crate::base::PrometheusConfig;
+
+#[derive(Debug, thiserror::Error)]
+enum Error {
+    #[error("Reqwest client error: {0}")]
+    Reqwest(#[from] reqwest::Error),
+    #[error("Io error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+pub struct Prometheus {
+    config: PrometheusConfig,
+    client: Client,
+}
+
+impl Prometheus {
+    pub fn new(config: PrometheusConfig) -> Self {
+        Self { client: Client::new(), config }
+    }
+
+    #[tokio::main]
+    pub async fn start(self) {
+        loop {
+            if let Err(e) = self.query().await {
+                error!("{e}")
+            }
+
+            tokio::time::sleep(Duration::from_secs(self.config.interval)).await;
+        }
+    }
+
+    async fn query(&self) -> Result<(), Error> {
+        let resp = self.client.request(Method::GET, &self.config.endpoint).send().await?;
+        let lines: Vec<_> = resp.text().await?.lines().map(|s| Ok(s.to_owned())).collect();
+        let metrics = Scrape::parse(lines.into_iter())?;
+
+        let mut json = Map::new();
+        for sample in metrics.samples {
+            let count = match sample.value {
+                prometheus_parse::Value::Counter(c) => c,
+                v => {
+                    warn!("Unexpected value: {v:?}");
+                    continue;
+                }
+            };
+            let count = match Number::from_f64(count) {
+                Some(c) => c,
+                _ => {
+                    warn!("Couldn't parse number: {count}");
+                    continue;
+                }
+            };
+            json.insert(sample.metric, Value::Number(count));
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->

### Why?
Required prometheus metrics collector that parses text serialized format into JSON, pushes onto platform appropriate stream

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
Run uplink with following config values included:
```
[prometheus]
endpoint = "http://localhost:9090/metrics"
stream_name = "prometheus_metrics"
interval = 5

[streams.prometheus_metrics]
topic = "/tenants/{tenant_id}/devices/{device_id}/events/prometheus_metrics/jsonarray"
buf_size = 1
```

Observation: It can be observed that we are receiving the collected values as JSON at appropriate interval on beamd.