### PR TITLE
fix: use `flush_period` instead of `buf_size` for important streams

### DIFF
--- a/configs/config.toml
+++ b/configs/config.toml
@@ -77,7 +77,7 @@ blacklist = ["cancollector_metrics", "candump_metrics", "pinger"]
 # it as non-persistent. streams are internally constructed as a map of Name -> Config
 [streams.device_shadow]
 topic = "/tenants/{tenant_id}/devices/{device_id}/events/device_shadow/jsonarray"
-buf_size = 1
+timeout = 5
 
 # Example using compression
 [streams.imu]
@@ -119,7 +119,7 @@ persistence = { max_file_count = 3 }
 # This also means that we require a topic to be configured or uplink will error out.
 [action_status]
 topic = "/tenants/{tenant_id}/devices/{device_id}/action/status"
-buf_size = 1
+timeout = 2
 
 # Configurations for uplink's built-in file downloader, including the actions that can trigger
 # a download, the location in file system where uplink will download and store files from the

--- a/configs/config.toml
+++ b/configs/config.toml
@@ -77,7 +77,7 @@ blacklist = ["cancollector_metrics", "candump_metrics", "pinger"]
 # it as non-persistent. streams are internally constructed as a map of Name -> Config
 [streams.device_shadow]
 topic = "/tenants/{tenant_id}/devices/{device_id}/events/device_shadow/jsonarray"
-timeout = 5
+flush_period = 5
 
 # Example using compression
 [streams.imu]
@@ -119,7 +119,7 @@ persistence = { max_file_count = 3 }
 # This also means that we require a topic to be configured or uplink will error out.
 [action_status]
 topic = "/tenants/{tenant_id}/devices/{device_id}/action/status"
-timeout = 2
+flush_period = 2
 
 # Configurations for uplink's built-in file downloader, including the actions that can trigger
 # a download, the location in file system where uplink will download and store files from the

--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -24,6 +24,11 @@ fn default_timeout() -> u64 {
     DEFAULT_TIMEOUT
 }
 
+#[inline]
+fn max_buf_size() -> usize {
+    MAX_BUFFER_SIZE
+}
+
 fn default_file_size() -> usize {
     10485760 // 10MB
 }
@@ -46,6 +51,7 @@ pub enum Compression {
 #[derive(Debug, Clone, Deserialize)]
 pub struct StreamConfig {
     pub topic: String,
+    #[serde(default = "max_buf_size")]
     pub buf_size: usize,
     #[serde(default = "default_timeout")]
     /// Duration(in seconds) that bridge collector waits from

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -129,12 +129,11 @@ pub mod config {
 
     [action_status]
     topic = "/tenants/{tenant_id}/devices/{device_id}/action/status"
-    buf_size = 1
-    timeout = 10
+    timeout = 2
 
     [streams.device_shadow]
     topic = "/tenants/{tenant_id}/devices/{device_id}/events/device_shadow/jsonarray"
-    buf_size = 1
+    timeout = 5
 
     [streams.logs]
     topic = "/tenants/{tenant_id}/devices/{device_id}/events/logs/jsonarray"

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -129,11 +129,11 @@ pub mod config {
 
     [action_status]
     topic = "/tenants/{tenant_id}/devices/{device_id}/action/status"
-    timeout = 2
+    flush_period = 2
 
     [streams.device_shadow]
     topic = "/tenants/{tenant_id}/devices/{device_id}/events/device_shadow/jsonarray"
-    timeout = 5
+    flush_period = 5
 
     [streams.logs]
     topic = "/tenants/{tenant_id}/devices/{device_id}/events/logs/jsonarray"


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->

### Why?
<!--Detailed description of why the changes had to be made-->
User apps may handle actions such that status messages are very frequent, the same in the case of `device_shadow` stream, thus `buf_size` is not a sensible requirement as anyways the receiver on the other side can handle the buffered data points as long as they are flushed as frequently as necessary, 5s per device shadow and 2s for action status.

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
Case 1: Generate 50 `action_status` messages in 2 seconds and 10 `device_shadow` data points in 5 seconds with simulator, ensure that they are batched with buffers of suitable size and within the expected time-period of 2s and 5s appropriately.
```
  2023-07-14T09:44:27.631118Z TRACE uplink::base::bridge::streams: Initialized stream buffer for device_shadow

  2023-07-14T09:44:32.633564Z TRACE uplink::base::serializer: Data received on stream: device_shadow; message count = 10; batching latency = 0
```
Case 2: Generate 1 `action_status` message every 5 seconds and 1 `device_shadow` data point every 10s with simulator, ensure they are flushed as batch of 1 and within expected time-period of 2s and 5s appropriately.
```
  2023-07-14T09:46:33.543673Z TRACE uplink::base::bridge::streams: Initialized stream buffer for device_shadow

  2023-07-14T09:46:38.546062Z TRACE uplink::base::serializer: Data received on stream: device_shadow; message count = 1; batching latency = 0
```
Case 3: Generate 300 `action_status` message in 2 seconds and 200 `device_shadow` data point every 5s with simulator, ensure they are flushed as batches of 100 or less and within expected time-period of 2s and 5s appropriately from first message in batch.
```
  2023-07-14T09:48:21.418342Z TRACE uplink::base::bridge::streams: Initialized stream buffer for device_shadow

  2023-07-14T09:48:23.420986Z TRACE uplink::base::serializer: Data received on stream: device_shadow; message count = 100; batching latency = 0

  2023-07-14T09:48:23.448644Z TRACE uplink::base::bridge::streams: Initialized stream buffer for device_shadow
... killed simulator...
  2023-07-14T09:48:28.451517Z TRACE uplink::base::serializer: Data received on stream: device_shadow; message count = 39; batching latency = 0
```