### PR TITLE
feat: force flush non-overflowed in-memory buffers

### DIFF
--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -85,6 +85,11 @@ impl Storage {
             return Ok(None);
         }
 
+        self.flush()
+    }
+
+    /// Force flush the contents of write buffer onto disk
+    pub fn flush(&mut self) -> Result<Option<u64>, Error> {
         match &mut self.persistence {
             Some(persistence) => {
                 let hash = hash(&self.current_write_file[..]);

--- a/uplink/src/base/serializer/mod.rs
+++ b/uplink/src/base/serializer/mod.rs
@@ -310,7 +310,7 @@ impl<C: MqttClient> Serializer<C> {
         }
 
         loop {
-            // Collect next data packet and write to disk
+            // Collect remaining data packets and write to disk
             let Ok(data) = self.collector_rx.recv_async().await else {
                 self.storage_handler.flush_all();
                 return Err(Error::Shutdown);

--- a/uplink/src/base/serializer/mod.rs
+++ b/uplink/src/base/serializer/mod.rs
@@ -209,8 +209,9 @@ impl StorageHandler {
 
     fn flush_all(&mut self) {
         for (stream_name, storage) in self.map.iter_mut() {
-            if let Err(e) = storage.flush() {
-                error!("Error when force flushing storage = {stream_name}; error = {e}")
+            match storage.flush() {
+                Ok(_) => trace!("Force flushed stream = {stream_name} onto disk"),
+                Err(e) => error!("Error when force flushing storage = {stream_name}; error = {e}"),
             }
         }
     }

--- a/uplink/src/main.rs
+++ b/uplink/src/main.rs
@@ -203,7 +203,7 @@ fn main() -> Result<(), Error> {
         uplink.resolve_on_shutdown().await.unwrap();
         info!("Uplink shutting down...");
         // NOTE: wait 5s to allow serializer to write to network/disk
-        sleep(Duration::from_secs(5)).await;
+        sleep(Duration::from_secs(10)).await;
     });
 
     Ok(())


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->

### Why?
<!--Detailed description of why the changes had to be made-->
We need to ensure that all data left in uplink serializer is written to disk during uplink shutdown.

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
1. Write config such that stream's persistence to disk has `max_file_size > size_of(serialized_data)`, e.g. 1MB.
2. Start uplink with network disabled.
3. Use example to push a single data onto the stream(run https://github.com/bytebeamio/uplink/blob/main/examples/demo.py#L105 after removing the while loop and `stream: "test"`).
```
  2023-12-01T11:27:20.228264Z DEBUG uplink::collector::tcpjson: 1: Received line = "{\"stream\": \"device_shadow\", \"sequence\": 1, \"timestamp\": 1701430040227, \"Status\": \"running\"}"

  2023-12-01T11:27:25.230178Z DEBUG uplink::base::bridge::data_lane: Flushing stream = device_shadow
```
4. Shutdown uplink.
```
  2023-12-01T11:29:41.783524Z  INFO uplink::base::serializer:              slow: batches = 15  errors = 0 lost = 0 disk_files = 0   write_memory = 18.1 kB read_memory = 0 B

  2023-12-01T11:30:06.093432Z  INFO uplink: Uplink shutting down...

  2023-12-01T11:30:06.093399Z DEBUG uplink::base::serializer: Forced into crash mode, writing all incoming data to persistence.

  2023-12-01T11:30:07.124332Z TRACE uplink::base::serializer: Force flushed stream = /tenants/demo/devices/1281/events/device_shadow/jsonarray onto disk

  2023-12-01T13:03:15.917657Z ERROR uplink: Serializer stopped!! Error = Shutdown
```
5. Check the stream's persistence folder to see if there is a backup file for the single data that was left in memory on shutdown.
```
ls path/to/persistence
```