### PR TITLE
log: start/complete reading from persisted stream

### DIFF
--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -89,7 +89,10 @@ impl Storage {
             Some(persistence) => {
                 let hash = hash(&self.current_write_file[..]);
                 let mut next_file = persistence.open_next_write_file()?;
-                info!("Flushing data to disk for stoarge: {}; path = {:?}", self.name, next_file.path);
+                info!(
+                    "Flushing data to disk for stoarge: {}; path = {:?}",
+                    self.name, next_file.path
+                );
 
                 next_file.file.write_all(&hash.to_be_bytes())?;
                 next_file.file.write_all(&self.current_write_file[..])?;

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -104,6 +104,10 @@ impl Storage {
                 // TODO(RT): Make sure that disk files starts with id 1 to represent in memory file
                 // with id 0
                 self.current_write_file.clear();
+                warn!(
+                    "Persistence disabled for storage: {}. Deleted in-memory buffer on overflow",
+                    self.name
+                );
                 Ok(Some(0))
             }
         }

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -382,7 +382,7 @@ mod test {
     fn flush_creates_new_file_after_size_limit() {
         // 1036 is the size of a publish message with topic = "hello", qos = 1, payload = 1024 bytes
         let backup = init_backup_folders();
-        let mut storage = Storage::new(10 * 1036);
+        let mut storage = Storage::new("test", 10 * 1036);
         storage.set_persistence(backup.path(), 10).unwrap();
 
         // 2 files on disk and a partially filled in memory buffer
@@ -399,7 +399,7 @@ mod test {
     #[test]
     fn old_file_is_deleted_after_limit() {
         let backup = init_backup_folders();
-        let mut storage = Storage::new(10 * 1036);
+        let mut storage = Storage::new("test", 10 * 1036);
         storage.set_persistence(backup.path(), 10).unwrap();
 
         // 11 files created. 10 on disk
@@ -419,7 +419,7 @@ mod test {
     #[test]
     fn reload_loads_correct_file_into_memory() {
         let backup = init_backup_folders();
-        let mut storage = Storage::new(10 * 1036);
+        let mut storage = Storage::new("test", 10 * 1036);
         storage.set_persistence(backup.path(), 10).unwrap();
 
         // 10 files on disk
@@ -437,7 +437,7 @@ mod test {
     #[test]
     fn reload_loads_partially_written_write_buffer_correctly() {
         let backup = init_backup_folders();
-        let mut storage = Storage::new(10 * 1036);
+        let mut storage = Storage::new("test", 10 * 1036);
         storage.set_persistence(backup.path(), 10).unwrap();
 
         // 10 files on disk and partially filled current write buffer
@@ -456,7 +456,7 @@ mod test {
     #[test]
     fn ensure_file_remove_on_read_completion_only() {
         let backup = init_backup_folders();
-        let mut storage = Storage::new(10 * 1036);
+        let mut storage = Storage::new("test", 10 * 1036);
         storage.set_persistence(backup.path(), 10).unwrap();
         // 10 files on disk and partially filled current write buffer, 10 publishes per file
         write_n_publishes(&mut storage, 105);
@@ -490,7 +490,7 @@ mod test {
     #[test]
     fn ensure_files_including_read_removed_post_flush_on_overflow() {
         let backup = init_backup_folders();
-        let mut storage = Storage::new(10 * 1036);
+        let mut storage = Storage::new("test", 10 * 1036);
         storage.set_persistence(backup.path(), 10).unwrap();
         // 10 files on disk and partially filled current write buffer, 10 publishes per file
         write_n_publishes(&mut storage, 105);

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -19,6 +19,7 @@ pub enum Error {
 }
 
 pub struct Storage {
+    name: String,
     /// maximum allowed file size
     max_file_size: usize,
     /// current open file
@@ -30,8 +31,9 @@ pub struct Storage {
 }
 
 impl Storage {
-    pub fn new(max_file_size: usize) -> Storage {
+    pub fn new(name: impl Into<String>, max_file_size: usize) -> Storage {
         Storage {
+            name: name.into(),
             max_file_size,
             current_write_file: BytesMut::with_capacity(max_file_size * 2),
             current_read_file: BytesMut::with_capacity(max_file_size * 2),
@@ -87,7 +89,7 @@ impl Storage {
             Some(persistence) => {
                 let hash = hash(&self.current_write_file[..]);
                 let mut next_file = persistence.open_next_write_file()?;
-                info!("Flushing data to disk!! {:?}", next_file.path);
+                info!("Flushing data to disk for stoarge: {}; path = {:?}", self.name, next_file.path);
 
                 next_file.file.write_all(&hash.to_be_bytes())?;
                 next_file.file.write_all(&self.current_write_file[..])?;

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -128,7 +128,7 @@ impl Storage {
             // Remove read file on completion in destructive-read mode
             let read_is_destructive = !persistence.non_destructive_read;
             let read_file_id = persistence.current_read_file_id.take();
-            if let Some(id) = read_is_destructive.then(|| read_file_id).flatten() {
+            if let Some(id) = read_is_destructive.then_some(read_file_id).flatten() {
                 let deleted_file = persistence.remove(id)?;
                 debug!("Completed reading a persistence file, deleting it; storage = {}, path = {deleted_file:?}", self.name);
             }

--- a/uplink/src/base/serializer/mod.rs
+++ b/uplink/src/base/serializer/mod.rs
@@ -846,7 +846,7 @@ mod test {
         let config = Arc::new(default_config());
 
         let (serializer, _, _) = defaults(config);
-        let mut storage = Storage::new(1024);
+        let mut storage = Storage::new("hello/world", 1024);
 
         let mut publish = Publish::new(
             "hello/world",
@@ -950,7 +950,7 @@ mod test {
             .storage_handler
             .map
             .entry("hello/world".to_string())
-            .or_insert(Storage::new(1024));
+            .or_insert(Storage::new("hello/world", 1024));
 
         let mut collector = MockCollector::new(data_tx);
         // Run a collector practically once
@@ -1002,7 +1002,7 @@ mod test {
             .storage_handler
             .map
             .entry("hello/world".to_string())
-            .or_insert(Storage::new(1024));
+            .or_insert(Storage::new("hello/world", 1024));
 
         let mut collector = MockCollector::new(data_tx);
         // Run a collector

--- a/uplink/src/base/serializer/mod.rs
+++ b/uplink/src/base/serializer/mod.rs
@@ -139,7 +139,8 @@ impl StorageHandler {
     fn new(config: Arc<Config>) -> Result<Self, Error> {
         let mut map = HashMap::with_capacity(2 * config.streams.len());
         for (stream_name, stream_config) in config.streams.iter() {
-            let mut storage = Storage::new(stream_config.persistence.max_file_size);
+            let mut storage =
+                Storage::new(&stream_config.topic, stream_config.persistence.max_file_size);
             if stream_config.persistence.max_file_count > 0 {
                 let mut path = config.persistence_path.clone();
                 path.push(stream_name);
@@ -161,7 +162,7 @@ impl StorageHandler {
     }
 
     fn select(&mut self, topic: &str) -> &mut Storage {
-        self.map.entry(topic.to_owned()).or_insert_with(|| Storage::new(default_file_size()))
+        self.map.entry(topic.to_owned()).or_insert_with(|| Storage::new(topic, default_file_size()))
     }
 
     fn next(&mut self, metrics: &mut SerializerMetrics) -> Option<&mut Storage> {


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->
- Name the storage with topic string
- Log in-memory storage being deleted on overflow, when file is deleted provide info on which stream it was storing data for, etc.

### Why?
<!--Detailed description of why the changes had to be made-->
Logs should reflect information about which stream is being read and which file is being deleted, to help trace cause of data-loss. To be able to trace the cause of data-loss, these logs will provide better observability into the storage layer for users to figure out what is wrong with their config, i.e. a log saying "Persistence disabled for storage: /tenants/.../gps/..., deleting in-memory buffer" would be easier to read and understand than having to look at `serializer: lost = 1` and not be able to figure out which stream is losing data.

### Trials Performed
Use qa script for persistence and disable mqtts for a while, before bringing it back up, the following log lines were observed:
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
```
2023-09-27T13:56:58.872176Z  INFO uplink::base::serializer: Switching to catchup mode!!

  2023-09-27T13:56:58.872502Z DEBUG uplink::base::serializer: Reading from: /tenants/demo/devices/1001/events/imu/jsonarray

  2023-09-27T13:56:58.872531Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/imu/jsonarray with size = 27008

  2023-09-27T13:56:58.872797Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/imu/jsonarray with size = 27005

  2023-09-27T13:56:58.872860Z  INFO uplink::base::serializer:              slow: batches = 19  errors = 0 lost = 3 disk_files = 3   write_memory = 52.29 kB read_memory = 0 B

  2023-09-27T13:56:58.872896Z  INFO uplink::base::serializer:           catchup: batches = 1   errors = 0 lost = 0 disk_files = 1   write_memory = 52.29 kB read_memory = 0 B

  2023-09-27T13:56:58.873182Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/imu/jsonarray with size = 27016

  2023-09-27T13:56:58.873315Z DEBUG uplink::base::serializer: Completed reading from: /tenants/demo/devices/1001/events/imu/jsonarray

  2023-09-27T13:56:58.873334Z DEBUG uplink::base::serializer: Reading from: /tenants/demo/devices/1001/events/gps/jsonarray

  2023-09-27T13:56:58.873353Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/gps/jsonarray with size = 24604

  2023-09-27T13:56:58.873385Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/gps/jsonarray with size = 5039

  2023-09-27T13:56:58.873404Z DEBUG uplink::base::serializer: Completed reading from: /tenants/demo/devices/1001/events/gps/jsonarray

  2023-09-27T13:56:58.873420Z DEBUG uplink::base::serializer: Reading from: /tenants/demo/devices/1001/events/device_shadow/jsonarray

  2023-09-27T13:56:58.873441Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/device_shadow/jsonarray with size = 1128
```
logs from storage module:
```
2023-09-28T10:26:44.380560Z  INFO storage: Flushing data to disk for stoarge: /tenants/demo/devices/1001/events/imu/jsonarray!! path = "/var/tmp/persistence/imu/backup@0"

  2023-09-28T10:26:49.230142Z  WARN storage: Persistence disabled for storage: /tenants/demo/devices/1001/events/bms/jsonarray. Deleted in-memory buffer on overflow
..
  2023-09-28T10:27:14.380006Z  WARN storage: file limit reached. deleting backup@0; path = "/var/tmp/persistence/imu/backup@0"
..
  2023-09-28T10:29:09.834334Z DEBUG storage: Completed reading a persistence file, deleting it; storage = /tenants/demo/devices/1001/events/imu/jsonarray, path = "/var/tmp/persistence/imu/backup@14"
```