### PR TITLE
feat: try continuing partially downloaded files

### DIFF
--- a/uplink/src/collector/downloader.rs
+++ b/uplink/src/collector/downloader.rs
@@ -307,13 +307,8 @@ impl FileDownloader {
             let resp = req.await?.error_for_status()?;
             match self.download(resp, &mut download).await {
                 Ok(_) => break,
-                Err(e) => {
-                    if let Error::Reqwest(e) = e {
-                        error!("Download failed: {e}");
-                    } else {
-                        return Err(e);
-                    }
-                }
+                Err(Error::Reqwest(e)) => error!("Download failed: {e}"),
+                Err(e) => return Err(e),
             }
             tokio::time::sleep(Duration::from_secs(30)).await;
 

--- a/uplink/src/collector/downloader.rs
+++ b/uplink/src/collector/downloader.rs
@@ -317,7 +317,7 @@ impl FileDownloader {
             }
             tokio::time::sleep(Duration::from_secs(30)).await;
 
-            let range = download.retry_range()?;
+            let range = download.retry_range();
             warn!("Retrying download; Continuing to download file from: {range}");
             req = self.client.get(url).header("Range", range).send();
         }
@@ -409,11 +409,8 @@ impl DownloadedFile {
         }
     }
 
-    fn retry_range(&self) -> Result<String, Error> {
-        let file_size = self.file.metadata()?.len();
-        let range = format!("bytes={file_size}-{}", self.content_length);
-
-        Ok(range)
+    fn retry_range(&self) -> String {
+        format!("bytes={}-{}", self.bytes_written, self.content_length)
     }
 }
 

--- a/uplink/src/collector/downloader.rs
+++ b/uplink/src/collector/downloader.rs
@@ -382,7 +382,7 @@ struct DownloadedFile {
 impl DownloadedFile {
     fn write_bytes(&mut self, buf: &[u8]) -> Result<Option<u8>, Error> {
         self.bytes_downloaded += buf.len();
-        self.file.write_all(&buf)?;
+        self.file.write_all(buf)?;
         self.bytes_written = self.bytes_downloaded;
         let size = human_bytes(self.content_length as f64);
 


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->

### Why?
<!--Detailed description of why the changes had to be made-->
Download behavior should support continuing downloads that were partially completed earlier.

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
Use [download_qa.sh](https://gist.github.com/de-sh/1bfa3c727c9dc9af77951e43d64e097b) to perform the network reset scenario required for circumstances where download must be restarted.

REFER
- [Logs of downloader running into failure and restarting](https://gist.github.com/de-sh/e8346d6d8aea55ed5e58f232d511f335#file-downloader-log-L49)
- Screenshot of md5sum run on file that was to be downloaded, compared against the file that ended up being downloaded:
![Screenshot from 2023-09-13 15-00-54](https://github.com/bytebeamio/uplink/assets/18750864/bf4753b6-85c0-49bd-a1a8-aec79924df6e)

