### PR TITLE
fix: usize multiplication overflow on 32bit machines

### DIFF
--- a/uplink/src/collector/downloader.rs
+++ b/uplink/src/collector/downloader.rs
@@ -383,7 +383,8 @@ impl DownloadState {
         let size = human_bytes(self.content_length as f64);
 
         // Calculate percentage on the basis of content_length
-        let percentage = (99 * self.bytes_downloaded / self.content_length) as u8;
+        let factor = self.bytes_downloaded as f32 / self.content_length as f32;
+        let percentage = (99.99 * factor) as u8;
 
         // NOTE: ensure lesser frequency of action responses, once every percentage points
         if percentage > self.percentage_downloaded {


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->

### Why?
<!--Detailed description of why the changes had to be made-->
on 32bit machines 99 * 571421193 overflows

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
```
fn main() {
    let x = 571401090;
    assert_eq!(dbg!(99.99 * x as f64 / 571421193 as f64) as u8, 99);

    // let x = 571401090;
    // assert_eq!(dbg!(99_usize * x / 571421193_usize) as u8, 99);
}
```

run against armv7 with `cross run --target=armv7-linux-androideabi`