### PR TITLE
feat: built-in script runner

### DIFF
--- a/configs/config.toml
+++ b/configs/config.toml
@@ -5,7 +5,11 @@ processes = [{ name = "echo", timeout = 10 }]
 
 # Map of action names for re-routing on partial completion. An action is considered
 # partially completed when progress is 100, but status is neither "Failed" nor "Completed".
-action_redirections = { "firmware_update" = "install_update", "send_file" = "load_file" }
+action_redirections = { "firmware_update" = "install_update", "send_file" = "load_file", "send_script" = "run_script" }
+
+# Script runner allows users to trigger an action that will run an already downloaded
+# file as described by the download_path field of the JSON payload of a download action.
+script_runner = [{ name = "run_script" }]
 
 # Location on disk for persisted streams to write backlogs into, also used to write
 persistence_path = "/tmp/uplink/"
@@ -130,7 +134,7 @@ buf_size = 1
 # - actions: List of actions names that can trigger the downloader, with configurable timeouts
 # - path: Location in fs where the files are downloaded into
 [downloader]
-actions = [{ name = "update_firmware" }, { name = "send_file" }]
+actions = [{ name = "update_firmware" }, { name = "send_file" }, { name = "send_script" }]
 path = "/var/tmp/ota-file"
 
 # Configurations associated with the system stats module of uplink, if enabled

--- a/uplink/src/base/bridge/mod.rs
+++ b/uplink/src/base/bridge/mod.rs
@@ -445,7 +445,7 @@ impl CurrentAction {
 
 #[derive(Debug)]
 pub struct ActionRouter {
-    actions_tx: Sender<Action>,
+    pub(crate) actions_tx: Sender<Action>,
     duration: Duration,
 }
 

--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -205,6 +205,8 @@ pub struct Config {
     pub mqtt: MqttConfig,
     #[serde(default)]
     pub processes: Vec<ActionRoute>,
+    #[serde(default)]
+    pub script_runner: Vec<ActionRoute>,
     #[serde(skip)]
     pub actions_subscription: String,
     pub streams: HashMap<String, StreamConfig>,

--- a/uplink/src/collector/mod.rs
+++ b/uplink/src/collector/mod.rs
@@ -1,3 +1,4 @@
+pub mod device_shadow;
 pub mod downloader;
 pub mod installer;
 #[cfg(target_os = "linux")]
@@ -5,8 +6,8 @@ pub mod journalctl;
 #[cfg(target_os = "android")]
 pub mod logcat;
 pub mod process;
+pub mod script_runner;
 pub mod simulator;
 pub mod systemstats;
 pub mod tcpjson;
 pub mod tunshell;
-pub mod device_shadow;

--- a/uplink/src/collector/script_runner.rs
+++ b/uplink/src/collector/script_runner.rs
@@ -67,13 +67,14 @@ impl ScriptRunner {
         loop {
             select! {
                 Ok(Some(line)) = stdout.next_line() => {
-                    let status: ActionResponse = match serde_json::from_str(&line) {
+                    let mut status: ActionResponse = match serde_json::from_str(&line) {
                         Ok(status) => status,
                         Err(e) => {
                             error!("Failed to deserialize script output: \"{line}\"; Error: {e}");
                             continue;
                         },
                     };
+                    status.action_id = id.to_owned();
 
                     debug!("Action status: {:?}", status);
                     self.bridge_tx.send_action_response(status).await;

--- a/uplink/src/collector/script_runner.rs
+++ b/uplink/src/collector/script_runner.rs
@@ -1,0 +1,121 @@
+use flume::{RecvError, SendError};
+use log::{debug, error, info, warn};
+use thiserror::Error;
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::{Child, Command};
+use tokio::{pin, select, time};
+
+use super::downloader::DownloadFile;
+use crate::base::{bridge::BridgeTx, ActionRoute};
+use crate::{ActionResponse, Package};
+
+use std::io;
+use std::process::Stdio;
+use std::time::Duration;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("IO Error {0}")]
+    Io(#[from] io::Error),
+    #[error("Json error {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("Recv error {0}")]
+    Recv(#[from] RecvError),
+    #[error("Send error {0}")]
+    Send(#[from] SendError<Box<dyn Package>>),
+    #[error("Busy with previous action")]
+    Busy,
+    #[error("No stdout in spawned action")]
+    NoStdout,
+}
+
+/// Script runner runs a script downloaded with FileDownloader and handles their output over the action_status stream.
+/// Multiple scripts can't be run in parallel. It can also send progress, result and errors to the platform by using
+/// the JSON formatted output over STDOUT.
+pub struct ScriptRunner {
+    // to receive actions and send responses back to bridge
+    bridge_tx: BridgeTx,
+}
+
+impl ScriptRunner {
+    pub fn new(bridge_tx: BridgeTx) -> Self {
+        Self { bridge_tx }
+    }
+
+    /// Spawn a child process to run the script with sh
+    pub async fn run(&mut self, command: String) -> Result<Child, Error> {
+        let mut cmd = Command::new("sh");
+        cmd.arg(command).kill_on_drop(true).stdout(Stdio::piped());
+
+        let child = cmd.spawn()?;
+
+        Ok(child)
+    }
+
+    /// Capture stdout of the running process in a spawned task and forward any action_status in JSON format
+    pub async fn spawn_and_capture_stdout(
+        &mut self,
+        mut child: Child,
+        id: &str,
+    ) -> Result<(), Error> {
+        let stdout = child.stdout.take().ok_or(Error::NoStdout)?;
+        let mut stdout = BufReader::new(stdout).lines();
+
+        let timeout = time::sleep(Duration::from_secs(10));
+        pin!(timeout);
+
+        loop {
+            select! {
+                Ok(Some(line)) = stdout.next_line() => {
+                    let status: ActionResponse = match serde_json::from_str(&line) {
+                        Ok(status) => status,
+                        Err(e) => {
+                            error!("Failed to deserialize script output: \"{line}\"; Error: {e}");
+                            continue;
+                        },
+                    };
+
+                    debug!("Action status: {:?}", status);
+                    self.bridge_tx.send_action_response(status).await;
+                }
+                // Send a success status at the end of execution
+                status = child.wait() => {
+                    info!("Action done!! Status = {:?}", status);
+                    self.bridge_tx.send_action_response(ActionResponse::success(id)).await;
+                    break;
+                },
+                _ = &mut timeout => break
+            }
+        }
+
+        Ok(())
+    }
+
+    pub async fn start(mut self, routes: Vec<ActionRoute>) -> Result<(), Error> {
+        let action_rx = match self.bridge_tx.register_action_routes(routes).await {
+            Some(r) => r,
+            _ => return Ok(()),
+        };
+
+        info!("Script runner is ready");
+
+        loop {
+            let action = action_rx.recv_async().await?;
+            let command = match serde_json::from_str::<DownloadFile>(&action.payload) {
+                Ok(DownloadFile { download_path: Some(download_path), .. }) => download_path,
+                Ok(_) => {
+                    warn!("Action payload could not be used for script execution");
+                    continue;
+                }
+                Err(e) => {
+                    error!("Failed to deserialize action payload: {e}");
+                    continue;
+                }
+            };
+
+            // Spawn the action and capture its stdout
+            let child = self.run(command).await?;
+            self.spawn_and_capture_stdout(child, &action.action_id).await?;
+        }
+    }
+}

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -53,6 +53,7 @@ use collector::device_shadow::DeviceShadow;
 use collector::downloader::FileDownloader;
 use collector::installer::OTAInstaller;
 use collector::process::ProcessHandler;
+use collector::script_runner::ScriptRunner;
 use collector::systemstats::StatCollector;
 use collector::tunshell::TunshellSession;
 use flume::{bounded, Receiver, RecvError, Sender};
@@ -431,6 +432,23 @@ impl Uplink {
         let process_handler = ProcessHandler::new(bridge_tx.clone());
         let processes = config.processes.clone();
         thread::spawn(move || process_handler.start(processes));
+
+        let script_runner = ScriptRunner::new(bridge_tx.clone());
+        let routes: Vec<ActionRoute> = config.script_runner.clone();
+        thread::spawn(move || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .thread_name("script_runner")
+                .enable_io()
+                .enable_time()
+                .build()
+                .unwrap();
+
+            rt.block_on(async move {
+                if let Err(e) = script_runner.start(routes).await {
+                    error!("Monitor stopped!! Error = {:?}", e);
+                }
+            })
+        });
 
         let monitor = Monitor::new(
             self.config.clone(),


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->
Script runner allows user to send custom scripts that are executed on the device with `sh`.

### Why?
<!--Detailed description of why the changes had to be made-->
User needs to run a shell script quickly on the connected device.

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
1. Start uplink with appropriate config:
```
action_redirections = { "send_file" = "run_script" }
script_runner = [{ name = "run_script" }]

persistence_path = "/var/tmp/uplink"

[downloader]
actions = [{ name = "send_file" }]
path = "/var/tmp/uplink"
```
2. Trigger `send_file` action with following script:
```
#!/bin/sh

echo 'This works'
```
3. Observe the execution of script on device:
```
 2023-06-28T16:02:57.835734Z  INFO uplink::collector::downloader: Downloading from https://firmware.stage.bytebeam.io/api/v1/file/b307b17e-d0ec-4e7e-8e60-beb243b45e41/artifact into /var/tmp/uplink/send_file/save.sh

  2023-06-28T16:02:57.835865Z  INFO uplink::collector::downloader: Firmware downloaded successfully

  2023-06-28T16:02:57.835984Z  INFO uplink::base::bridge: Action response = ActionResponse { action_id: "893", device_id: None, sequence: 2, timestamp: 1687968177835, state: "Downloading", progress: 99, errors: [], done_response: None }

  2023-06-28T16:02:57.836041Z TRACE uplink::base::bridge::stream: Flushing stream name: action_status, topic: /tenants/demo/devices/1001/action/status

  2023-06-28T16:02:57.836078Z  INFO uplink::base::bridge: Action response = ActionResponse { action_id: "893", device_id: None, sequence: 3, timestamp: 1687968177835, state: "Downloaded", progress: 100, errors: [], done_response: Some(Action { device_id: None, action_id: "893", kind: "process", name: "send_file", payload: "{\"url\":\"https://firmware.stage.bytebeam.io/api/v1/file/b307b17e-d0ec-4e7e-8e60-beb243b45e41/artifact\",\"content_length\":29,\"file_name\":\"save.sh\",\"download_path\":\"/var/tmp/uplink/send_file/save.sh\"}" }) }

  2023-06-28T16:02:57.836121Z TRACE uplink::base::bridge::stream: Flushing stream name: action_status, topic: /tenants/demo/devices/1001/action/status

  2023-06-28T16:02:57.836127Z TRACE uplink::base::serializer: Data received on stream: action_status; message count = 1; batching latency = 0

  2023-06-28T16:02:57.836180Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/action/status with size = 108

  2023-06-28T16:02:57.836212Z TRACE uplink::base::serializer: Data received on stream: action_status; message count = 1; batching latency = 0

  2023-06-28T16:02:57.836223Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/action/status with size = 108

  2023-06-28T16:02:57.836434Z DEBUG uplink::base::mqtt: Outgoing = Publish(12)

  2023-06-28T16:02:57.836491Z DEBUG uplink::base::mqtt: Outgoing = Publish(13)

  2023-06-28T16:02:57.838979Z ERROR uplink::collector::script_runner: Failed to deserialize script output: "This works"; Error: expected value at line 1 column 1

  2023-06-28T16:02:57.839043Z  INFO uplink::collector::script_runner: Action done!! Status = Ok(ExitStatus(unix_wait_status(0)))

  2023-06-28T16:02:57.839126Z  INFO uplink::base::bridge: Action response = ActionResponse { action_id: "893", device_id: None, sequence: 0, timestamp: 1687968177839, state: "Completed", progress: 100, errors: [], done_response: None }
```
5. Observe updates on platform:
![image](https://github.com/bytebeamio/uplink/assets/18750864/d295a4d1-6396-43b3-bc89-a8f0f752be75)

P.S: there needs to be a discussion about extracting action_status from stdout.
P.P.S: name user triggered action `send_script` and redirect it as `run_script` within the config as a best practice.