### PR TITLE
refactor: remove use of separate stream for `action_status`

### DIFF
--- a/uplink/src/base/bridge/mod.rs
+++ b/uplink/src/base/bridge/mod.rs
@@ -19,7 +19,6 @@ use super::Compression;
 use crate::base::ActionRoute;
 use crate::{Action, ActionResponse, Config};
 pub use metrics::StreamMetrics;
-use stream::Stream;
 use streams::Streams;
 
 const TUNSHELL_ACTION: &str = "launch_shell";
@@ -107,14 +106,10 @@ pub struct Bridge {
     bridge_tx: Sender<Event>,
     /// Rx to receive events from apps
     bridge_rx: Receiver<Event>,
-    /// Handle to send batched data to serialzer
-    package_tx: Sender<Box<dyn Package>>,
-    /// Handle to send stream metrics to monitor
-    metrics_tx: Sender<StreamMetrics>,
+    /// Handle to send data over streams
+    streams: Streams,
     /// Actions incoming from backend
     actions_rx: Receiver<Action>,
-    /// Action responses going to backend
-    action_status: Stream<ActionResponse>,
     /// Apps registered with the bridge
     /// NOTE: Sometimes action_routes could overlap, the latest route
     /// to be registered will be used in such a circumstance.
@@ -135,19 +130,16 @@ impl Bridge {
         package_tx: Sender<Box<dyn Package>>,
         metrics_tx: Sender<StreamMetrics>,
         actions_rx: Receiver<Action>,
-        action_status: Stream<ActionResponse>,
         shutdown_handle: Sender<()>,
     ) -> Bridge {
         let (bridge_tx, bridge_rx) = bounded(10);
         let action_redirections = config.action_redirections.clone();
         let (ctrl_tx, ctrl_rx) = bounded(1);
+        let streams = Streams::new(config.clone(), package_tx, metrics_tx);
 
         Bridge {
-            action_status,
             bridge_tx,
             bridge_rx,
-            package_tx,
-            metrics_tx,
             config,
             actions_rx,
             action_routes: HashMap::with_capacity(10),
@@ -157,6 +149,7 @@ impl Bridge {
             shutdown_handle,
             ctrl_rx,
             ctrl_tx,
+            streams,
         }
     }
 
@@ -170,10 +163,7 @@ impl Bridge {
 
     pub async fn start(&mut self) -> Result<(), Error> {
         let mut metrics_timeout = interval(Duration::from_secs(self.config.stream_metrics.timeout));
-        let mut streams =
-            Streams::new(self.config.clone(), self.package_tx.clone(), self.metrics_tx.clone())
-                .await;
-        let mut end = Box::pin(time::sleep(Duration::from_secs(u64::MAX)));
+        let mut end: Pin<Box<Sleep>> = Box::pin(time::sleep(Duration::from_secs(u64::MAX)));
         self.load_saved_action()?;
 
         loop {
@@ -226,7 +216,7 @@ impl Bridge {
                             self.action_routes.insert(name, tx);
                         }
                         Event::Data(v) => {
-                            streams.forward(v).await;
+                            self.streams.forward(v).await;
                         }
                         Event::ActionResponse(response) => {
                             self.forward_action_response(response).await;
@@ -242,15 +232,15 @@ impl Bridge {
                     self.clear_current_action()
                 }
                 // Flush streams that timeout
-                Some(timedout_stream) = streams.stream_timeouts.next(), if streams.stream_timeouts.has_pending() => {
+                Some(timedout_stream) = self.streams.stream_timeouts.next(), if self.streams.stream_timeouts.has_pending() => {
                     debug!("Flushing stream = {}", timedout_stream);
-                    if let Err(e) = streams.flush_stream(&timedout_stream).await {
+                    if let Err(e) = self.streams.flush_stream(&timedout_stream).await {
                         error!("Failed to flush stream = {}. Error = {}", timedout_stream, e);
                     }
                 }
                 // Flush all metrics when timed out
                 _ = metrics_timeout.tick() => {
-                    if let Err(e) = streams.check_and_flush_metrics() {
+                    if let Err(e) = self.streams.check_and_flush_metrics() {
                         debug!("Failed to flush stream metrics. Error = {}", e);
                     }
                 }
@@ -259,7 +249,7 @@ impl Bridge {
                     if let Err(e) = self.save_current_action() {
                         error!("Failed to save current action: {e}");
                     }
-                    streams.flush_all().await;
+                    self.streams.flush_all().await;
                     // NOTE: there might be events still waiting for recv on bridge_rx
                     self.shutdown_handle.send(()).unwrap();
 
@@ -338,9 +328,7 @@ impl Bridge {
         }
 
         info!("Action response = {:?}", response);
-        if let Err(e) = self.action_status.fill(response.clone()).await {
-            error!("Failed to fill. Error = {:?}", e);
-        }
+        self.streams.forward(response.as_payload()).await;
 
         if response.is_completed() || response.is_failed() {
             self.clear_current_action();
@@ -356,9 +344,7 @@ impl Bridge {
                     // NOTE: send success reponse for actions that don't have redirections configured
                     warn!("Action redirection for {} not configured", inflight_action.action.name);
                     let response = ActionResponse::success(&inflight_action.id);
-                    if let Err(e) = self.action_status.fill(response).await {
-                        error!("Failed to send status. Error = {:?}", e);
-                    }
+                    self.streams.forward(response.as_payload()).await;
 
                     self.clear_current_action();
                     return;
@@ -384,9 +370,7 @@ impl Bridge {
 
     async fn forward_parallel_action_response(&mut self, response: ActionResponse) {
         info!("Action response = {:?}", response);
-        if let Err(e) = self.action_status.fill(response.clone()).await {
-            error!("Failed to fill. Error = {:?}", e);
-        }
+        self.streams.forward(response.as_payload()).await;
 
         if response.is_completed() || response.is_failed() {
             self.parallel_actions.remove(&response.action_id);
@@ -394,11 +378,9 @@ impl Bridge {
     }
 
     async fn forward_action_error(&mut self, action: Action, error: Error) {
-        let status = ActionResponse::failure(&action.action_id, error.to_string());
+        let response = ActionResponse::failure(&action.action_id, error.to_string());
 
-        if let Err(e) = self.action_status.fill(status).await {
-            error!("Failed to send status. Error = {:?}", e);
-        }
+        self.streams.forward(response.as_payload()).await;
     }
 }
 
@@ -553,11 +535,9 @@ mod tests {
         let (package_tx, package_rx) = bounded(10);
         let (metrics_tx, _) = bounded(10);
         let (actions_tx, actions_rx) = bounded(10);
-        let action_status = Stream::dynamic("", "", "", 1, package_tx.clone());
         let (shutdown_handle, _) = bounded(1);
 
-        let mut bridge =
-            Bridge::new(config, package_tx, metrics_tx, actions_rx, action_status, shutdown_handle);
+        let mut bridge = Bridge::new(config, package_tx, metrics_tx, actions_rx, shutdown_handle);
         let bridge_tx = bridge.tx();
 
         std::thread::spawn(move || {

--- a/uplink/src/base/bridge/stream.rs
+++ b/uplink/src/base/bridge/stream.rs
@@ -182,6 +182,7 @@ where
         Ok(status)
     }
 
+    #[cfg(test)]
     /// Push data into buffer and trigger sync channel send on max_buf_size.
     /// Returns [`StreamStatus`].
     pub fn push(&mut self, data: T) -> Result<StreamStatus, Error> {
@@ -198,9 +199,9 @@ where
         Ok(status)
     }
 
-    pub fn metrics(&self) -> StreamMetrics {
-        self.metrics.clone()
-    }
+    // pub fn metrics(&self) -> StreamMetrics {
+    //     self.metrics.clone()
+    // }
 }
 
 /// Buffer is an abstraction of a collection that serializer receives.

--- a/uplink/src/base/bridge/streams.rs
+++ b/uplink/src/base/bridge/streams.rs
@@ -1,10 +1,8 @@
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Duration;
 
 use flume::Sender;
 use log::{error, info, trace};
-use tokio::time::{interval, Interval};
 
 use super::stream::{self, StreamStatus, MAX_BUFFER_SIZE};
 use super::StreamMetrics;
@@ -19,11 +17,10 @@ pub struct Streams {
     map: HashMap<String, Stream<Payload>>,
     pub stream_timeouts: DelayMap<String>,
     pub metrics_timeouts: DelayMap<String>,
-    pub metrics_timeout: Interval,
 }
 
 impl Streams {
-    pub async fn new(
+    pub fn new(
         config: Arc<Config>,
         data_tx: Sender<Box<dyn Package>>,
         metrics_tx: Sender<StreamMetrics>,
@@ -34,7 +31,6 @@ impl Streams {
             map.insert(name.to_owned(), stream);
         }
 
-        let metrics_timeout = interval(Duration::from_secs(config.stream_metrics.timeout));
         Self {
             config,
             data_tx,
@@ -42,7 +38,6 @@ impl Streams {
             map,
             stream_timeouts: DelayMap::new(),
             metrics_timeouts: DelayMap::new(),
-            metrics_timeout,
         }
     }
 

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -216,6 +216,8 @@ pub mod config {
             stream_config.buf_size = buf_size;
         }
 
+        config.streams.insert("action_status".to_owned(), config.action_status.to_owned());
+
         let action_topic_template = "/tenants/{tenant_id}/devices/{device_id}/actions";
         let mut device_action_topic = action_topic_template.to_string();
         replace_topic_placeholders(&mut device_action_topic, tenant_id, device_id);

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -48,7 +48,6 @@ use anyhow::Error;
 
 use base::bridge::stream::Stream;
 use base::monitor::Monitor;
-use base::Compression;
 use collector::device_shadow::DeviceShadow;
 use collector::downloader::FileDownloader;
 use collector::installer::OTAInstaller;
@@ -273,7 +272,6 @@ pub struct Uplink {
     action_tx: Sender<Action>,
     data_rx: Receiver<Box<dyn Package>>,
     data_tx: Sender<Box<dyn Package>>,
-    action_status: Stream<ActionResponse>,
     stream_metrics_tx: Sender<StreamMetrics>,
     stream_metrics_rx: Receiver<StreamMetrics>,
     serializer_metrics_tx: Sender<SerializerMetrics>,
@@ -290,21 +288,12 @@ impl Uplink {
         let (serializer_metrics_tx, serializer_metrics_rx) = bounded(10);
         let (shutdown_tx, shutdown_rx) = bounded(1);
 
-        let action_status_topic = &config.action_status.topic;
-        let action_status = Stream::new(
-            "action_status",
-            action_status_topic,
-            1,
-            data_tx.clone(),
-            Compression::Disabled,
-        );
         Ok(Uplink {
             config,
             action_rx,
             action_tx,
             data_rx,
             data_tx,
-            action_status,
             stream_metrics_tx,
             stream_metrics_rx,
             serializer_metrics_tx,
@@ -321,7 +310,6 @@ impl Uplink {
             self.data_tx.clone(),
             self.stream_metrics_tx(),
             self.action_rx.clone(),
-            self.action_status(),
             self.shutdown_tx.clone(),
         );
 
@@ -477,10 +465,6 @@ impl Uplink {
 
     pub fn serializer_metrics_tx(&self) -> Sender<SerializerMetrics> {
         self.serializer_metrics_tx.clone()
-    }
-
-    pub fn action_status(&self) -> Stream<ActionResponse> {
-        self.action_status.clone()
     }
 
     pub async fn resolve_on_shutdown(&self) -> Result<(), RecvError> {


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->

### Why?
<!--Detailed description of why the changes had to be made-->
`ActionResponse` messages should be batched by `Bridge` and not handled separately.

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
Run against stage with simulator:
```
  2023-09-05T14:09:44.706971Z TRACE uplink::base::bridge::streams: Initialized stream buffer for action_status

  2023-09-05T14:09:46.708824Z DEBUG uplink::base::bridge: Flushing stream = action_status

  2023-09-05T14:09:46.708889Z TRACE uplink::base::bridge::stream: Flushing stream name: action_status, topic: /tenants/demo/devices/1001/action/status
```
![Screenshot from 2023-09-05 19-40-35](https://github.com/bytebeamio/uplink/assets/18750864/061e40f3-6855-4b56-abf6-4909176ab5f9)
