### PR TITLE
feat: restart download if saved action

### DIFF
--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -172,6 +172,8 @@ pub struct ActionRoute {
     pub name: String,
     #[serde(default = "default_timeout")]
     pub timeout: u64,
+    #[serde(skip)]
+    pub resend: bool,
 }
 
 impl From<&ActionRoute> for ActionRoute {

--- a/uplink/src/collector/downloader.rs
+++ b/uplink/src/collector/downloader.rs
@@ -308,7 +308,11 @@ mod test {
         std::fs::create_dir_all(DOWNLOAD_DIR).unwrap();
         // Prepare config
         let downloader_cfg = DownloaderConfig {
-            actions: vec![ActionRoute { name: "firmware_update".to_owned(), timeout: 10 }],
+            actions: vec![ActionRoute {
+                name: "firmware_update".to_owned(),
+                timeout: 10,
+                resend: true,
+            }],
             path: format!("{DOWNLOAD_DIR}/uplink-test"),
         };
         let config = config(downloader_cfg.clone());
@@ -384,7 +388,11 @@ mod test {
         std::fs::create_dir_all(DOWNLOAD_DIR).unwrap();
         // Prepare config
         let downloader_cfg = DownloaderConfig {
-            actions: vec![ActionRoute { name: "firmware_update".to_owned(), timeout: 10 }],
+            actions: vec![ActionRoute {
+                name: "firmware_update".to_owned(),
+                timeout: 10,
+                resend: true,
+            }],
             path: format!("{}/download", DOWNLOAD_DIR),
         };
         let config = config(downloader_cfg.clone());

--- a/uplink/src/collector/journalctl.rs
+++ b/uplink/src/collector/journalctl.rs
@@ -129,6 +129,7 @@ impl JournalCtl {
             .register_action_route(ActionRoute {
                 name: "journalctl_config".to_string(),
                 timeout: 10,
+                resend: false,
             })
             .await;
 

--- a/uplink/src/collector/logcat.rs
+++ b/uplink/src/collector/logcat.rs
@@ -172,7 +172,11 @@ impl Logcat {
 
         let log_rx = self
             .bridge
-            .register_action_route(ActionRoute { name: "logcat_config".to_string(), timeout: 10 })
+            .register_action_route(ActionRoute {
+                name: "logcat_config".to_string(),
+                timeout: 10,
+                resend: false,
+            })
             .await;
 
         loop {

--- a/uplink/src/collector/tunshell.rs
+++ b/uplink/src/collector/tunshell.rs
@@ -43,7 +43,7 @@ impl TunshellSession {
 
     #[tokio::main(flavor = "current_thread")]
     pub async fn start(self) {
-        let route = ActionRoute { name: "launch_shell".to_owned(), timeout: 10 };
+        let route = ActionRoute { name: "launch_shell".to_owned(), timeout: 10, resend: false };
         let actions_rx = self.bridge.register_action_route(route).await;
 
         while let Ok(action) = actions_rx.recv_async().await {

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -207,6 +207,11 @@ pub mod config {
             }
         }
 
+        // NOTE: download actions must be resend on load from save file
+        for route in config.downloader.actions.iter_mut() {
+            route.resend = true
+        }
+
         #[cfg(any(target_os = "linux", target_os = "android"))]
         if let Some(buf_size) = config.logging.as_ref().and_then(|c| c.stream_size) {
             let stream_config =


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
If saved action on restart is a download action, ensure it is resent to downloader, else wait for timeout or success as usual.

### Why?
Customer seeing uplink reporting failure on devices where uplink restarts before download completion, where it should instead restart the download and allow appropriate time for completion. In this case uplink forwards the action to downloader and allows full duration for download completion instead of waiting for response and failing on timeout as was done earlier. NOTE: The change in behaviour is directed only towards routes handled by downloader.

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
1. Start uplink with appropriate config for downloader, trigger large download action from platform.
2. Restart uplink before download reaches completion.
3. Notice that uplink re-triggers download on loading from save file.