### PR TITLE
fix: downloader thread error out without logline

### DIFF
--- a/uplink/src/collector/downloader.rs
+++ b/uplink/src/collector/downloader.rs
@@ -145,6 +145,8 @@ impl FileDownloader {
             Some(r) => r,
             _ => return,
         };
+
+        info!("Downloader thread is ready to receive download actions");
         loop {
             self.sequence = 0;
             let action = match download_rx.recv_async().await {

--- a/uplink/src/collector/downloader.rs
+++ b/uplink/src/collector/downloader.rs
@@ -48,7 +48,6 @@
 //! [`action_redirections`]: Config#structfield.action_redirections
 
 use bytes::BytesMut;
-use flume::RecvError;
 use futures_util::StreamExt;
 use log::{error, info, warn};
 use reqwest::{Certificate, Client, ClientBuilder, Identity, Response};
@@ -78,8 +77,6 @@ pub enum Error {
     Reqwest(#[from] reqwest::Error),
     #[error("File io Error: {0}")]
     Io(#[from] std::io::Error),
-    #[error("Error receiving action: {0}")]
-    Recv(#[from] RecvError),
     #[error("Empty file name")]
     EmptyFileName,
     #[error("Missing file path")]


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->

### Why?
Downloader thread was not printing any loglines when it dies out due to recv errors, making it tough to debug

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->