### PR TITLE
feat: force flush all streams before shutdown

### DIFF
--- a/uplink/src/base/bridge/mod.rs
+++ b/uplink/src/base/bridge/mod.rs
@@ -253,8 +253,11 @@ impl Bridge {
                 // Handle a shutdown signal
                 _ = self.ctrl_rx.recv_async() => {
                     self.save_current_action()?;
-
+                    streams.flush_all().await;
+                    // NOTE: there might be events still waiting for recv on bridge_rx
                     self.shutdown_handle.send(()).unwrap();
+
+                    return Ok(())
                 }
             }
         }

--- a/uplink/src/base/bridge/streams.rs
+++ b/uplink/src/base/bridge/streams.rs
@@ -97,6 +97,16 @@ impl Streams {
         }
     }
 
+    /// Flush all streams, use on bridge shutdown
+    pub async fn flush_all(&mut self) {
+        for (stream_name, stream) in self.map.iter_mut() {
+            match stream.flush().await {
+                Err(e) => error!("Couldn't flush stream = {stream_name}; Error = {e}"),
+                _ => info!("Flushed stream = {stream_name}"),
+            }
+        }
+    }
+
     // Flush stream/partitions that timeout
     pub async fn flush_stream(&mut self, stream: &str) -> Result<(), stream::Error> {
         let stream = self.map.get_mut(stream).unwrap();

--- a/uplink/src/main.rs
+++ b/uplink/src/main.rs
@@ -2,13 +2,14 @@ mod console;
 
 use std::sync::Arc;
 use std::thread;
+use std::time::Duration;
 
 use anyhow::Error;
-
 use log::info;
 use signal_hook::consts::{SIGINT, SIGQUIT, SIGTERM};
 use signal_hook_tokio::Signals;
 use structopt::StructOpt;
+use tokio::time::sleep;
 use tokio_stream::StreamExt;
 use tracing::error;
 use tracing_subscriber::fmt::format::{Format, Pretty};
@@ -137,6 +138,7 @@ fn main() -> Result<(), Error> {
 
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_io()
+        .enable_time()
         .thread_name("tcpjson")
         .build()
         .unwrap();
@@ -164,7 +166,9 @@ fn main() -> Result<(), Error> {
         });
 
         uplink.resolve_on_shutdown().await.unwrap();
-        info!("Uplink shutting down");
+        info!("Uplink shutting down...");
+        // NOTE: wait 5s to allow serializer to write to network/disk
+        sleep(Duration::from_secs(5)).await;
     });
 
     Ok(())


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->
Flush all streams in bridge to ensure data is not lost during shutdown.

### Why?
<!--Detailed description of why the changes had to be made-->
Data in streams that are not flushed get dropped on uplink shutdown.

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
Run uplink and trigger shutdown after some time:
```
^C  2023-06-23T11:54:18.245006Z  INFO uplink::base::bridge::streams: Flushed stream = uplink_disk_stats

  2023-06-23T11:54:18.245066Z  INFO uplink::base::bridge::streams: Flushed stream = logs

  2023-06-23T11:54:18.245075Z  INFO uplink::base::bridge::streams: Flushed stream = uplink_system_stats

  2023-06-23T11:54:18.245082Z  INFO uplink::base::bridge::streams: Flushed stream = uplink_network_stats

  2023-06-23T11:54:18.245088Z  INFO uplink::base::bridge::streams: Flushed stream = uplink_component_stats

  2023-06-23T11:54:18.245094Z  INFO uplink::base::bridge::streams: Flushed stream = uplink_processor_stats

  2023-06-23T11:54:18.245100Z  INFO uplink::base::bridge::streams: Flushed stream = uplink_process_stats

  2023-06-23T11:54:18.245108Z  INFO uplink::base::bridge::streams: Flushed stream = device_shadow

  2023-06-23T11:54:18.245253Z  INFO uplink: Uplink shutting down...
```