### PR TITLE
fix: spawn generators to remove time skew

### DIFF
--- a/tools/simulator/Cargo.lock
+++ b/tools/simulator/Cargo.lock
@@ -333,15 +333,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc32fast"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
-dependencies = [
- "cfg-if 1.0.0",
-]
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,16 +584,6 @@ dependencies = [
  "libc",
  "redox_syscall",
  "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "flate2"
-version = "1.0.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
 ]
 
 [[package]]
@@ -2349,6 +2330,7 @@ name = "simulator"
 version = "0.1.0"
 dependencies = [
  "fake",
+ "flume",
  "futures-util",
  "log",
  "rand 0.8.5",
@@ -3083,10 +3065,8 @@ dependencies = [
  "axum",
  "bytes 1.4.0",
  "config",
- "flate2",
  "flume",
  "futures-util",
- "glob",
  "lazy_static",
  "log",
  "lz4_flex",

--- a/tools/simulator/Cargo.toml
+++ b/tools/simulator/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Devdutt Shenoi <devdutt@bytebeam.io>"]
 
 [dependencies]
 fake = { version = "2.5.0", features = ["derive"] }
+flume = "0.10"
 futures-util = "0.3"
 log = "0.4"
 rand = "0.8"
@@ -16,5 +17,5 @@ structopt = "0.3"
 thiserror = "1"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"
-tokio-util = { version = "0.7", features = ["codec", "time"] }
+tokio-util = { version = "0.7", features = ["codec"] }
 uplink = { path = "../../uplink" }

--- a/tools/simulator/src/data.rs
+++ b/tools/simulator/src/data.rs
@@ -1,6 +1,6 @@
 use fake::{Dummy, Fake, Faker};
-use flume::{SendError, Sender};
-use log::trace;
+use flume::Sender;
+use log::{error, trace};
 use rand::seq::SliceRandom;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
@@ -12,7 +12,6 @@ use std::time::Duration;
 
 use crate::Payload;
 
-type SimResult<T> = Result<(), T>;
 const RESET_LIMIT: u32 = 1500;
 
 #[inline]
@@ -60,7 +59,7 @@ pub struct Gps {
 }
 
 impl Gps {
-    pub async fn simulate(tx: Sender<Payload>, device: DeviceData) -> SimResult<SendError<Payload>> {
+    pub async fn simulate(tx: Sender<Payload>, device: DeviceData) {
         let mut sequence = 0;
         let mut interval = interval(DataType::Gps.duration());
         let path_len = device.path.len() as u32;
@@ -73,7 +72,12 @@ impl Gps {
 
             trace!("Data Event: {:?}", payload);
 
-            tx.send_async(Payload::new("gps".to_string(), sequence, json!(payload))).await?
+            if let Err(e) =
+                tx.send_async(Payload::new("gps".to_string(), sequence, json!(payload))).await
+            {
+                error!("{e}");
+                break;
+            }
         }
     }
 }
@@ -183,7 +187,7 @@ pub struct Bms {
 }
 
 impl Bms {
-    pub async fn simulate(tx: Sender<Payload>) -> SimResult<SendError<Payload>> {
+    pub async fn simulate(tx: Sender<Payload>) {
         let mut sequence = 0;
         let mut interval = interval(DataType::Bms.duration());
         loop {
@@ -193,7 +197,12 @@ impl Bms {
 
             trace!("Data Event: {:?}", payload);
 
-            tx.send_async(Payload::new("bms".to_string(), sequence, json!(payload))).await?
+            if let Err(e) =
+                tx.send_async(Payload::new("bms".to_string(), sequence, json!(payload))).await
+            {
+                error!("{e}");
+                break;
+            }
         }
     }
 }
@@ -221,7 +230,7 @@ pub struct Imu {
 }
 
 impl Imu {
-    pub async fn simulate(tx: Sender<Payload>) -> SimResult<SendError<Payload>> {
+    pub async fn simulate(tx: Sender<Payload>) {
         let mut sequence = 0;
         let mut interval = interval(DataType::Imu.duration());
         loop {
@@ -231,7 +240,12 @@ impl Imu {
 
             trace!("Data Event: {:?}", payload);
 
-            tx.send_async(Payload::new("imu".to_string(), sequence, json!(payload))).await?
+            if let Err(e) =
+                tx.send_async(Payload::new("imu".to_string(), sequence, json!(payload))).await
+            {
+                error!("{e}");
+                break;
+            }
         }
     }
 }
@@ -253,7 +267,7 @@ pub struct Motor {
 }
 
 impl Motor {
-    pub async fn simulate(tx: Sender<Payload>) -> SimResult<SendError<Payload>> {
+    pub async fn simulate(tx: Sender<Payload>) {
         let mut sequence = 0;
         let mut interval = interval(DataType::Motor.duration());
         loop {
@@ -263,7 +277,12 @@ impl Motor {
 
             trace!("Data Event: {:?}", payload);
 
-            tx.send_async(Payload::new("motor".to_string(), sequence, json!(payload))).await?
+            if let Err(e) =
+                tx.send_async(Payload::new("motor".to_string(), sequence, json!(payload))).await
+            {
+                error!("{e}");
+                break;
+            }
         }
     }
 }
@@ -291,7 +310,7 @@ pub struct PeripheralState {
 }
 
 impl PeripheralState {
-    pub async fn simulate(tx: Sender<Payload>) -> SimResult<SendError<Payload>> {
+    pub async fn simulate(tx: Sender<Payload>) {
         let mut sequence = 0;
         let mut interval = interval(DataType::PeripheralData.duration());
         loop {
@@ -301,8 +320,13 @@ impl PeripheralState {
 
             trace!("Data Event: {:?}", payload);
 
-            tx.send_async(Payload::new("peripheral_state".to_string(), sequence, json!(payload)))
-                .await?
+            if let Err(e) = tx
+                .send_async(Payload::new("peripheral_state".to_string(), sequence, json!(payload)))
+                .await
+            {
+                error!("{e}");
+                break;
+            }
         }
     }
 }
@@ -327,7 +351,7 @@ pub struct DeviceShadow {
 }
 
 impl DeviceShadow {
-    pub async fn simulate(tx: Sender<Payload>) -> SimResult<SendError<Payload>> {
+    pub async fn simulate(tx: Sender<Payload>) {
         let mut sequence = 0;
         let mut interval = interval(DataType::DeviceShadow.duration());
         loop {
@@ -337,8 +361,14 @@ impl DeviceShadow {
 
             trace!("Data Event: {:?}", payload);
 
-            tx.send_async(Payload::new("device_shadow".to_string(), sequence, json!(payload)))
-                .await?;
+            if let Err(e) = tx
+                .send_async(Payload::new("device_shadow".to_string(), sequence, json!(payload)))
+                .await
+            {
+                error!("{e}");
+
+                break;
+            }
         }
     }
 }

--- a/tools/simulator/src/data.rs
+++ b/tools/simulator/src/data.rs
@@ -1,0 +1,344 @@
+use fake::{Dummy, Fake, Faker};
+use flume::{SendError, Sender};
+use log::trace;
+use rand::seq::SliceRandom;
+use rand::Rng;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use tokio::time::interval;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::Payload;
+
+type SimResult<T> = Result<(), T>;
+const RESET_LIMIT: u32 = 1500;
+
+#[inline]
+fn next_sequence(sequence: &mut u32) {
+    if *sequence > RESET_LIMIT {
+        *sequence = 1
+    } else {
+        *sequence += 1
+    };
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum DataType {
+    Gps,
+    Imu,
+    DeviceShadow,
+    PeripheralData,
+    Motor,
+    Bms,
+}
+
+impl DataType {
+    fn duration(&self) -> Duration {
+        match self {
+            DataType::Gps => Duration::from_millis(1000),
+            DataType::Imu => Duration::from_millis(100),
+            DataType::DeviceShadow => Duration::from_millis(1000),
+            DataType::PeripheralData => Duration::from_millis(1000),
+            DataType::Motor => Duration::from_millis(250),
+            DataType::Bms => Duration::from_millis(250),
+        }
+    }
+}
+
+#[derive(Clone, PartialEq)]
+pub struct DeviceData {
+    pub path: Arc<Vec<Gps>>,
+    pub path_offset: u32,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub struct Gps {
+    latitude: f64,
+    longitude: f64,
+}
+
+impl Gps {
+    pub async fn simulate(tx: Sender<Payload>, device: DeviceData) -> SimResult<SendError<Payload>> {
+        let mut sequence = 0;
+        let mut interval = interval(DataType::Gps.duration());
+        let path_len = device.path.len() as u32;
+
+        loop {
+            interval.tick().await;
+            next_sequence(&mut sequence);
+            let path_index = ((device.path_offset + sequence) % path_len) as usize;
+            let payload = device.path.get(path_index).unwrap();
+
+            trace!("Data Event: {:?}", payload);
+
+            tx.send_async(Payload::new("gps".to_string(), sequence, json!(payload))).await?
+        }
+    }
+}
+
+struct BoolString;
+
+impl Dummy<BoolString> for String {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &BoolString, rng: &mut R) -> String {
+        const NAMES: &[&str] = &["on", "off"];
+        NAMES.choose(rng).unwrap().to_string()
+    }
+}
+
+struct VerString;
+
+impl Dummy<VerString> for String {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &VerString, rng: &mut R) -> String {
+        const NAMES: &[&str] = &["v0.0.1", "v0.5.0", "v1.0.1"];
+        NAMES.choose(rng).unwrap().to_string()
+    }
+}
+
+#[derive(Debug, Serialize, Dummy)]
+pub struct Bms {
+    #[dummy(faker = "250")]
+    periodicity_ms: i32,
+    #[dummy(faker = "40.0 .. 45.0")]
+    mosfet_temperature: f64,
+    #[dummy(faker = "35.0 .. 40.0")]
+    ambient_temperature: f64,
+    #[dummy(faker = "1")]
+    mosfet_status: i32,
+    #[dummy(faker = "16")]
+    cell_voltage_count: i32,
+    #[dummy(faker = "3.0 .. 3.2")]
+    cell_voltage_1: f64,
+    #[dummy(faker = "3.0 .. 3.2")]
+    cell_voltage_2: f64,
+    #[dummy(faker = "3.0 .. 3.2")]
+    cell_voltage_3: f64,
+    #[dummy(faker = "3.0 .. 3.2")]
+    cell_voltage_4: f64,
+    #[dummy(faker = "3.0 .. 3.2")]
+    cell_voltage_5: f64,
+    #[dummy(faker = "3.0 .. 3.2")]
+    cell_voltage_6: f64,
+    #[dummy(faker = "3.0 .. 3.2")]
+    cell_voltage_7: f64,
+    #[dummy(faker = "3.0 .. 3.2")]
+    cell_voltage_8: f64,
+    #[dummy(faker = "3.0 .. 3.2")]
+    cell_voltage_9: f64,
+    #[dummy(faker = "3.0 .. 3.2")]
+    cell_voltage_10: f64,
+    #[dummy(faker = "3.0 .. 3.2")]
+    cell_voltage_11: f64,
+    #[dummy(faker = "3.0 .. 3.2")]
+    cell_voltage_12: f64,
+    #[dummy(faker = "3.0 .. 3.2")]
+    cell_voltage_13: f64,
+    #[dummy(faker = "3.0 .. 3.2")]
+    cell_voltage_14: f64,
+    #[dummy(faker = "3.0 .. 3.2")]
+    cell_voltage_15: f64,
+    #[dummy(faker = "3.0 .. 3.2")]
+    cell_voltage_16: f64,
+    #[dummy(faker = "8")]
+    cell_thermistor_count: i32,
+    #[dummy(faker = "40.0 .. 43.0")]
+    cell_temp_1: f64,
+    #[dummy(faker = "40.0 .. 43.0")]
+    cell_temp_2: f64,
+    #[dummy(faker = "40.0 .. 43.0")]
+    cell_temp_3: f64,
+    #[dummy(faker = "40.0 .. 43.0")]
+    cell_temp_4: f64,
+    #[dummy(faker = "40.0 .. 43.0")]
+    cell_temp_5: f64,
+    #[dummy(faker = "40.0 .. 43.0")]
+    cell_temp_6: f64,
+    #[dummy(faker = "40.0 .. 43.0")]
+    cell_temp_7: f64,
+    #[dummy(faker = "40.0 .. 43.0")]
+    cell_temp_8: f64,
+    #[dummy(faker = "1")]
+    cell_balancing_status: i32,
+    #[dummy(faker = "95.0 .. 96.0")]
+    pack_voltage: f64,
+    #[dummy(faker = "15.0 .. 20.0")]
+    pack_current: f64,
+    #[dummy(faker = "80.0 .. 90.0")]
+    pack_soc: f64,
+    #[dummy(faker = "9.5 .. 9.9")]
+    pack_soh: f64,
+    #[dummy(faker = "9.5 .. 9.9")]
+    pack_sop: f64,
+    #[dummy(faker = "100 .. 150")]
+    pack_cycle_count: i64,
+    #[dummy(faker = "2000 .. 3000")]
+    pack_available_energy: i64,
+    #[dummy(faker = "2000 .. 3000")]
+    pack_consumed_energy: i64,
+    #[dummy(faker = "0")]
+    pack_fault: i32,
+    #[dummy(faker = "1")]
+    pack_status: i32,
+}
+
+impl Bms {
+    pub async fn simulate(tx: Sender<Payload>) -> SimResult<SendError<Payload>> {
+        let mut sequence = 0;
+        let mut interval = interval(DataType::Bms.duration());
+        loop {
+            interval.tick().await;
+            let payload: Bms = Faker.fake();
+            next_sequence(&mut sequence);
+
+            trace!("Data Event: {:?}", payload);
+
+            tx.send_async(Payload::new("bms".to_string(), sequence, json!(payload))).await?
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Dummy)]
+pub struct Imu {
+    #[dummy(faker = "1.0 .. 2.8")]
+    ax: f64,
+    #[dummy(faker = "1.0 .. 2.8")]
+    ay: f64,
+    #[dummy(faker = "9.79 .. 9.82")]
+    az: f64,
+    #[dummy(faker = "0.8 .. 1.0")]
+    pitch: f64,
+    #[dummy(faker = "0.8 .. 1.0")]
+    roll: f64,
+    #[dummy(faker = "0.8 .. 1.0")]
+    yaw: f64,
+    #[dummy(faker = "-45.0 .. -15.0")]
+    magx: f64,
+    #[dummy(faker = "-45.0 .. -15.0")]
+    magy: f64,
+    #[dummy(faker = "-45.0 .. -15.0")]
+    magz: f64,
+}
+
+impl Imu {
+    pub async fn simulate(tx: Sender<Payload>) -> SimResult<SendError<Payload>> {
+        let mut sequence = 0;
+        let mut interval = interval(DataType::Imu.duration());
+        loop {
+            interval.tick().await;
+            let payload: Imu = Faker.fake();
+            next_sequence(&mut sequence);
+
+            trace!("Data Event: {:?}", payload);
+
+            tx.send_async(Payload::new("imu".to_string(), sequence, json!(payload))).await?
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Dummy)]
+pub struct Motor {
+    #[dummy(faker = "40.0 .. 45.0")]
+    motor_temperature1: f64,
+    #[dummy(faker = "40.0 .. 45.0")]
+    motor_temperature2: f64,
+    #[dummy(faker = "40.0 .. 45.0")]
+    motor_temperature3: f64,
+    #[dummy(faker = "95.0 .. 96.0")]
+    motor_voltage: f64,
+    #[dummy(faker = "20.0 .. 25.0")]
+    motor_current: f64,
+    #[dummy(faker = "1000 .. 9000")]
+    motor_rpm: i64,
+}
+
+impl Motor {
+    pub async fn simulate(tx: Sender<Payload>) -> SimResult<SendError<Payload>> {
+        let mut sequence = 0;
+        let mut interval = interval(DataType::Motor.duration());
+        loop {
+            interval.tick().await;
+            let payload: Motor = Faker.fake();
+            next_sequence(&mut sequence);
+
+            trace!("Data Event: {:?}", payload);
+
+            tx.send_async(Payload::new("motor".to_string(), sequence, json!(payload))).await?
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Dummy)]
+pub struct PeripheralState {
+    #[dummy(faker = "BoolString")]
+    gps_status: String,
+    #[dummy(faker = "BoolString")]
+    gsm_status: String,
+    #[dummy(faker = "BoolString")]
+    imu_status: String,
+    #[dummy(faker = "BoolString")]
+    left_indicator: String,
+    #[dummy(faker = "BoolString")]
+    right_indicator: String,
+    #[dummy(faker = "BoolString")]
+    headlamp: String,
+    #[dummy(faker = "BoolString")]
+    horn: String,
+    #[dummy(faker = "BoolString")]
+    left_brake: String,
+    #[dummy(faker = "BoolString")]
+    right_brake: String,
+}
+
+impl PeripheralState {
+    pub async fn simulate(tx: Sender<Payload>) -> SimResult<SendError<Payload>> {
+        let mut sequence = 0;
+        let mut interval = interval(DataType::PeripheralData.duration());
+        loop {
+            interval.tick().await;
+            let payload: PeripheralState = Faker.fake();
+            next_sequence(&mut sequence);
+
+            trace!("Data Event: {:?}", payload);
+
+            tx.send_async(Payload::new("peripheral_state".to_string(), sequence, json!(payload)))
+                .await?
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Dummy)]
+pub struct DeviceShadow {
+    #[dummy(faker = "BoolString")]
+    mode: String,
+    #[dummy(faker = "BoolString")]
+    status: String,
+    #[dummy(faker = "VerString")]
+    firmware_version: String,
+    #[dummy(faker = "VerString")]
+    config_version: String,
+    #[dummy(faker = "20000..30000")]
+    distance_travelled: i64,
+    #[dummy(faker = "50000..60000")]
+    range: i64,
+    #[serde(rename(serialize = "SOC"))]
+    #[dummy(faker = "50.0..90.0")]
+    soc: f64,
+}
+
+impl DeviceShadow {
+    pub async fn simulate(tx: Sender<Payload>) -> SimResult<SendError<Payload>> {
+        let mut sequence = 0;
+        let mut interval = interval(DataType::DeviceShadow.duration());
+        loop {
+            interval.tick().await;
+            let payload: DeviceShadow = Faker.fake();
+            next_sequence(&mut sequence);
+
+            trace!("Data Event: {:?}", payload);
+
+            tx.send_async(Payload::new("device_shadow".to_string(), sequence, json!(payload)))
+                .await?;
+        }
+    }
+}

--- a/tools/simulator/src/main.rs
+++ b/tools/simulator/src/main.rs
@@ -103,8 +103,6 @@ pub struct ActionResponseEvent {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Payload {
     pub stream: String,
-    #[serde(skip)]
-    pub device_id: Option<String>,
     pub sequence: u32,
     pub timestamp: u64,
     #[serde(flatten)]
@@ -127,7 +125,6 @@ pub fn generate_gps_data(device: &DeviceData, sequence: u32) -> Payload {
 
     Payload {
         timestamp,
-        device_id: None,
         sequence,
         stream: "gps".to_string(),
         payload: json!(position),
@@ -246,7 +243,6 @@ pub fn generate_bms_data(sequence: u32) -> Payload {
 
     Payload {
         timestamp,
-        device_id: None,
         sequence,
         stream: "bms".to_string(),
         payload: json!(payload),
@@ -283,7 +279,6 @@ pub fn generate_imu_data(sequence: u32) -> Payload {
 
     Payload {
         timestamp,
-        device_id: None,
         sequence,
         stream: "imu".to_string(),
         payload: json!(payload),
@@ -314,7 +309,6 @@ pub fn generate_motor_data(sequence: u32) -> Payload {
 
     Payload {
         timestamp,
-        device_id: None,
         sequence,
         stream: "motor".to_string(),
         payload: json!(payload),
@@ -351,7 +345,6 @@ pub fn generate_peripheral_state_data(sequence: u32) -> Payload {
 
     Payload {
         timestamp,
-        device_id: None,
         sequence,
         stream: "peripheral_state".to_string(),
         payload: json!(payload),
@@ -385,7 +378,6 @@ pub fn generate_device_shadow_data(sequence: u32) -> Payload {
 
     Payload {
         timestamp,
-        device_id: None,
         sequence,
         stream: "device_shadow".to_string(),
         payload: json!(payload),
@@ -519,7 +511,6 @@ async fn process_action_response_event(
     //info!("Sending action response {:?} {} {} {}", event.action_id, event.progress, event.status);
     let payload = Payload {
         stream: "action_status".to_string(),
-        device_id: None,
         sequence: 0,
         timestamp: SystemTime::UNIX_EPOCH.elapsed().unwrap().as_millis() as u64,
         payload: json!({

--- a/tools/simulator/src/main.rs
+++ b/tools/simulator/src/main.rs
@@ -1,9 +1,8 @@
-use fake::{Dummy, Fake, Faker};
+use data::{Bms, DeviceData, DeviceShadow, Gps, Imu, Motor, PeripheralState};
+use flume::{bounded, SendError, Sender};
 use futures_util::sink::SinkExt;
-use futures_util::stream::SplitSink;
 use futures_util::StreamExt;
-use log::{error, info, trace, LevelFilter};
-use rand::seq::SliceRandom;
+use log::{error, info, LevelFilter};
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -13,15 +12,15 @@ use simplelog::{
 use structopt::StructOpt;
 use thiserror::Error;
 use tokio::net::TcpStream;
-use tokio::select;
+use tokio::time::interval;
+use tokio::{select, spawn};
 use tokio_util::codec::{Framed, LinesCodec, LinesCodecError};
-use tokio_util::time::DelayQueue;
 use uplink::Action;
 
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use std::{fs, io, sync::Arc};
 
-const RESET_LIMIT: u32 = 1500;
+mod data;
 
 #[derive(StructOpt, Debug)]
 #[structopt(name = "simulator", about = "simulates a demo device")]
@@ -49,55 +48,42 @@ pub enum Error {
     Json(#[from] serde_json::error::Error),
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
-pub struct Location {
-    latitude: f64,
-    longitude: f64,
-}
-
-#[derive(Clone, PartialEq)]
-pub struct DeviceData {
-    path: Arc<Vec<Location>>,
-    path_offset: u32,
-}
-
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub enum DataEventType {
-    GenerateGPS,
-    GenerateIMU,
-    GenerateVehicleData,
-    GeneratePeripheralData,
-    GenerateMotor,
-    GenerateBMS,
-}
-
-impl DataEventType {
-    fn duration(&self) -> Duration {
-        match self {
-            DataEventType::GenerateGPS => Duration::from_millis(1000),
-            DataEventType::GenerateIMU => Duration::from_millis(100),
-            DataEventType::GenerateVehicleData => Duration::from_millis(1000),
-            DataEventType::GeneratePeripheralData => Duration::from_millis(1000),
-            DataEventType::GenerateMotor => Duration::from_millis(250),
-            DataEventType::GenerateBMS => Duration::from_millis(250),
-        }
-    }
-}
-
-#[derive(Clone, PartialEq)]
-pub struct DataEvent {
-    timestamp: Instant,
-    event_type: DataEventType,
-    device: DeviceData,
-    sequence: u32,
-}
-
-#[derive(Clone, PartialEq, Eq)]
-pub struct ActionResponseEvent {
-    timestamp: Instant,
+#[derive(Serialize)]
+pub struct ActionResponse {
     action_id: String,
     status: String,
     progress: u8,
+}
+
+impl ActionResponse {
+    pub async fn simulate(action: Action, tx: Sender<Payload>) -> Result<(), SendError<Payload>> {
+        let action_id = action.action_id;
+        info!("Generating action events for action: {action_id}");
+        let mut sequence = 0;
+        let mut interval = interval(Duration::from_secs(10));
+
+        // Action response, 10% completion per second
+        for i in 1..10 {
+            let response = ActionResponse {
+                action_id: action_id.clone(),
+                progress: i * 10 + rand::thread_rng().gen_range(0..10),
+                status: String::from("in_progress"),
+            };
+            sequence += 1;
+            tx.send_async(Payload::new("action_status".to_string(), sequence, json!(response)))
+                .await?;
+
+            interval.tick().await;
+        }
+
+        let response =
+            ActionResponse { action_id, progress: 100, status: String::from("Completed") };
+        sequence += 1;
+        tx.send_async(Payload::new("action_status".to_string(), sequence, json!(response))).await?;
+        info!("Successfully sent all action responses");
+
+        Ok(())
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -109,293 +95,29 @@ pub struct Payload {
     pub payload: Value,
 }
 
-#[derive(Clone, PartialEq)]
-pub enum Event {
-    DataEvent(DataEvent),
-    ActionResponseEvent(ActionResponseEvent),
-}
-
-pub fn generate_gps_data(device: &DeviceData, sequence: u32) -> Payload {
-    let timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis() as u64;
-    let path_len = device.path.len() as u32;
-    let path_index = ((device.path_offset + sequence) % path_len) as usize;
-    let position = device.path.get(path_index).unwrap();
-
-    trace!("Data Event: GPS {:?}", position);
-
-    Payload {
-        timestamp,
-        sequence,
-        stream: "gps".to_string(),
-        payload: json!(position),
+impl Payload {
+    fn new(stream: String, sequence: u32, payload: Value) -> Self {
+        Self {
+            stream,
+            sequence,
+            timestamp: SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis() as u64,
+            payload,
+        }
     }
 }
 
-struct BoolString;
-
-impl Dummy<BoolString> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &BoolString, rng: &mut R) -> String {
-        const NAMES: &[&str] = &["on", "off"];
-        NAMES.choose(rng).unwrap().to_string()
-    }
-}
-
-struct VerString;
-
-impl Dummy<VerString> for String {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &VerString, rng: &mut R) -> String {
-        const NAMES: &[&str] = &["v0.0.1", "v0.5.0", "v1.0.1"];
-        NAMES.choose(rng).unwrap().to_string()
-    }
-}
-
-#[derive(Debug, Serialize, Dummy)]
-struct Bms {
-    #[dummy(faker = "250")]
-    periodicity_ms: i32,
-    #[dummy(faker = "40.0 .. 45.0")]
-    mosfet_temperature: f64,
-    #[dummy(faker = "35.0 .. 40.0")]
-    ambient_temperature: f64,
-    #[dummy(faker = "1")]
-    mosfet_status: i32,
-    #[dummy(faker = "16")]
-    cell_voltage_count: i32,
-    #[dummy(faker = "3.0 .. 3.2")]
-    cell_voltage_1: f64,
-    #[dummy(faker = "3.0 .. 3.2")]
-    cell_voltage_2: f64,
-    #[dummy(faker = "3.0 .. 3.2")]
-    cell_voltage_3: f64,
-    #[dummy(faker = "3.0 .. 3.2")]
-    cell_voltage_4: f64,
-    #[dummy(faker = "3.0 .. 3.2")]
-    cell_voltage_5: f64,
-    #[dummy(faker = "3.0 .. 3.2")]
-    cell_voltage_6: f64,
-    #[dummy(faker = "3.0 .. 3.2")]
-    cell_voltage_7: f64,
-    #[dummy(faker = "3.0 .. 3.2")]
-    cell_voltage_8: f64,
-    #[dummy(faker = "3.0 .. 3.2")]
-    cell_voltage_9: f64,
-    #[dummy(faker = "3.0 .. 3.2")]
-    cell_voltage_10: f64,
-    #[dummy(faker = "3.0 .. 3.2")]
-    cell_voltage_11: f64,
-    #[dummy(faker = "3.0 .. 3.2")]
-    cell_voltage_12: f64,
-    #[dummy(faker = "3.0 .. 3.2")]
-    cell_voltage_13: f64,
-    #[dummy(faker = "3.0 .. 3.2")]
-    cell_voltage_14: f64,
-    #[dummy(faker = "3.0 .. 3.2")]
-    cell_voltage_15: f64,
-    #[dummy(faker = "3.0 .. 3.2")]
-    cell_voltage_16: f64,
-    #[dummy(faker = "8")]
-    cell_thermistor_count: i32,
-    #[dummy(faker = "40.0 .. 43.0")]
-    cell_temp_1: f64,
-    #[dummy(faker = "40.0 .. 43.0")]
-    cell_temp_2: f64,
-    #[dummy(faker = "40.0 .. 43.0")]
-    cell_temp_3: f64,
-    #[dummy(faker = "40.0 .. 43.0")]
-    cell_temp_4: f64,
-    #[dummy(faker = "40.0 .. 43.0")]
-    cell_temp_5: f64,
-    #[dummy(faker = "40.0 .. 43.0")]
-    cell_temp_6: f64,
-    #[dummy(faker = "40.0 .. 43.0")]
-    cell_temp_7: f64,
-    #[dummy(faker = "40.0 .. 43.0")]
-    cell_temp_8: f64,
-    #[dummy(faker = "1")]
-    cell_balancing_status: i32,
-    #[dummy(faker = "95.0 .. 96.0")]
-    pack_voltage: f64,
-    #[dummy(faker = "15.0 .. 20.0")]
-    pack_current: f64,
-    #[dummy(faker = "80.0 .. 90.0")]
-    pack_soc: f64,
-    #[dummy(faker = "9.5 .. 9.9")]
-    pack_soh: f64,
-    #[dummy(faker = "9.5 .. 9.9")]
-    pack_sop: f64,
-    #[dummy(faker = "100 .. 150")]
-    pack_cycle_count: i64,
-    #[dummy(faker = "2000 .. 3000")]
-    pack_available_energy: i64,
-    #[dummy(faker = "2000 .. 3000")]
-    pack_consumed_energy: i64,
-    #[dummy(faker = "0")]
-    pack_fault: i32,
-    #[dummy(faker = "1")]
-    pack_status: i32,
-}
-
-pub fn generate_bms_data(sequence: u32) -> Payload {
-    let timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis() as u64;
-    let payload: Bms = Faker.fake();
-
-    trace!("Data Event: {:?}", payload);
-
-    Payload {
-        timestamp,
-        sequence,
-        stream: "bms".to_string(),
-        payload: json!(payload),
-    }
-}
-
-#[derive(Debug, Serialize, Dummy)]
-struct Imu {
-    #[dummy(faker = "1.0 .. 2.8")]
-    ax: f64,
-    #[dummy(faker = "1.0 .. 2.8")]
-    ay: f64,
-    #[dummy(faker = "9.79 .. 9.82")]
-    az: f64,
-    #[dummy(faker = "0.8 .. 1.0")]
-    pitch: f64,
-    #[dummy(faker = "0.8 .. 1.0")]
-    roll: f64,
-    #[dummy(faker = "0.8 .. 1.0")]
-    yaw: f64,
-    #[dummy(faker = "-45.0 .. -15.0")]
-    magx: f64,
-    #[dummy(faker = "-45.0 .. -15.0")]
-    magy: f64,
-    #[dummy(faker = "-45.0 .. -15.0")]
-    magz: f64,
-}
-
-pub fn generate_imu_data(sequence: u32) -> Payload {
-    let timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis() as u64;
-    let payload: Imu = Faker.fake();
-
-    trace!("Data Event: {:?}", payload);
-
-    Payload {
-        timestamp,
-        sequence,
-        stream: "imu".to_string(),
-        payload: json!(payload),
-    }
-}
-
-#[derive(Debug, Serialize, Dummy)]
-struct Motor {
-    #[dummy(faker = "40.0 .. 45.0")]
-    motor_temperature1: f64,
-    #[dummy(faker = "40.0 .. 45.0")]
-    motor_temperature2: f64,
-    #[dummy(faker = "40.0 .. 45.0")]
-    motor_temperature3: f64,
-    #[dummy(faker = "95.0 .. 96.0")]
-    motor_voltage: f64,
-    #[dummy(faker = "20.0 .. 25.0")]
-    motor_current: f64,
-    #[dummy(faker = "1000 .. 9000")]
-    motor_rpm: i64,
-}
-
-pub fn generate_motor_data(sequence: u32) -> Payload {
-    let timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis() as u64;
-    let payload: Motor = Faker.fake();
-
-    trace!("Data Event: {:?}", payload);
-
-    Payload {
-        timestamp,
-        sequence,
-        stream: "motor".to_string(),
-        payload: json!(payload),
-    }
-}
-
-#[derive(Debug, Serialize, Dummy)]
-struct PeripheralState {
-    #[dummy(faker = "BoolString")]
-    gps_status: String,
-    #[dummy(faker = "BoolString")]
-    gsm_status: String,
-    #[dummy(faker = "BoolString")]
-    imu_status: String,
-    #[dummy(faker = "BoolString")]
-    left_indicator: String,
-    #[dummy(faker = "BoolString")]
-    right_indicator: String,
-    #[dummy(faker = "BoolString")]
-    headlamp: String,
-    #[dummy(faker = "BoolString")]
-    horn: String,
-    #[dummy(faker = "BoolString")]
-    left_brake: String,
-    #[dummy(faker = "BoolString")]
-    right_brake: String,
-}
-
-pub fn generate_peripheral_state_data(sequence: u32) -> Payload {
-    let timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis() as u64;
-    let payload: PeripheralState = Faker.fake();
-
-    trace!("Data Event: {:?}", payload);
-
-    Payload {
-        timestamp,
-        sequence,
-        stream: "peripheral_state".to_string(),
-        payload: json!(payload),
-    }
-}
-
-#[derive(Debug, Serialize, Dummy)]
-struct DeviceShadow {
-    #[dummy(faker = "BoolString")]
-    mode: String,
-    #[dummy(faker = "BoolString")]
-    status: String,
-    #[dummy(faker = "VerString")]
-    firmware_version: String,
-    #[dummy(faker = "VerString")]
-    config_version: String,
-    #[dummy(faker = "20000..30000")]
-    distance_travelled: i64,
-    #[dummy(faker = "50000..60000")]
-    range: i64,
-    #[serde(rename(serialize = "SOC"))]
-    #[dummy(faker = "50.0..90.0")]
-    soc: f64,
-}
-
-pub fn generate_device_shadow_data(sequence: u32) -> Payload {
-    let timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis() as u64;
-    let payload: DeviceShadow = Faker.fake();
-
-    trace!("Data Event: {:?}", payload);
-
-    Payload {
-        timestamp,
-        sequence,
-        stream: "device_shadow".to_string(),
-        payload: json!(payload),
-    }
-}
-
-pub fn read_gps_path(paths_dir: &str) -> Arc<Vec<Location>> {
+pub fn read_gps_path(paths_dir: &str) -> Arc<Vec<Gps>> {
     let i = rand::thread_rng().gen_range(0..10);
-    let file_name = format!("{}/path{}.json", paths_dir, i);
+    let file_name: String = format!("{}/path{}.json", paths_dir, i);
 
     let contents = fs::read_to_string(file_name).expect("Oops, failed ot read path");
 
-    let parsed: Vec<Location> = serde_json::from_str(&contents).unwrap();
+    let parsed: Vec<Gps> = serde_json::from_str(&contents).unwrap();
 
     Arc::new(parsed)
 }
 
-pub fn new_device_data(path: Arc<Vec<Location>>) -> DeviceData {
+pub fn new_device_data(path: Arc<Vec<Gps>>) -> DeviceData {
     let mut rng = rand::thread_rng();
 
     let path_index = rng.gen_range(0..path.len()) as u32;
@@ -403,182 +125,13 @@ pub fn new_device_data(path: Arc<Vec<Location>>) -> DeviceData {
     DeviceData { path, path_offset: path_index }
 }
 
-pub fn generate_initial_events(events: &mut DelayQueue<Event>, now: Instant, device: &DeviceData) {
-    let duration = DataEventType::GenerateGPS.duration();
-    events.insert(
-        Event::DataEvent(DataEvent {
-            event_type: DataEventType::GenerateGPS,
-            device: device.clone(),
-            timestamp: now + duration,
-            sequence: 1,
-        }),
-        duration,
-    );
-
-    let duration = DataEventType::GenerateVehicleData.duration();
-    events.insert(
-        Event::DataEvent(DataEvent {
-            event_type: DataEventType::GenerateVehicleData,
-            device: device.clone(),
-            timestamp: now + duration,
-            sequence: 1,
-        }),
-        duration,
-    );
-
-    let duration = DataEventType::GeneratePeripheralData.duration();
-    events.insert(
-        Event::DataEvent(DataEvent {
-            event_type: DataEventType::GeneratePeripheralData,
-            device: device.clone(),
-            timestamp: now + duration,
-            sequence: 1,
-        }),
-        duration,
-    );
-
-    let duration = DataEventType::GenerateMotor.duration();
-    events.insert(
-        Event::DataEvent(DataEvent {
-            event_type: DataEventType::GenerateMotor,
-            device: device.clone(),
-            timestamp: now + duration,
-            sequence: 1,
-        }),
-        duration,
-    );
-
-    let duration = DataEventType::GenerateBMS.duration();
-    events.insert(
-        Event::DataEvent(DataEvent {
-            event_type: DataEventType::GenerateBMS,
-            device: device.clone(),
-            timestamp: now + duration,
-            sequence: 1,
-        }),
-        duration,
-    );
-
-    let duration = DataEventType::GenerateIMU.duration();
-    events.insert(
-        Event::DataEvent(DataEvent {
-            event_type: DataEventType::GenerateIMU,
-            device: device.clone(),
-            timestamp: now + duration,
-            sequence: 1,
-        }),
-        duration,
-    );
-}
-
-pub async fn process_data_event(
-    event: &DataEvent,
-    events: &mut DelayQueue<Event>,
-    client: &mut SplitSink<Framed<TcpStream, LinesCodec>, String>,
-) -> Result<(), Error> {
-    let data = match event.event_type {
-        DataEventType::GenerateGPS => generate_gps_data(&event.device, event.sequence),
-        DataEventType::GenerateIMU => generate_imu_data(event.sequence),
-        DataEventType::GenerateVehicleData => generate_device_shadow_data(event.sequence),
-        DataEventType::GeneratePeripheralData => generate_peripheral_state_data(event.sequence),
-        DataEventType::GenerateMotor => generate_motor_data(event.sequence),
-        DataEventType::GenerateBMS => generate_bms_data(event.sequence),
-    };
-
-    let payload = serde_json::to_string(&data)?;
-    client.send(payload).await?;
-
-    let duration = event.event_type.duration();
-    let sequence = if event.sequence >= RESET_LIMIT { 1 } else { event.sequence + 1 };
-
-    events.insert(
-        Event::DataEvent(DataEvent {
-            sequence,
-            timestamp: event.timestamp + duration,
-            device: event.device.clone(),
-            event_type: event.event_type,
-        }),
-        duration,
-    );
-
-    Ok(())
-}
-
-async fn process_action_response_event(
-    event: &ActionResponseEvent,
-    client: &mut SplitSink<Framed<TcpStream, LinesCodec>, String>,
-) -> Result<(), Error> {
-    //info!("Sending action response {:?} {} {} {}", event.action_id, event.progress, event.status);
-    let payload = Payload {
-        stream: "action_status".to_string(),
-        sequence: 0,
-        timestamp: SystemTime::UNIX_EPOCH.elapsed().unwrap().as_millis() as u64,
-        payload: json!({
-            "action_id": event.action_id,
-            "state": event.status,
-            "progress": event.progress,
-            "errors": []
-        }),
-    };
-
-    info!("Sending action response {} {} {}", event.action_id, event.progress, event.status);
-
-    let payload = serde_json::to_string(&payload)?;
-    client.send(payload).await?;
-    info!("Successfully sent action response");
-
-    Ok(())
-}
-
-pub async fn process_events(
-    events: &mut DelayQueue<Event>,
-    client: &mut SplitSink<Framed<TcpStream, LinesCodec>, String>,
-) -> Result<(), Error> {
-    if let Some(e) = events.next().await {
-        match e.into_inner() {
-            Event::DataEvent(event) => {
-                process_data_event(&event, events, client).await?;
-            }
-
-            Event::ActionResponseEvent(event) => {
-                process_action_response_event(&event, client).await?;
-            }
-        }
-    }
-
-    Ok(())
-}
-
-pub fn generate_action_events(action: Action, events: &mut DelayQueue<Event>) {
-    let action_id = action.action_id;
-
-    info!("Generating action events for action: {action_id}");
-    let now = Instant::now();
-
-    // Action response, 10% completion per second
-    for i in 1..10 {
-        let duration = Duration::from_secs(i as u64);
-        events.insert(
-            Event::ActionResponseEvent(ActionResponseEvent {
-                action_id: action_id.clone(),
-                progress: i * 10,
-                status: String::from("in_progress"),
-                timestamp: now + duration,
-            }),
-            duration,
-        );
-    }
-
-    let duration = Duration::from_secs(10);
-    events.insert(
-        Event::ActionResponseEvent(ActionResponseEvent {
-            action_id,
-            progress: 100,
-            status: String::from("Completed"),
-            timestamp: now + duration,
-        }),
-        duration,
-    );
+pub fn spawn_data_simulators(device: DeviceData, tx: Sender<Payload>) {
+    spawn(Gps::simulate(tx.clone(), device));
+    spawn(Bms::simulate(tx.clone()));
+    spawn(Imu::simulate(tx.clone()));
+    spawn(Motor::simulate(tx.clone()));
+    spawn(PeripheralState::simulate(tx.clone()));
+    spawn(DeviceShadow::simulate(tx.clone()));
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -592,18 +145,28 @@ async fn main() -> Result<(), Error> {
     let stream = TcpStream::connect(addr).await?;
     let (mut data_tx, mut actions_rx) = Framed::new(stream, LinesCodec::new()).split();
 
-    let mut events = DelayQueue::new();
-
-    generate_initial_events(&mut events, Instant::now(), &device);
+    let (tx, rx) = bounded(10);
+    spawn_data_simulators(device, tx.clone());
 
     loop {
         select! {
             line = actions_rx.next() => {
                 let line = line.ok_or(Error::StreamDone)??;
                 let action = serde_json::from_str(&line)?;
-                generate_action_events(action, &mut events);
+                spawn(ActionResponse::simulate(action,  tx.clone()));
             }
-            _ = process_events(&mut events, &mut data_tx) => {
+            p = rx.recv_async() => {
+                let payload = match p {
+                    Ok(p) => p,
+                    Err(_) => {
+                        error!("All generators have stopped!");
+                        return Ok(())
+                    }
+                };
+
+
+                let text = serde_json::to_string(&payload)?;
+                data_tx.send(text).await?;
             }
         }
     }


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->

### Why?
Readability and timely generation of messages is a problem as we are unnecessarily relying on hand written code to handle it when tokio has abstractions that can easily improve readability as well as effectively remove the time skew

### Trials Performed
Test against stage: [uplink.log](https://gist.github.com/de-sh/c92f536568cea98f930f77171c87d4bb)

As can be noted from the logs, delta between timestamp values are exactly the values expected:
```
# GPS
>>> 1692540495482 - 1692540494482 
1000
# BMS
>>> 1692540494732 - 1692540494482
250
# IMU
>>> 1692540494582 - 1692540494482
100
# Motor
>>> 1692540494732 - 1692540494482
250
```