### PR TITLE
feat: don't persist simulated streams in-memory

### DIFF
--- a/simulator.sh
+++ b/simulator.sh
@@ -42,6 +42,30 @@ persistence_path = \"/var/tmp/persistence/$id\"
 max_file_size = 104857600
 max_file_count = 3
 
+[streams.gps]
+topic = "/tenants/{tenant_id}/devices/{device_id}/events/gps/jsonarray"
+persistence = { max_file_size = 0 }
+
+[streams.bms]
+topic = "/tenants/{tenant_id}/devices/{device_id}/events/bms/jsonarray"
+persistence = { max_file_size = 0 }
+
+[streams.imu]
+topic = "/tenants/{tenant_id}/devices/{device_id}/events/imu/jsonarray"
+persistence = { max_file_size = 0 }
+
+[streams.motor]
+topic = "/tenants/{tenant_id}/devices/{device_id}/events/motor/jsonarray"
+persistence = { max_file_size = 0 }
+
+[streams.peripheral_state]
+topic = "/tenants/{tenant_id}/devices/{device_id}/events/peripheral_state/jsonarray"
+persistence = { max_file_size = 0 }
+
+[streams.device_shadow]
+topic = "/tenants/{tenant_id}/devices/{device_id}/events/device_shadow/jsonarray"
+persistence = { max_file_size = 0 }
+
 [simulator]
 gps_paths = "./paths"
 actions= [{ name = \"load_file\" }, { name = \"install_firmware\" }, { name = \"update_config\" }, { name = \"unlock\" }, { name = \"lock\" }]


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->

### Why?
<!--Detailed description of why the changes had to be made-->
It's desirable to not persist simulated streams in-memory, which has the capability of triggering the pod running simulator to be OOMkilled

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
Run against wrong url for broker, triggering a connection issue, but keeping uplink alive to receive simulated data:
```
  2023-09-09T09:16:08.393065Z  INFO uplink::base::serializer:              slow: batches = 11  errors = 0 lost = 10 disk_files = 0   write_memory = 0 B read_memory = 0 B
...
2023-09-09T09:20:38.393373Z  INFO uplink::base::serializer:              slow: batches = 135 errors = 0 lost = 114 disk_files = 0   write_memory = 25.09 kB read_memory = 0 B
```
It can be observed that lost segment count is increasing, but some data, specifically from the following streams do get written into associated memory buffer:
- "uplink_disk_stats"
- "uplink_network_stats"
- "uplink_processor_stats"
- "uplink_process_stats"
- "uplink_component_stats"
- "uplink_system_stats"