### PR TITLE
fix: timeout process as per config

### DIFF
--- a/uplink/src/collector/process.rs
+++ b/uplink/src/collector/process.rs
@@ -83,7 +83,10 @@ impl ProcessHandler {
                     debug!("Action status: {:?}", status);
                     self.bridge_tx.send_action_response(status).await;
                  }
-                 status = child.wait() => info!("Action done!! Status = {:?}", status),
+                 status = child.wait() => {
+                    info!("Action done!! Status = {:?}", status);
+                    return Ok(());
+                },
             }
         }
     }

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -452,7 +452,8 @@ impl Uplink {
         };
 
         if let Some(actions_rx) = bridge.register_action_routes(&self.config.processes) {
-            let process_handler = ProcessHandler::new(actions_rx, bridge_tx.clone());
+            let process_handler =
+                ProcessHandler::new(actions_rx, bridge_tx.clone(), &self.config.processes);
             thread::spawn(move || {
                 if let Err(e) = process_handler.start() {
                     error!("Process handler stopped!! Error = {:?}", e);


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->

### Why?
<!--Detailed description of why the changes had to be made-->

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
Run against stage with example `tools/lock`:
```
#!/bin/bash

echo "{ \"sequence\": 0, \"timestamp\": $(date +%s%N | cut -b1-13),\"action_id\": \"$1\", \"state\": \"Locked\", \"progress\": 100, \"errors\": [] }"
```
send action with `name = "lock"` and see the following logs:
```
  2023-09-13T15:16:19.508475Z  INFO uplink::base::mqtt: Action = Action { action_id: "1738", kind: "process", name: "lock", payload: "{}" }

  2023-09-13T15:16:19.508628Z  INFO uplink::base::bridge: Received action: Action { action_id: "1738", kind: "process", name: "lock", payload: "{}" }

  2023-09-13T15:16:19.508686Z  INFO uplink::base::bridge: Action response = ActionResponse { action_id: "1738", sequence: 0, timestamp: 1694618179508, state: "Received", progress: 0, errors: [], done_response: None }

  2023-09-13T15:16:19.508743Z DEBUG uplink::base::bridge::stream: Sequence number anomaly! [0, 0

  2023-09-13T15:16:19.524885Z DEBUG uplink::collector::process: Action status: ActionResponse { action_id: "1738", sequence: 0, timestamp: 1694618179523, state: "Locked", progress: 100, errors: [], done_response: None }

  2023-09-13T15:16:19.525047Z  INFO uplink::base::bridge: Action response = ActionResponse { action_id: "1738", sequence: 0, timestamp: 1694618179523, state: "Locked", progress: 100, errors: [], done_response: None }

  2023-09-13T15:16:19.525099Z DEBUG uplink::base::bridge::stream: Sequence number anomaly! [0, 0

  2023-09-13T15:16:19.525113Z  INFO uplink::collector::process: Action done!!
```
With 60s being default timeout, using a sleep of 2min in the same lock file will trigger timeout, even if timeout is increased to 90s, showing that the app now works according to config and not arbitrarily timeout at 10s.
```
  2023-09-13T15:20:01.756286Z  INFO uplink::base::mqtt: Action = Action { action_id: "1739", kind: "process", name: "lock", payload: "{}" }

  2023-09-13T15:20:01.756394Z  INFO uplink::base::bridge: Received action: Action { action_id: "1739", kind: "process", name: "lock", payload: "{}" }

  2023-09-13T15:20:01.756433Z  INFO uplink::base::bridge: Action response = ActionResponse { action_id: "1739", sequence: 0, timestamp: 1694618401756, state: "Received", progress: 0, errors: [], done_response: None }

  2023-09-13T15:20:01.756467Z DEBUG uplink::base::bridge::stream: Sequence number anomaly! [0, 0

  2023-09-13T15:20:03.757922Z DEBUG uplink::base::bridge: Flushing stream = action_status

  2023-09-13T15:20:03.758143Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/action/status with size = 98
...
  2023-09-13T15:21:01.758138Z ERROR uplink::base::bridge: Timeout waiting for action response. Action ID = 1739

  2023-09-13T15:21:01.758292Z DEBUG uplink::base::bridge::stream: Sequence number anomaly! [0, 0

  2023-09-13T15:21:03.760157Z DEBUG uplink::base::bridge: Flushing stream = action_status

  2023-09-13T15:21:03.760565Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/action/status with size = 115
```