### PR TITLE
fix: retry only `reqwest` errors

### DIFF
--- a/uplink/src/collector/downloader.rs
+++ b/uplink/src/collector/downloader.rs
@@ -174,10 +174,9 @@ impl FileDownloader {
 
     // Retry mechanism tries atleast 3 times before returning an error
     async fn retry_thrice(&mut self, action: Action) -> Result<(), Error> {
-        let mut res = Ok(());
         for _ in 0..3 {
             match self.run(action.clone()).await {
-                Ok(_) => return Ok(()),
+                Ok(_) => break,
                 Err(e) => {
                     if let Error::Reqwest(e) = e {
                         error!("Download failed: {e}");
@@ -190,7 +189,7 @@ impl FileDownloader {
             warn!("Retrying download");
         }
 
-        res
+        Ok(())
     }
 
     // Accepts a download `Action` and performs necessary data extraction to actually download the file

--- a/uplink/src/collector/downloader.rs
+++ b/uplink/src/collector/downloader.rs
@@ -179,8 +179,11 @@ impl FileDownloader {
             match self.run(action.clone()).await {
                 Ok(_) => return Ok(()),
                 Err(e) => {
-                    error!("Download failed: {e}");
-                    res = Err(e);
+                    if let Error::Reqwest(e) = e {
+                        error!("Download failed: {e}");
+                    } else {
+                        return Err(e);
+                    }
                 }
             }
             tokio::time::sleep(Duration::from_secs(30)).await;


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->

### Why?
Downloader retrying issues related to file-system, the actual file being empty, etc. doesn't make much sense, whereas when it is caused by something related to the HTTP client, retrying could help.

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
1. HTTP error:
```
  2023-08-15T10:32:25.912726Z  INFO uplink::base::bridge: Action response = ActionResponse { action_id: "1411", device_id: None, sequence: 1, timestamp: 1692095545912, state: "Downloading", progress: 0, errors: [], done_response: None }

  2023-08-15T10:34:36.865645Z ERROR uplink::collector::downloader: Download failed: error sending request for url (https://firmware.stage.bytebeam.io/api/v1/file/0dd74499-4d79-480b-9892-165497654281/artifact): error trying to connect: tcp connect error: Network is unreachable (os error 101)

  2023-08-15T10:35:06.252073Z  WARN uplink::collector::downloader: Retrying download
```
2. Non HTTP error:
```
    2023-08-15T10:23:17.754027Z  INFO uplink::base::bridge: Action response = ActionResponse { action_id: "1406", device_id: None, sequence: 0, timestamp: 1692094997754, state: "Received", progress: 0, errors: [], done_response: None }

    2023-08-15T10:23:17.754167Z  INFO uplink::base::bridge: Action response = ActionResponse { action_id: "1406", device_id: None, sequence: 1, timestamp: 1692094997754, state: "Downloading", progress: 0, errors: [], done_response: None }

    2023-08-15T10:23:18.367453Z  INFO uplink::collector::downloader: Downloading from https://firmware.stage.bytebeam.io/api/v1/firmwares/new firmware/artifact into /media/devdutt/EC6C23BE6C238286/persistence/update_firmware/new firmware

    2023-08-15T10:23:18.367744Z  INFO uplink::base::bridge: Action response = ActionResponse { action_id: "1406", device_id: None, sequence: 2, timestamp: 1692094998367, state: "Failed", progress: 100, errors: ["File io Error: No space left on device (os error 28)"], done_response: None }
```