### PR TITLE
fix: glob error stopping stat collector

### DIFF
--- a/uplink/src/collector/systemstats.rs
+++ b/uplink/src/collector/systemstats.rs
@@ -630,10 +630,17 @@ impl StatCollector {
 
     // Refresh special component stats
     fn update_special_stats(&mut self) -> Result<(), Error> {
-        let files = glob::glob("/sys/devices/virtual/thermal/thermal_zone*/temp")?;
+        let paths = glob::glob("/sys/devices/virtual/thermal/thermal_zone*/temp")?;
         let timestamp = clock() as u64;
-        for thermal_zone in files {
-            let path = thermal_zone?;
+
+        for path in paths {
+            let path = match path {
+                Ok(p) => p,
+                Err(e) => {
+                    error!("Couldn't extract file path from glob: {e}");
+                    continue;
+                }
+            };
             let mut label = path.as_os_str().to_str().unwrap_or("temp_component").to_string();
             label.retain(|c| c.is_numeric());
             let label = "thermal_zone".to_owned() + &label;

--- a/uplink/src/collector/systemstats.rs
+++ b/uplink/src/collector/systemstats.rs
@@ -535,25 +535,53 @@ impl StatCollector {
     }
 
     /// Stat collector execution loop, sleeps for the duation of `config.stats.update_period` in seconds.
+    /// Update system information values and increment sequence numbers, while sending to specific data streams.
     pub fn start(mut self) {
         loop {
             std::thread::sleep(Duration::from_secs(self.config.system_stats.update_period));
 
-            if let Err(e) = self.update() {
-                error!("Faced error while refreshing system statistics: {}", e);
-                return;
-            };
+            if let Err(e) = self.update_memory_stats() {
+                error!("Error refreshing system memory statistics: {}", e);
+            }
+
+            if let Err(e) = self.update_disk_stats() {
+                error!("Error refreshing disk statistics: {}", e);
+            }
+
+            if let Err(e) = self.update_network_stats() {
+                error!("Error refreshing network statistics: {}", e);
+            }
+
+            if let Err(e) = self.update_cpu_stats() {
+                error!("Error refreshing CPU statistics: {}", e);
+            }
+
+            if let Err(e) = self.update_component_stats() {
+                error!("Error refreshing component statistics: {}", e);
+            }
+
+            if let Err(e) = self.update_special_stats() {
+                error!("Error refreshing special component statistics: {}", e);
+            }
+
+            if let Err(e) = self.update_process_stats() {
+                error!("Error refreshing process statistics: {}", e);
+            }
         }
     }
 
-    /// Update system information values and increment sequence numbers, while sending to specific data streams.
-    fn update(&mut self) -> Result<(), Error> {
+    // Refresh memory stats
+    fn update_memory_stats(&mut self) -> Result<(), Error> {
         self.sys.refresh_memory();
         let timestamp = clock() as u64;
         let payload = self.system.push(&self.sys, timestamp);
         self.bridge_tx.send_payload_sync(payload);
 
-        // Refresh disk info
+        Ok(())
+    }
+
+    // Refresh disk stats
+    fn update_disk_stats(&mut self) -> Result<(), Error> {
         self.sys.refresh_disks();
         let timestamp = clock() as u64;
         for disk_data in self.sys.disks() {
@@ -561,7 +589,11 @@ impl StatCollector {
             self.bridge_tx.send_payload_sync(payload);
         }
 
-        // Refresh network byte rate info
+        Ok(())
+    }
+
+    // Refresh network byte rate stats
+    fn update_network_stats(&mut self) -> Result<(), Error> {
         self.sys.refresh_networks();
         let timestamp = clock() as u64;
         for (net_name, net_data) in self.sys.networks() {
@@ -569,7 +601,11 @@ impl StatCollector {
             self.bridge_tx.send_payload_sync(payload);
         }
 
-        // Refresh processor info
+        Ok(())
+    }
+
+    // Refresh processor stats
+    fn update_cpu_stats(&mut self) -> Result<(), Error> {
         self.sys.refresh_cpu();
         let timestamp = clock() as u64;
         for proc_data in self.sys.cpus().iter() {
@@ -577,14 +613,25 @@ impl StatCollector {
             self.bridge_tx.send_payload_sync(payload);
         }
 
-        // Refresh component info
+        Ok(())
+    }
+
+    // Refresh component stats
+    fn update_component_stats(&mut self) -> Result<(), Error> {
         self.sys.refresh_components();
         let timestamp = clock() as u64;
         for comp_data in self.sys.components().iter() {
             let payload = self.components.push(comp_data, timestamp);
             self.bridge_tx.send_payload_sync(payload);
         }
+
+        Ok(())
+    }
+
+    // Refresh special component stats
+    fn update_special_stats(&mut self) -> Result<(), Error> {
         let files = glob::glob("/sys/devices/virtual/thermal/thermal_zone*/temp")?;
+        let timestamp = clock() as u64;
         for thermal_zone in files {
             let path = thermal_zone?;
             let mut label = path.as_os_str().to_str().unwrap_or("temp_component").to_string();
@@ -596,10 +643,14 @@ impl StatCollector {
             self.bridge_tx.send_payload_sync(payload);
         }
 
-        // Refresh processes info
-        // NOTE: This can be further optimized by storing pids of interested processes
-        // at init and only collecting process information for them instead of iterating
-        // over all running processes as is being done now.
+        Ok(())
+    }
+
+    // Refresh processes info
+    // NOTE: This can be further optimized by storing pids of interested processes
+    // at init and only collecting process information for them instead of iterating
+    // over all running processes as is being done now.
+    fn update_process_stats(&mut self) -> Result<(), Error> {
         self.sys.refresh_processes();
         let timestamp = clock() as u64;
         for (&id, p) in self.sys.processes() {


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->
- Separate out updater and directly print errors to log instead of returning.
- Remove special stats collectors

Users can continue to include the special stat collector as a separate app connecting to uplink through TCP with [this code](https://gist.github.com/de-sh/e2085eb2f28fa97eb712038b8b07ef20).

### Why?
<!--Detailed description of why the changes had to be made-->
Certain glob related errors lead to uplink's built-in stat collector failing, which shouldn't be the case.

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
Run uplink with stat collector enabled on a device without files at the path described by `/sys/devices/virtual/thermal/thermal_zone*/temp`.