### PR TITLE
refactor: `TunshellSession` ~> `TunshellClient`

### DIFF
--- a/uplink/src/collector/tunshell.rs
+++ b/uplink/src/collector/tunshell.rs
@@ -1,14 +1,22 @@
-use std::sync::Arc;
-
 use log::error;
 use serde::{Deserialize, Serialize};
 use tokio_compat_02::FutureExt;
 use tunshell_client::{Client, ClientMode, Config, HostShell};
 
 use crate::{
-    base::{self, bridge::BridgeTx, ActionRoute},
-    ActionResponse,
+    base::{bridge::BridgeTx, ActionRoute},
+    Action, ActionResponse,
 };
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("Failed to deserialize keys. Error = {0}")]
+    Serde(#[from] serde_json::Error),
+    #[error("TunshellClient client Error = {0}")]
+    TunshellClient(#[from] anyhow::Error),
+    #[error("TunshellClient exited with unexpected status: {0}")]
+    UnexpectedStatus(u8),
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Keys {
@@ -17,15 +25,14 @@ pub struct Keys {
     encryption: String,
 }
 
-pub struct TunshellSession {
-    _config: Arc<base::Config>,
-    echo_stdout: bool,
+#[derive(Debug, Clone)]
+pub struct TunshellClient {
     bridge: BridgeTx,
 }
 
-impl TunshellSession {
-    pub fn new(config: Arc<base::Config>, echo_stdout: bool, bridge: BridgeTx) -> Self {
-        Self { _config: config, echo_stdout, bridge }
+impl TunshellClient {
+    pub fn new(bridge: BridgeTx) -> Self {
+        Self { bridge }
     }
 
     fn config(&self, keys: Keys) -> Config {
@@ -37,7 +44,7 @@ impl TunshellSession {
             443,
             &keys.encryption,
             true,
-            self.echo_stdout,
+            false,
         )
     }
 
@@ -47,45 +54,34 @@ impl TunshellSession {
         let actions_rx = self.bridge.register_action_route(route).await;
 
         while let Ok(action) = actions_rx.recv_async().await {
-            let action_id = action.action_id.clone();
-
-            // println!("{:?}", keys);
-            let keys = match serde_json::from_str(&action.payload) {
-                Ok(k) => k,
-                Err(e) => {
-                    error!("Failed to deserialize keys. Error = {:?}", e);
-                    let status = ActionResponse::failure(&action_id, "corruptkeys".to_owned());
-                    self.bridge.send_action_response(status).await;
-                    continue;
-                }
-            };
-
-            let mut client = Client::new(self.config(keys), HostShell::new().unwrap());
-            let status_tx = self.bridge.clone();
-
+            let session = self.clone();
             //TODO(RT): Findout why this is spawned. We want to send other action's with shell?
             tokio::spawn(async move {
-                let response = ActionResponse::progress(&action_id, "ShellSpawned", 90);
-                status_tx.send_action_response(response).await;
-
-                match client.start_session().compat().await {
-                    Ok(status) => {
-                        if status != 0 {
-                            let response = ActionResponse::failure(&action_id, status.to_string());
-                            status_tx.send_action_response(response).await;
-                        } else {
-                            log::info!("tunshell exited with status: {}", status);
-                            let response = ActionResponse::success(&action_id);
-                            status_tx.send_action_response(response).await;
-                        }
-                    }
-                    Err(e) => {
-                        log::warn!("tunshell client error: {}", e);
-                        let response = ActionResponse::failure(&action_id, e.to_string());
-                        status_tx.send_action_response(response).await;
-                    }
-                };
+                if let Err(e) = session.session(&action).await {
+                    error!("{}", e.to_string());
+                    let status = ActionResponse::failure(&action.action_id, e.to_string());
+                    session.bridge.send_action_response(status).await;
+                }
             });
+        }
+    }
+
+    async fn session(&self, action: &Action) -> Result<(), Error> {
+        let action_id = action.action_id.clone();
+
+        // println!("{:?}", keys);
+        let keys = serde_json::from_str(&action.payload)?;
+        let mut client = Client::new(self.config(keys), HostShell::new().unwrap());
+
+        let response = ActionResponse::progress(&action_id, "ShellSpawned", 90);
+        self.bridge.send_action_response(response).await;
+
+        let status = client.start_session().compat().await?;
+        if status != 0 {
+            Err(Error::UnexpectedStatus(status))
+        } else {
+            log::info!("Tunshell session ended successfully");
+            Ok(())
         }
     }
 }

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -55,7 +55,7 @@ use collector::installer::OTAInstaller;
 use collector::process::ProcessHandler;
 use collector::script_runner::ScriptRunner;
 use collector::systemstats::StatCollector;
-use collector::tunshell::TunshellSession;
+use collector::tunshell::TunshellClient;
 use flume::{bounded, Receiver, RecvError, Sender};
 use log::error;
 
@@ -392,8 +392,8 @@ impl Uplink {
             })
         });
 
-        let tunshell_session = TunshellSession::new(config.clone(), false, bridge_tx.clone());
-        thread::spawn(move || tunshell_session.start());
+        let tunshell_client = TunshellClient::new(bridge_tx.clone());
+        thread::spawn(move || tunshell_client.start());
 
         let file_downloader = FileDownloader::new(config.clone(), bridge_tx.clone())?;
         thread::spawn(move || file_downloader.start());


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->
- Rename `TunshellSession` to `TunshellClient`
- Create an error type
- Remove unused `_config` and `echo_stdout`
- Refactor code to improve readabilitiy

### Why?
<!--Detailed description of why the changes had to be made-->
For maintainability

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
Start a tunshell session from stage:
```
  2023-08-23T03:55:35.200529Z  INFO uplink::base::mqtt: Action = Action { device_id: None, action_id: "1457", kind: "process", name: "launch_shell", payload: "{\"encryption\":\"JKyD8e86uifeBdJdf6ZuLM\",\"relay\":\"eu.relay.tunshell.com\",\"session\":\"PyqjSk1RBHKax2Soh6OXPG\"}" }

  2023-08-23T03:55:35.200776Z  INFO uplink::base::bridge: Received action: Action { device_id: None, action_id: "1457", kind: "process", name: "launch_shell", payload: "{\"encryption\":\"JKyD8e86uifeBdJdf6ZuLM\",\"relay\":\"eu.relay.tunshell.com\",\"session\":\"PyqjSk1RBHKax2Soh6OXPG\"}" }

  2023-08-23T03:55:35.200918Z  INFO uplink::base::bridge: Action response = ActionResponse { action_id: "1457", device_id: None, sequence: 0, timestamp: 1692762935200, state: "Received", progress: 0, errors: [], done_response: None }

  2023-08-23T03:55:35.201006Z DEBUG uplink::base::bridge::stream: Sequence number anomaly! [0, 0

  2023-08-23T03:55:35.201043Z TRACE uplink::base::bridge::stream: Flushing stream name: action_status, topic: /tenants/demo/devices/1001/action/status

  2023-08-23T03:55:35.201217Z  INFO uplink::base::bridge: Action response = ActionResponse { action_id: "1457", device_id: None, sequence: 0, timestamp: 1692762935201, state: "ShellSpawned", progress: 90, errors: [], done_response: None }

  2023-08-23T03:55:35.201201Z TRACE uplink::base::serializer: Data received on stream: action_status; message count = 1; batching latency = 0

  2023-08-23T03:55:35.201279Z DEBUG uplink::base::bridge::stream: Sequence number anomaly! [0, 0

  2023-08-23T03:55:35.201317Z TRACE uplink::base::bridge::stream: Flushing stream name: action_status, topic: /tenants/demo/devices/1001/action/status

  2023-08-23T03:55:35.201331Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/action/status with size = 105

  2023-08-23T03:55:35.201394Z TRACE uplink::base::serializer: Data received on stream: action_status; message count = 1; batching latency = 0

  2023-08-23T03:55:35.201421Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/action/status with size = 110

  2023-08-23T03:55:35.201551Z DEBUG uplink::base::mqtt: Outgoing = Publish(5)

Connecting to relay server...
  2023-08-23T03:55:35.201643Z DEBUG uplink::base::mqtt: Outgoing = Publish(6)

  2023-08-23T03:55:35.321139Z DEBUG uplink::base::mqtt: Incoming = PubAck(PubAck { pkid: 5 })

  2023-08-23T03:55:35.321175Z DEBUG uplink::base::mqtt: Incoming = PubAck(PubAck { pkid: 6 })

Waiting for peer to join...
```
![image](https://github.com/bytebeamio/uplink/assets/18750864/7970eddb-c170-4169-9e62-c2c78d5b7ca0)

