### PR TITLE
feat: `action_status` on action specific stream

### DIFF
--- a/uplink/src/base/actions.rs
+++ b/uplink/src/base/actions.rs
@@ -24,10 +24,14 @@ pub struct Action {
     pub deadline: Option<Instant>,
 }
 
+const DEFAULT_RESPONSE_STREAM: &str = "action_status";
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ActionResponse {
     #[serde(alias = "id")]
     pub action_id: String,
+    #[serde(skip)]
+    pub action_name: Option<String>,
     // sequence number
     pub sequence: u32,
     // timestamp
@@ -48,6 +52,7 @@ impl ActionResponse {
 
         ActionResponse {
             action_id: id.to_owned(),
+            action_name: None,
             sequence: 0,
             timestamp,
             state: state.to_owned(),
@@ -67,6 +72,10 @@ impl ActionResponse {
 
     pub fn is_done(&self) -> bool {
         self.progress == 100
+    }
+
+    pub fn set_action_name(&mut self, action_name: String) {
+        self.action_name = Some(action_name)
     }
 
     pub fn progress(id: &str, state: &str, progress: u8) -> Self {
@@ -105,7 +114,7 @@ impl ActionResponse {
 
 impl Point for ActionResponse {
     fn stream_name(&self) -> &str {
-        "action_status"
+        self.action_name.as_ref().map(|n| n.as_str()).unwrap_or_else(|| DEFAULT_RESPONSE_STREAM)
     }
 
     fn sequence(&self) -> u32 {

--- a/uplink/src/base/actions.rs
+++ b/uplink/src/base/actions.rs
@@ -114,7 +114,7 @@ impl ActionResponse {
 
 impl Point for ActionResponse {
     fn stream_name(&self) -> &str {
-        self.action_name.as_ref().map(|n| n.as_str()).unwrap_or_else(|| DEFAULT_RESPONSE_STREAM)
+        self.action_name.as_deref().unwrap_or(DEFAULT_RESPONSE_STREAM)
     }
 
     fn sequence(&self) -> u32 {

--- a/uplink/src/base/bridge/data_lane.rs
+++ b/uplink/src/base/bridge/data_lane.rs
@@ -36,7 +36,9 @@ impl DataBridge {
         let (data_tx, data_rx) = bounded(10);
         let (ctrl_tx, ctrl_rx) = bounded(1);
 
-        let mut streams = Streams::new(config.clone(), package_tx, metrics_tx);
+        let topic_template =
+            "/tenants/{tenant_id}/devices/{device_id}/events/{stream_name}/jsonarray".to_string();
+        let mut streams = Streams::new(config.clone(), package_tx, metrics_tx, topic_template);
         streams.config_streams(config.streams.clone());
 
         Self { data_tx, data_rx, config, streams, ctrl_rx, ctrl_tx }

--- a/uplink/src/base/bridge/stream.rs
+++ b/uplink/src/base/bridge/stream.rs
@@ -81,25 +81,23 @@ where
     }
 
     pub fn dynamic(
-        stream: impl Into<String>,
-        project_id: impl Into<String>,
+        stream_name: impl Into<String>,
+        tenant_id: impl Into<String>,
         device_id: impl Into<String>,
         max_buffer_size: usize,
         tx: Sender<Box<dyn Package>>,
+        topic_template: &str,
     ) -> Stream<T> {
-        let stream = stream.into();
-        let project_id = project_id.into();
+        let stream_name = stream_name.into();
+        let tenant_id = tenant_id.into();
         let device_id = device_id.into();
 
-        let topic = String::from("/tenants/")
-            + &project_id
-            + "/devices/"
-            + &device_id
-            + "/events/"
-            + &stream
-            + "/jsonarray";
+        // e.g. "/tenants/{tenant_id}/devices/{device_id}/events/{stream_name}/jsonarray"
+        let topic_template = topic_template.replace("{tenant_id}", &tenant_id);
+        let topic_template = topic_template.replace("{device_id}", &device_id);
+        let topic = topic_template.replace("{stream_name}", &stream_name);
 
-        Stream::new(stream, topic, max_buffer_size, tx, Compression::Disabled)
+        Stream::new(stream_name, topic, max_buffer_size, tx, Compression::Disabled)
     }
 
     fn add(&mut self, data: T) -> Result<Option<Buffer<T>>, Error> {

--- a/uplink/src/base/bridge/streams.rs
+++ b/uplink/src/base/bridge/streams.rs
@@ -17,6 +17,8 @@ pub struct Streams<T> {
     metrics_tx: Sender<StreamMetrics>,
     map: HashMap<String, Stream<T>>,
     pub stream_timeouts: DelayMap<String>,
+    pub max_buf_size: usize,
+    topic_template: String,
 }
 
 impl<T: Point> Streams<T> {
@@ -24,8 +26,17 @@ impl<T: Point> Streams<T> {
         config: Arc<Config>,
         data_tx: Sender<Box<dyn Package>>,
         metrics_tx: Sender<StreamMetrics>,
+        topic_template: String,
     ) -> Self {
-        Self { config, data_tx, metrics_tx, map: HashMap::new(), stream_timeouts: DelayMap::new() }
+        Self {
+            config,
+            data_tx,
+            metrics_tx,
+            map: HashMap::new(),
+            stream_timeouts: DelayMap::new(),
+            topic_template,
+            max_buf_size: MAX_BUFFER_SIZE,
+        }
     }
 
     pub fn config_streams(&mut self, streams_config: HashMap<String, StreamConfig>) {
@@ -50,8 +61,9 @@ impl<T: Point> Streams<T> {
                     &stream_name,
                     &self.config.project_id,
                     &self.config.device_id,
-                    MAX_BUFFER_SIZE,
+                    self.max_buf_size,
                     self.data_tx.clone(),
+                    &self.topic_template,
                 );
 
                 self.map.entry(stream_name.to_owned()).or_insert(stream)


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->

### Why?
<!--Detailed description of why the changes had to be made-->
We seek to send action responses onto two streams of the following form:
1. The original: `/tenants/{tenant_id}/devices/{device_id}/action/status`
2. The more action specific: `/tenants/{tenant_id}/devices/{device_id}/action_status/{stream_name}`

The action specific topics can hence forth be subscribed to receive notifications regarding progress of an action that is of interest.

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
```
  2023-11-16T13:17:35.344081Z  INFO uplink::collector::simulator: Successfully sent all action responses

  2023-11-16T13:17:35.344317Z  INFO uplink::base::bridge::actions_lane: Action response = ActionResponse { action_id: "2223", action_name: None, sequence: 10, timestamp: 1700140655344, state: "Completed", progress: 100, errors: [], done_response: None }

  2023-11-16T13:17:35.344555Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1002/action/status with size = 109

  2023-11-16T13:17:35.344604Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1002/action_status/lock with size = 109
```