### PR TITLE
fix: stop download on action timeout, don't drop action on resend

### DIFF
--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -4,9 +4,9 @@ use std::{collections::HashMap, fmt::Debug};
 
 use serde::{Deserialize, Serialize};
 
-#[cfg(any(target_os = "linux"))]
+#[cfg(target_os = "linux")]
 use crate::collector::journalctl::JournalCtlConfig;
-#[cfg(any(target_os = "android"))]
+#[cfg(target_os = "android")]
 use crate::collector::logcat::LogcatConfig;
 
 use self::bridge::stream::MAX_BUFFER_SIZE;
@@ -224,8 +224,8 @@ pub struct Config {
     pub action_redirections: HashMap<String, String>,
     #[serde(default)]
     pub ignore_actions_if_no_clients: bool,
-    #[cfg(any(target_os = "linux"))]
+    #[cfg(target_os = "linux")]
     pub logging: Option<JournalCtlConfig>,
-    #[cfg(any(target_os = "android"))]
+    #[cfg(target_os = "android")]
     pub logging: Option<LogcatConfig>,
 }

--- a/uplink/src/collector/downloader.rs
+++ b/uplink/src/collector/downloader.rs
@@ -50,10 +50,12 @@
 use bytes::BytesMut;
 use flume::RecvError;
 use futures_util::StreamExt;
-use log::{error, info};
+use log::{error, info, warn};
 use reqwest::{Certificate, Client, ClientBuilder, Identity, Response};
 use serde::{Deserialize, Serialize};
+use tokio::time::timeout;
 
+use std::collections::HashMap;
 use std::fs::{create_dir_all, metadata, remove_dir_all, File};
 use std::sync::Arc;
 use std::time::Duration;
@@ -91,6 +93,7 @@ pub struct FileDownloader {
     bridge_tx: BridgeTx,
     client: Client,
     sequence: u32,
+    timeouts: HashMap<String, Duration>,
 }
 
 impl FileDownloader {
@@ -111,8 +114,16 @@ impl FileDownloader {
         }
         .build()?;
 
+        let timeouts = config
+            .downloader
+            .actions
+            .iter()
+            .map(|s| (s.name.to_owned(), Duration::from_secs(s.timeout)))
+            .collect();
+
         Ok(Self {
             config: config.downloader.clone(),
+            timeouts,
             client,
             bridge_tx,
             sequence: 0,
@@ -134,27 +145,44 @@ impl FileDownloader {
             let action = download_rx.recv_async().await?;
             self.action_id = action.action_id.clone();
 
-            let mut error = None;
-            // NOTE: retry mechanism tries atleast 3 times before returning an error
-            for _ in 0..3 {
-                match self.run(action.clone()).await {
-                    Ok(_) => {
-                        error = None;
-                        break;
-                    }
-                    Err(e) => {
-                        error!("Download failed: {e}\nretrying");
-                        error = Some(e);
-                    }
+            let duration = match self.timeouts.get(&action.name) {
+                Some(t) => *t,
+                _ => {
+                    error!("Action: {} unconfigured", action.name);
+                    continue;
                 }
-                tokio::time::sleep(Duration::from_secs(30)).await;
-            }
-            if let Some(e) = error {
-                let status = ActionResponse::failure(&self.action_id, e.to_string());
-                let status = status.set_sequence(self.sequence());
-                self.bridge_tx.send_action_response(status).await;
+            };
+
+            // NOTE: if download has timedout don't do anything, else ensure errors are forwarded after three retries
+            if let Ok(Err(e)) = timeout(duration, self.retry_thrice(action)).await {
+                self.forward_error(e).await;
             }
         }
+    }
+
+    // Forward errors as action response to bridge
+    async fn forward_error(&mut self, err: Error) {
+        let status =
+            ActionResponse::failure(&self.action_id, err.to_string()).set_sequence(self.sequence());
+        self.bridge_tx.send_action_response(status).await;
+    }
+
+    // Retry mechanism tries atleast 3 times before returning an error
+    async fn retry_thrice(&mut self, action: Action) -> Result<(), Error> {
+        let mut res = Ok(());
+        for _ in 0..3 {
+            match self.run(action.clone()).await {
+                Ok(_) => return Ok(()),
+                Err(e) => {
+                    error!("Download failed: {e}");
+                    res = Err(e);
+                }
+            }
+            tokio::time::sleep(Duration::from_secs(30)).await;
+            warn!("Retrying download");
+        }
+
+        res
     }
 
     // Accepts a download `Action` and performs necessary data extraction to actually download the file

--- a/uplink/src/collector/downloader.rs
+++ b/uplink/src/collector/downloader.rs
@@ -154,8 +154,10 @@ impl FileDownloader {
             };
 
             // NOTE: if download has timedout don't do anything, else ensure errors are forwarded after three retries
-            if let Ok(Err(e)) = timeout(duration, self.retry_thrice(action)).await {
-                self.forward_error(e).await;
+            match timeout(duration, self.retry_thrice(action)).await {
+                Ok(Err(e)) => self.forward_error(e).await,
+                Err(_) => error!("Last download has timedout"),
+                _ => {}
             }
         }
     }


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->
1. Timeout downloads at expected timeout of action on bridge
2. Don't clear action on unsuccessful re-send even if with same id

### Why?
Downloader as of right now continues to run despite the action having timedout on bridge, leading to further action failures as download actions clog the channel into the downloader

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
1. Create http server accessible over toxiproxy.
```
echo '#!/bin.sh' > test.sh
echo 'echo "Hello, World!"' >> test.sh
python3 -m http.server 8000
```
```
curl --request POST \
  --url http://localhost:8474/proxies \
  --header 'Content-Type: application/json' \
  --data '{
    "name": "script-server",
    "listen": "0.0.0.0:8001",
    "upstream": "localhost:8000",
    "enabled": true
}'
```
3. Start uplink without auth.
```
# auth.json
{
  "project_id": "demo",
  "broker": "localhost",
  "port": 1883,
  "device_id":"1"
}
# config.toml
[downloader]
actions = [{ name = "send_script" }]
path = "/tmp/downloads"

```
4. Send action to uplink that points to http sever.
```
mosquitto_pub -t /tenants/demo/devices/1/actions -m '{ "action_id":
 "1", "kind": "process", "name": "send_script", "payload": "{\"file_n
ame\":\"test.sh\",\"content-length\":31,\"id\":\"123\",\"url\":\"http
://0.0.0.0:8001/test.sh\"}" }'
```
5. Ensure at normal speeds this doesn't trigger failure.
6. Repeat step 3 with extremely slow speed access, see if this triggers failure and download continues to run despite action timeout in bridge.
```
  2023-07-25T16:18:02.531840Z ERROR uplink::collector::downloader: Last download has timedout

  2023-07-25T16:18:02.532611Z ERROR uplink::base::bridge: Timeout waiting for action response. Action ID = 1
```