### PR TITLE
fix: `ActionResponse.action_id` serialization

### DIFF
--- a/uplink/src/base/actions.rs
+++ b/uplink/src/base/actions.rs
@@ -1,5 +1,4 @@
 use serde::{Deserialize, Serialize};
-use serde_json::json;
 use tokio::time::Instant;
 
 use crate::{Payload, Point};
@@ -98,33 +97,17 @@ impl ActionResponse {
         self
     }
 
-    pub fn as_payload(&self) -> Payload {
-        Payload::from(self)
-    }
-
     pub fn from_payload(payload: &Payload) -> Result<Self, serde_json::Error> {
         let intermediate = serde_json::to_value(payload)?;
         serde_json::from_value(intermediate)
     }
 }
 
-impl From<&ActionResponse> for Payload {
-    fn from(resp: &ActionResponse) -> Self {
-        Self {
-            stream: "action_status".to_owned(),
-            sequence: resp.sequence,
-            timestamp: resp.timestamp,
-            payload: json!({
-                "id": resp.action_id,
-                "state": resp.state,
-                "progress": resp.progress,
-                "errors": resp.errors
-            }),
-        }
-    }
-}
-
 impl Point for ActionResponse {
+    fn stream_name(&self) -> &str {
+        "action_status"
+    }
+
     fn sequence(&self) -> u32 {
         self.sequence
     }

--- a/uplink/src/base/bridge/actions_lane.rs
+++ b/uplink/src/base/bridge/actions_lane.rs
@@ -48,7 +48,7 @@ pub struct ActionsBridge {
     /// Actions incoming from backend
     actions_rx: Receiver<Action>,
     /// Contains stream to send ActionResponses on
-    streams: Streams,
+    streams: Streams<ActionResponse>,
     /// Apps registered with the bridge
     /// NOTE: Sometimes action_routes could overlap, the latest route
     /// to be registered will be used in such a circumstance.
@@ -276,7 +276,7 @@ impl ActionsBridge {
         Ok(())
     }
 
-    async fn forward_action_response(&mut self, response: ActionResponse) {
+    async fn forward_action_response(&mut self, mut response: ActionResponse) {
         if self.parallel_actions.contains(&response.action_id) {
             self.forward_parallel_action_response(response).await;
 
@@ -297,9 +297,8 @@ impl ActionsBridge {
         }
 
         info!("Action response = {:?}", response);
-        self.streams.forward(response.as_payload()).await;
-
         if response.is_completed() || response.is_failed() {
+            self.streams.forward(response).await;
             self.clear_current_action();
             return;
         }
@@ -309,15 +308,17 @@ impl ActionsBridge {
         if response.is_done() {
             let mut action = inflight_action.action.clone();
 
-            if let Some(a) = response.done_response {
+            if let Some(a) = response.done_response.take() {
                 action = a;
             }
+
+            self.streams.forward(response.clone()).await;
 
             if let Err(RedirectionError(action)) = self.redirect_action(action).await {
                 // NOTE: send success reponse for actions that don't have redirections configured
                 warn!("Action redirection is not configured for: {:?}", action);
                 let response = ActionResponse::success(&action.action_id);
-                self.streams.forward(response.as_payload()).await;
+                self.streams.forward(response).await;
 
                 self.clear_current_action();
             }
@@ -350,17 +351,17 @@ impl ActionsBridge {
 
     async fn forward_parallel_action_response(&mut self, response: ActionResponse) {
         info!("Action response = {:?}", response);
-        self.streams.forward(response.as_payload()).await;
-
         if response.is_completed() || response.is_failed() {
             self.parallel_actions.remove(&response.action_id);
         }
+
+        self.streams.forward(response).await;
     }
 
     async fn forward_action_error(&mut self, action: Action, error: Error) {
         let response = ActionResponse::failure(&action.action_id, error.to_string());
 
-        self.streams.forward(response.as_payload()).await;
+        self.streams.forward(response).await;
     }
 }
 

--- a/uplink/src/base/bridge/actions_lane.rs
+++ b/uplink/src/base/bridge/actions_lane.rs
@@ -297,8 +297,9 @@ impl ActionsBridge {
         }
 
         info!("Action response = {:?}", response);
+        self.streams.forward(response.clone()).await;
+
         if response.is_completed() || response.is_failed() {
-            self.streams.forward(response).await;
             self.clear_current_action();
             return;
         }
@@ -311,8 +312,6 @@ impl ActionsBridge {
             if let Some(a) = response.done_response.take() {
                 action = a;
             }
-
-            self.streams.forward(response.clone()).await;
 
             if let Err(RedirectionError(action)) = self.redirect_action(action).await {
                 // NOTE: send success reponse for actions that don't have redirections configured

--- a/uplink/src/base/bridge/data_lane.rs
+++ b/uplink/src/base/bridge/data_lane.rs
@@ -22,7 +22,7 @@ pub struct DataBridge {
     /// Rx to receive data from apps
     data_rx: Receiver<Payload>,
     /// Handle to send data over streams
-    streams: Streams,
+    streams: Streams<Payload>,
     ctrl_rx: Receiver<DataBridgeShutdown>,
     ctrl_tx: Sender<DataBridgeShutdown>,
 }

--- a/uplink/src/base/bridge/mod.rs
+++ b/uplink/src/base/bridge/mod.rs
@@ -23,7 +23,7 @@ pub use self::{
 use super::Compression;
 pub use metrics::StreamMetrics;
 
-pub trait Point: Send + Debug {
+pub trait Point: Send + Debug + Serialize + 'static {
     fn stream_name(&self) -> &str;
     fn sequence(&self) -> u32;
     fn timestamp(&self) -> u64;

--- a/uplink/src/base/bridge/mod.rs
+++ b/uplink/src/base/bridge/mod.rs
@@ -24,6 +24,7 @@ use super::Compression;
 pub use metrics::StreamMetrics;
 
 pub trait Point: Send + Debug {
+    fn stream_name(&self) -> &str;
     fn sequence(&self) -> u32;
     fn timestamp(&self) -> u64;
 }
@@ -56,6 +57,10 @@ pub struct Payload {
 }
 
 impl Point for Payload {
+    fn stream_name(&self) -> &str {
+        &self.stream
+    }
+
     fn sequence(&self) -> u32 {
         self.sequence
     }

--- a/uplink/src/base/bridge/stream.rs
+++ b/uplink/src/base/bridge/stream.rs
@@ -40,7 +40,7 @@ pub struct Stream<T> {
 
 impl<T> Stream<T>
 where
-    T: Point + Debug + Send + 'static,
+    T: Point,
     Buffer<T>: Package,
 {
     pub fn new(
@@ -265,7 +265,7 @@ impl<T> Buffer<T> {
 
 impl<T> Package for Buffer<T>
 where
-    T: Debug + Send + Point,
+    T: Point,
     Vec<T>: Serialize,
 {
     fn topic(&self) -> Arc<String> {

--- a/uplink/src/base/bridge/streams.rs
+++ b/uplink/src/base/bridge/streams.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 
 use flume::Sender;
 use log::{error, info, trace};
-use serde::Serialize;
 
 use super::stream::{self, StreamStatus, MAX_BUFFER_SIZE};
 use super::{Point, StreamMetrics};

--- a/uplink/src/base/bridge/streams.rs
+++ b/uplink/src/base/bridge/streams.rs
@@ -20,7 +20,7 @@ pub struct Streams<T> {
     pub stream_timeouts: DelayMap<String>,
 }
 
-impl<T: Point + Serialize + 'static> Streams<T> {
+impl<T: Point> Streams<T> {
     pub fn new(
         config: Arc<Config>,
         data_tx: Sender<Box<dyn Package>>,


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->

### Why?
<!--Detailed description of why the changes had to be made-->
Clickhouse expects the field "id" to be the device_id and not the action_id, this fixes that clash in beamd which lead to loss of action_id information

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
```
  2023-11-03T07:36:25.015854Z  INFO uplink::base::bridge::actions_lane: Action response = ActionResponse { action_id: "2183", sequence: 4, timestamp: 1698996985015, state: "Downloaded", progress: 100, errors: [], done_response: Some(Action { action_id: "2183", kind: "process", name: "update_firmware", payload: "{\"url\":\"https://firmware.stage.bytebeam.io/api/v1/firmwares/new firmware/artifact\",\"content_length\":12734,\"file_name\":\"new firmware\",\"download_path\":\"/var/tmp/ota/1/update_firmware/new firmware\"}", deadline: Some(Instant { tv_sec: 43865, tv_nsec: 161892981 }) }) }

[uplink/src/base/serializer/mod.rs:481] String::from_utf8(data.serialize().unwrap()).unwrap() = "[{\"action_id\":\"2183\",\"sequence\":4,\"timestamp\":1698996985015,\"state\":\"Downloaded\",\"progress\":100,\"errors\":[]}]"
```