### PR TITLE
feat: use `current_dir` instead of `/var/lib`

### DIFF
--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -1,3 +1,4 @@
+use std::env::current_dir;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::{collections::HashMap, fmt::Debug};
@@ -34,7 +35,9 @@ fn default_file_size() -> usize {
 }
 
 fn default_persistence_path() -> PathBuf {
-    PathBuf::from("/var/lib/uplink")
+    let mut path = current_dir().expect("Couldn't figure out current directory");
+    path.push(".persistence");
+    path
 }
 
 pub fn clock() -> u128 {

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -104,9 +104,6 @@ pub mod config {
     keep_alive = 30
     network_timeout = 30
 
-    # Create empty streams map
-    [streams]
-
     # Downloader config
     [downloader]
     actions = []


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->

### Why?
<!--Detailed description of why the changes had to be made-->
This will ensure that use of default config isn't hindered by change in platform, i.e. `/var/lib/` isn't accessible on windows/android.

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
```
    ░█░▒█░▄▀▀▄░█░░░▀░░█▀▀▄░█░▄
    ░█░▒█░█▄▄█░█░░░█▀░█░▒█░█▀▄
    ░░▀▀▀░█░░░░▀▀░▀▀▀░▀░░▀░▀░▀
    
    version: 2.5.0
    profile: debug
    commit_sha: 7a4cb757110f5944ac2b821125f945617add1ff8
    commit_date: 2023-07-27T08:34:04Z
    project_id: demo
    device_id: 1001
    remote: stage.bytebeam.io:8883
    persistence_path: /home/uplink/.persistence
    secure_transport: true
    max_packet_size: 256000
    max_inflight_messages: 100
    keep_alive_timeout: 30
```