### PR TITLE
fix: continuous retry till timeout

### DIFF
--- a/uplink/src/collector/downloader.rs
+++ b/uplink/src/collector/downloader.rs
@@ -186,7 +186,7 @@ impl FileDownloader {
     // Retry mechanism tries atleast 3 times before returning a download error
     async fn retry_thrice(&mut self, url: &str, mut download: DownloadState) -> Result<(), Error> {
         let mut req = self.client.get(url).send();
-        for _ in 0..3 {
+        loop {
             let resp = req.await?.error_for_status()?;
             match self.download(resp, &mut download).await {
                 Ok(_) => break,

--- a/uplink/src/collector/downloader.rs
+++ b/uplink/src/collector/downloader.rs
@@ -193,7 +193,7 @@ impl FileDownloader {
                 Err(Error::Reqwest(e)) => error!("Download failed: {e}"),
                 Err(e) => return Err(e),
             }
-            tokio::time::sleep(Duration::from_secs(30)).await;
+            tokio::time::sleep(Duration::from_secs(1)).await;
 
             let range = download.retry_range();
             warn!("Retrying download; Continuing to download file from: {range}");


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->

### Why?
<!--Detailed description of why the changes had to be made-->
Downloader retries should not be limited to 3 times, continuously retry till the download action is timedout

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
```
 2023-10-10T16:59:01.368213Z  WARN uplink::collector::downloader: Retrying download; Continuing to download file from: bytes=0-33482

  2023-10-10T16:59:01.369021Z ERROR uplink::collector::downloader: Download failed: error sending request for url (https://firmware.stage.bytebeam.io/api/v1/file/60e38118-4541-470a-a1cf-5901d9757da4/artifact): error trying to connect: tcp connect error: Connection refused (os error 111)

  2023-10-10T16:59:02.371229Z  WARN uplink::collector::downloader: Retrying download; Continuing to download file from: bytes=0-33482

  2023-10-10T16:59:02.371601Z ERROR uplink::collector::downloader: Download failed: error sending request for url (https://firmware.stage.bytebeam.io/api/v1/file/60e38118-4541-470a-a1cf-5901d9757da4/artifact): error trying to connect: tcp connect error: Connection refused (os error 111)

  2023-10-10T16:59:03.372799Z  WARN uplink::collector::downloader: Retrying download; Continuing to download file from: bytes=0-33482

  2023-10-10T16:59:03.373657Z ERROR uplink::collector::downloader: Download failed: error sending request for url (https://firmware.stage.bytebeam.io/api/v1/file/60e38118-4541-470a-a1cf-5901d9757da4/artifact): error trying to connect: tcp connect error: Connection refused (os error 111)

  2023-10-10T16:59:04.374872Z  WARN uplink::collector::downloader: Retrying download; Continuing to download file from: bytes=0-33482

  2023-10-10T16:59:04.375549Z ERROR uplink::collector::downloader: Download failed: error sending request for url (https://firmware.stage.bytebeam.io/api/v1/file/60e38118-4541-470a-a1cf-5901d9757da4/artifact): error trying to connect: tcp connect error: Connection refused (os error 111)

  2023-10-10T16:59:05.376945Z  WARN uplink::collector::downloader: Retrying download; Continuing to download file from: bytes=0-33482

  2023-10-10T16:59:05.377787Z ERROR uplink::collector::downloader: Download failed: error sending request for url (https://firmware.stage.bytebeam.io/api/v1/file/60e38118-4541-470a-a1cf-5901d9757da4/artifact): error trying to connect: tcp connect error: Connection refused (os error 111)

  2023-10-10T16:59:06.378287Z  WARN uplink::collector::downloader: Retrying download; Continuing to download file from: bytes=0-33482

  2023-10-10T16:59:06.379031Z ERROR uplink::collector::downloader: Download failed: error sending request for url (https://firmware.stage.bytebeam.io/api/v1/file/60e38118-4541-470a-a1cf-5901d9757da4/artifact): error trying to connect: tcp connect error: Connection refused (os error 111)

  2023-10-10T16:59:07.380512Z  WARN uplink::collector::downloader: Retrying download; Continuing to download file from: bytes=0-33482

  2023-10-10T16:59:07.381807Z ERROR uplink::collector::downloader: Download failed: error sending request for url (https://firmware.stage.bytebeam.io/api/v1/file/60e38118-4541-470a-a1cf-5901d9757da4/artifact): error trying to connect: tcp connect error: Connection refused (os error 111)

  2023-10-10T16:59:08.383052Z  WARN uplink::collector::downloader: Retrying download; Continuing to download file from: bytes=0-33482

  2023-10-10T16:59:08.383917Z ERROR uplink::collector::downloader: Download failed: error sending request for url (https://firmware.stage.bytebeam.io/api/v1/file/60e38118-4541-470a-a1cf-5901d9757da4/artifact): error trying to connect: tcp connect error: Connection refused (os error 111)

  2023-10-10T16:59:09.385353Z  WARN uplink::collector::downloader: Retrying download; Continuing to download file from: bytes=0-33482

  2023-10-10T16:59:09.386617Z ERROR uplink::collector::downloader: Download failed: error sending request for url (https://firmware.stage.bytebeam.io/api/v1/file/60e38118-4541-470a-a1cf-5901d9757da4/artifact): error trying to connect: tcp connect error: Connection refused (os error 111)

  2023-10-10T16:59:10.387427Z  WARN uplink::collector::downloader: Retrying download; Continuing to download file from: bytes=0-33482

  2023-10-10T16:59:10.388942Z ERROR uplink::collector::downloader: Download failed: error sending request for url (https://firmware.stage.bytebeam.io/api/v1/file/60e38118-4541-470a-a1cf-5901d9757da4/artifact): error trying to connect: tcp connect error: Connection refused (os error 111)

  2023-10-10T16:59:11.390228Z  WARN uplink::collector::downloader: Retrying download; Continuing to download file from: bytes=0-33482

  2023-10-10T16:59:11.390636Z ERROR uplink::collector::downloader: Download failed: error sending request for url (https://firmware.stage.bytebeam.io/api/v1/file/60e38118-4541-470a-a1cf-5901d9757da4/artifact): error trying to connect: tcp connect error: Connection refused (os error 111)

  2023-10-10T16:59:12.392185Z  WARN uplink::collector::downloader: Retrying download; Continuing to download file from: bytes=0-33482

  2023-10-10T16:59:12.393441Z ERROR uplink::collector::downloader: Download failed: error sending request for url (https://firmware.stage.bytebeam.io/api/v1/file/60e38118-4541-470a-a1cf-5901d9757da4/artifact): error trying to connect: tcp connect error: Connection refused (os error 111)
```