### PR TITLE
Uplink should ignore `save_current_action` failures

### DIFF
--- a/uplink/src/base/bridge/mod.rs
+++ b/uplink/src/base/bridge/mod.rs
@@ -1,5 +1,5 @@
 use flume::{bounded, Receiver, RecvError, Sender, TrySendError};
-use log::{debug, error, info, warn};
+use log::{debug, error, info, log, warn};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokio::select;
@@ -252,7 +252,9 @@ impl Bridge {
                 }
                 // Handle a shutdown signal
                 _ = self.ctrl_rx.recv_async() => {
-                    self.save_current_action()?;
+                    if let Err(e) = self.save_current_action() {
+                        error!("Failed to save current action: {e}");
+                    }
                     streams.flush_all().await;
                     // NOTE: there might be events still waiting for recv on bridge_rx
                     self.shutdown_handle.send(()).unwrap();

--- a/uplink/src/base/bridge/mod.rs
+++ b/uplink/src/base/bridge/mod.rs
@@ -1,5 +1,5 @@
 use flume::{bounded, Receiver, RecvError, Sender, TrySendError};
-use log::{debug, error, info, log, warn};
+use log::{debug, error, info, warn};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokio::select;


### PR DESCRIPTION
Closes #<!--Issue Number-->


### Changes

Uplink should ignore any failures during shutdown.

### Why?

Right now save_current_action fails if `persistence_path` is wrong, causing uplink to ignore pkill.

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->