### PR TITLE
refactor: remove timeout information from apps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3008,7 +3008,7 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "uplink"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/uplink/src/base/actions.rs
+++ b/uplink/src/base/actions.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use tokio::time::Instant;
 
 use crate::{Payload, Point};
 
@@ -19,6 +20,9 @@ pub struct Action {
     pub name: String,
     // action payload. json. can be args/payload. depends on the invoked command
     pub payload: String,
+    // Instant at which action must be timedout
+    #[serde(skip)]
+    pub deadline: Option<Instant>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/uplink/src/base/actions.rs
+++ b/uplink/src/base/actions.rs
@@ -6,10 +6,6 @@ use crate::{Payload, Point};
 
 use super::clock;
 
-fn now() -> Instant {
-    Instant::now()
-}
-
 /// On the Bytebeam platform, an Action is how beamd and through it,
 /// the end-user, can communicate the tasks they want to perform on
 /// said device, in this case, uplink.
@@ -25,8 +21,8 @@ pub struct Action {
     // action payload. json. can be args/payload. depends on the invoked command
     pub payload: String,
     // Instant at which action must be timedout
-    #[serde(skip, default = "now")]
-    pub deadline: Instant,
+    #[serde(skip)]
+    pub deadline: Option<Instant>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/uplink/src/base/actions.rs
+++ b/uplink/src/base/actions.rs
@@ -6,6 +6,10 @@ use crate::{Payload, Point};
 
 use super::clock;
 
+fn now() -> Instant {
+    Instant::now()
+}
+
 /// On the Bytebeam platform, an Action is how beamd and through it,
 /// the end-user, can communicate the tasks they want to perform on
 /// said device, in this case, uplink.
@@ -21,8 +25,8 @@ pub struct Action {
     // action payload. json. can be args/payload. depends on the invoked command
     pub payload: String,
     // Instant at which action must be timedout
-    #[serde(skip)]
-    pub deadline: Option<Instant>,
+    #[serde(skip, default = "now")]
+    pub deadline: Instant,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/uplink/src/base/bridge/actions_lane.rs
+++ b/uplink/src/base/bridge/actions_lane.rs
@@ -419,7 +419,7 @@ impl ActionRouter {
     /// Forwards action to the appropriate application and returns the instance in time at which it should be timedout if incomplete
     pub fn try_send(&self, mut action: Action) -> Result<Instant, TrySendError<Action>> {
         let deadline = Instant::now() + self.duration;
-        action.deadline = Some(deadline);
+        action.deadline = deadline;
         self.actions_tx.try_send(action)?;
 
         Ok(deadline)
@@ -547,7 +547,7 @@ mod tests {
             kind: "test".to_string(),
             name: "route_1".to_string(),
             payload: "test".to_string(),
-            deadline: None,
+            deadline: Instant::now(),
         };
         actions_tx.send(action_1).unwrap();
 
@@ -571,7 +571,7 @@ mod tests {
             kind: "test".to_string(),
             name: "route_2".to_string(),
             payload: "test".to_string(),
-            deadline: None,
+            deadline: Instant::now(),
         };
         actions_tx.send(action_2).unwrap();
 
@@ -615,7 +615,7 @@ mod tests {
             kind: "test".to_string(),
             name: "test".to_string(),
             payload: "test".to_string(),
-            deadline: None,
+            deadline: Instant::now(),
         };
         actions_tx.send(action_1).unwrap();
 
@@ -630,7 +630,7 @@ mod tests {
             kind: "test".to_string(),
             name: "test".to_string(),
             payload: "test".to_string(),
-            deadline: None,
+            deadline: Instant::now(),
         };
         actions_tx.send(action_2).unwrap();
 
@@ -671,7 +671,7 @@ mod tests {
             kind: "test".to_string(),
             name: "test".to_string(),
             payload: "test".to_string(),
-            deadline: None,
+            deadline: Instant::now(),
         };
         actions_tx.send(action).unwrap();
 
@@ -735,7 +735,7 @@ mod tests {
             kind: "test".to_string(),
             name: "test".to_string(),
             payload: "test".to_string(),
-            deadline: None,
+            deadline: Instant::now(),
         };
         actions_tx.send(action).unwrap();
 
@@ -804,7 +804,7 @@ mod tests {
             kind: "tunshell".to_string(),
             name: "launch_shell".to_string(),
             payload: "test".to_string(),
-            deadline: None,
+            deadline: Instant::now(),
         };
         actions_tx.send(action).unwrap();
 
@@ -815,7 +815,7 @@ mod tests {
             kind: "test".to_string(),
             name: "test".to_string(),
             payload: "test".to_string(),
-            deadline: None,
+            deadline: Instant::now(),
         };
         actions_tx.send(action).unwrap();
 
@@ -894,7 +894,7 @@ mod tests {
             kind: "test".to_string(),
             name: "test".to_string(),
             payload: "test".to_string(),
-            deadline: None,
+            deadline: Instant::now(),
         };
         actions_tx.send(action).unwrap();
 
@@ -905,7 +905,7 @@ mod tests {
             kind: "tunshell".to_string(),
             name: "launch_shell".to_string(),
             payload: "test".to_string(),
-            deadline: None,
+            deadline: Instant::now(),
         };
         actions_tx.send(action).unwrap();
 

--- a/uplink/src/base/bridge/actions_lane.rs
+++ b/uplink/src/base/bridge/actions_lane.rs
@@ -416,6 +416,7 @@ pub struct ActionRouter {
 
 impl ActionRouter {
     #[allow(clippy::result_large_err)]
+    /// Forwards action to the appropriate application and returns the instance in time at which it should be timedout if incomplete
     pub fn try_send(&self, mut action: Action) -> Result<Instant, TrySendError<Action>> {
         let deadline = Instant::now() + self.duration;
         action.deadline = Some(deadline);

--- a/uplink/src/base/bridge/actions_lane.rs
+++ b/uplink/src/base/bridge/actions_lane.rs
@@ -419,7 +419,7 @@ impl ActionRouter {
     /// Forwards action to the appropriate application and returns the instance in time at which it should be timedout if incomplete
     pub fn try_send(&self, mut action: Action) -> Result<Instant, TrySendError<Action>> {
         let deadline = Instant::now() + self.duration;
-        action.deadline = deadline;
+        action.deadline = Some(deadline);
         self.actions_tx.try_send(action)?;
 
         Ok(deadline)
@@ -547,7 +547,7 @@ mod tests {
             kind: "test".to_string(),
             name: "route_1".to_string(),
             payload: "test".to_string(),
-            deadline: Instant::now(),
+            deadline: None,
         };
         actions_tx.send(action_1).unwrap();
 
@@ -571,7 +571,7 @@ mod tests {
             kind: "test".to_string(),
             name: "route_2".to_string(),
             payload: "test".to_string(),
-            deadline: Instant::now(),
+            deadline: None,
         };
         actions_tx.send(action_2).unwrap();
 
@@ -615,7 +615,7 @@ mod tests {
             kind: "test".to_string(),
             name: "test".to_string(),
             payload: "test".to_string(),
-            deadline: Instant::now(),
+            deadline: None,
         };
         actions_tx.send(action_1).unwrap();
 
@@ -630,7 +630,7 @@ mod tests {
             kind: "test".to_string(),
             name: "test".to_string(),
             payload: "test".to_string(),
-            deadline: Instant::now(),
+            deadline: None,
         };
         actions_tx.send(action_2).unwrap();
 
@@ -671,7 +671,7 @@ mod tests {
             kind: "test".to_string(),
             name: "test".to_string(),
             payload: "test".to_string(),
-            deadline: Instant::now(),
+            deadline: None,
         };
         actions_tx.send(action).unwrap();
 
@@ -735,7 +735,7 @@ mod tests {
             kind: "test".to_string(),
             name: "test".to_string(),
             payload: "test".to_string(),
-            deadline: Instant::now(),
+            deadline: None,
         };
         actions_tx.send(action).unwrap();
 
@@ -804,7 +804,7 @@ mod tests {
             kind: "tunshell".to_string(),
             name: "launch_shell".to_string(),
             payload: "test".to_string(),
-            deadline: Instant::now(),
+            deadline: None,
         };
         actions_tx.send(action).unwrap();
 
@@ -815,7 +815,7 @@ mod tests {
             kind: "test".to_string(),
             name: "test".to_string(),
             payload: "test".to_string(),
-            deadline: Instant::now(),
+            deadline: None,
         };
         actions_tx.send(action).unwrap();
 
@@ -894,7 +894,7 @@ mod tests {
             kind: "test".to_string(),
             name: "test".to_string(),
             payload: "test".to_string(),
-            deadline: Instant::now(),
+            deadline: None,
         };
         actions_tx.send(action).unwrap();
 
@@ -905,7 +905,7 @@ mod tests {
             kind: "tunshell".to_string(),
             name: "launch_shell".to_string(),
             payload: "test".to_string(),
-            deadline: Instant::now(),
+            deadline: None,
         };
         actions_tx.send(action).unwrap();
 

--- a/uplink/src/collector/downloader.rs
+++ b/uplink/src/collector/downloader.rs
@@ -471,7 +471,7 @@ mod test {
             kind: "firmware_update".to_string(),
             name: "firmware_update".to_string(),
             payload: json!(download_update).to_string(),
-            deadline: Instant::now(),
+            deadline: Instant::now() + Duration::from_secs(60),
         };
 
         std::thread::sleep(Duration::from_millis(10));

--- a/uplink/src/collector/process.rs
+++ b/uplink/src/collector/process.rs
@@ -83,17 +83,10 @@ impl ProcessHandler {
         loop {
             let action = self.actions_rx.recv_async().await?;
             let command = String::from("tools/") + &action.name;
-            let deadline = match &action.deadline {
-                Some(d) => *d,
-                _ => {
-                    error!("Unconfigured deadline: {}", action.name);
-                    continue;
-                }
-            };
 
             // Spawn the action and capture its stdout, ignore timeouts
             let child = self.run(&action.action_id, &command, &action.payload).await?;
-            if let Ok(o) = timeout_at(deadline, self.spawn_and_capture_stdout(child)).await {
+            if let Ok(o) = timeout_at(action.deadline, self.spawn_and_capture_stdout(child)).await {
                 o?;
             } else {
                 error!("Process timedout: {command}; action_id = {}", action.action_id);

--- a/uplink/src/collector/script_runner.rs
+++ b/uplink/src/collector/script_runner.rs
@@ -119,17 +119,11 @@ impl ScriptRunner {
                     continue;
                 }
             };
-            let deadline = match &action.deadline {
-                Some(d) => *d,
-                _ => {
-                    error!("Unconfigured deadline: {}", action.name);
-                    continue;
-                }
-            };
             // Spawn the action and capture its stdout
             let child = self.run(command).await?;
             if let Ok(o) =
-                timeout_at(deadline, self.spawn_and_capture_stdout(child, &action.action_id)).await
+                timeout_at(action.deadline, self.spawn_and_capture_stdout(child, &action.action_id))
+                    .await
             {
                 o?
             }
@@ -155,6 +149,7 @@ mod tests {
     };
 
     use flume::bounded;
+    use tokio::time::Instant;
 
     fn create_bridge() -> (BridgeTx, Receiver<ActionResponse>) {
         let (data_tx, _) = flume::bounded(2);
@@ -181,7 +176,7 @@ mod tests {
                 kind: "1".to_string(),
                 name: "test".to_string(),
                 payload: "".to_string(),
-                deadline: None,
+                deadline: Instant::now(),
             })
             .unwrap();
 
@@ -206,7 +201,7 @@ mod tests {
                 name: "test".to_string(),
                 payload: "{\"url\": \"...\", \"content_length\": 0,\"file_name\": \"...\"}"
                     .to_string(),
-                deadline: None,
+                deadline: Instant::now(),
             })
             .unwrap();
 

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -476,8 +476,7 @@ impl Uplink {
         if !self.config.processes.is_empty() {
             let (actions_tx, actions_rx) = bounded(1);
             bridge.register_action_routes(&self.config.processes, actions_tx)?;
-            let process_handler =
-                ProcessHandler::new(actions_rx, bridge_tx.clone(), &self.config.processes);
+            let process_handler = ProcessHandler::new(actions_rx, bridge_tx.clone());
             thread::spawn(move || {
                 if let Err(e) = process_handler.start() {
                     error!("Process handler stopped!! Error = {:?}", e);
@@ -488,8 +487,7 @@ impl Uplink {
         if !self.config.script_runner.is_empty() {
             let (actions_tx, actions_rx) = bounded(1);
             bridge.register_action_routes(&self.config.script_runner, actions_tx)?;
-            let script_runner =
-                ScriptRunner::new(self.config.script_runner.clone(), actions_rx, bridge_tx);
+            let script_runner = ScriptRunner::new(actions_rx, bridge_tx);
             thread::spawn(move || {
                 if let Err(e) = script_runner.start() {
                     error!("Script runner stopped!! Error = {:?}", e);


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->

### Why?
<!--Detailed description of why the changes had to be made-->
To remove/cleanup unnecessary code for handling timeout from app side.

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
Run uplink as usual but with an action of extremely short duration, send an action that it is configured to handle, no change in uplink behavior observed. Action still timedout when not responded to and the app stopped processing action on timeout.