### PR TITLE
feat: track disk space utilized by persistence

### DIFF
--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -70,6 +70,13 @@ impl Storage {
         }
     }
 
+    pub fn disk_utilized(&self) -> usize {
+        match &self.persistence {
+            Some(p) => p.bytes_occupied,
+            None => 0,
+        }
+    }
+
     pub fn inmemory_read_size(&self) -> usize {
         self.current_read_file.len()
     }

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -234,6 +234,13 @@ impl Persistence {
         let backlog_files = get_file_ids(&path)?;
         info!("List of file ids loaded from disk: {backlog_files:?}");
 
+        let bytes_occupied = backlog_files.iter().fold(0, |acc, id| {
+            let mut file = PathBuf::from(&path);
+            let file_name = format!("backup@{id}");
+            file.push(file_name);
+            fs::metadata(&file).unwrap().len() as usize + acc
+        });
+
         Ok(Persistence {
             path,
             max_file_count,
@@ -241,7 +248,7 @@ impl Persistence {
             current_read_file_id: None,
             // deleted: None,
             non_destructive_read: false,
-            bytes_occupied: 0,
+            bytes_occupied,
         })
     }
 

--- a/uplink/src/base/serializer/metrics.rs
+++ b/uplink/src/base/serializer/metrics.rs
@@ -17,6 +17,8 @@ pub struct SerializerMetrics {
     pub read_memory: usize,
     /// Number of files that have been written to disk
     pub disk_files: usize,
+    /// Number of bytes that have been written to disk
+    pub disk_utilized: usize,
     /// Nuber of persistence files that had to deleted before being consumed
     pub lost_segments: usize,
     /// Number of errors faced during serializer operation
@@ -35,6 +37,7 @@ impl SerializerMetrics {
             write_memory: 0,
             read_memory: 0,
             disk_files: 0,
+            disk_utilized: 0,
             lost_segments: 0,
             errors: 0,
             sent_size: 0,
@@ -66,6 +69,10 @@ impl SerializerMetrics {
 
     pub fn set_disk_files(&mut self, count: usize) {
         self.disk_files = count;
+    }
+
+    pub fn set_disk_utilized(&mut self, bytes: usize) {
+        self.disk_utilized = bytes;
     }
 
     pub fn increment_errors(&mut self) {

--- a/uplink/src/base/serializer/metrics.rs
+++ b/uplink/src/base/serializer/metrics.rs
@@ -17,7 +17,7 @@ pub struct SerializerMetrics {
     pub read_memory: usize,
     /// Number of files that have been written to disk
     pub disk_files: usize,
-    /// Number of bytes that have been written to disk
+    /// Disk size currently occupied by persistence files
     pub disk_utilized: usize,
     /// Nuber of persistence files that had to deleted before being consumed
     pub lost_segments: usize,

--- a/uplink/src/base/serializer/mod.rs
+++ b/uplink/src/base/serializer/mod.rs
@@ -578,16 +578,19 @@ fn check_metrics(metrics: &mut SerializerMetrics, storage_handler: &StorageHandl
     let mut inmemory_write_size = 0;
     let mut inmemory_read_size = 0;
     let mut file_count = 0;
+    let mut disk_utilized = 0;
 
     for storage in storage_handler.map.values() {
         inmemory_read_size += storage.inmemory_read_size();
         inmemory_write_size += storage.inmemory_write_size();
         file_count += storage.file_count();
+        disk_utilized += storage.disk_utilized();
     }
 
     metrics.set_write_memory(inmemory_write_size);
     metrics.set_read_memory(inmemory_read_size);
     metrics.set_disk_files(file_count);
+    metrics.set_disk_files(disk_utilized);
 
     info!(
         "{:>17}: batches = {:<3} errors = {} lost = {} disk_files = {:<3} write_memory = {} read_memory = {}",
@@ -609,16 +612,19 @@ fn save_and_prepare_next_metrics(
     let mut inmemory_write_size = 0;
     let mut inmemory_read_size = 0;
     let mut file_count = 0;
+    let mut disk_utilized = 0;
 
     for storage in storage_handler.map.values() {
         inmemory_write_size += storage.inmemory_write_size();
         inmemory_read_size += storage.inmemory_read_size();
         file_count += storage.file_count();
+        disk_utilized += storage.disk_utilized();
     }
 
     metrics.set_write_memory(inmemory_write_size);
     metrics.set_read_memory(inmemory_read_size);
     metrics.set_disk_files(file_count);
+    metrics.set_disk_utilized(disk_utilized);
 
     let m = metrics.clone();
     pending.push_back(m);
@@ -637,16 +643,19 @@ fn check_and_flush_metrics(
     let mut inmemory_write_size = 0;
     let mut inmemory_read_size = 0;
     let mut file_count = 0;
+    let mut disk_utilized = 0;
 
     for storage in storage_handler.map.values() {
         inmemory_write_size += storage.inmemory_write_size();
         inmemory_read_size += storage.inmemory_read_size();
         file_count += storage.file_count();
+        disk_utilized += storage.disk_utilized();
     }
 
     metrics.set_write_memory(inmemory_write_size);
     metrics.set_read_memory(inmemory_read_size);
     metrics.set_disk_files(file_count);
+    metrics.set_disk_utilized(disk_utilized);
 
     // Send pending metrics. This signifies state change
     while let Some(metrics) = pending.get(0) {

--- a/uplink/src/base/serializer/mod.rs
+++ b/uplink/src/base/serializer/mod.rs
@@ -590,7 +590,7 @@ fn check_metrics(metrics: &mut SerializerMetrics, storage_handler: &StorageHandl
     metrics.set_write_memory(inmemory_write_size);
     metrics.set_read_memory(inmemory_read_size);
     metrics.set_disk_files(file_count);
-    metrics.set_disk_files(disk_utilized);
+    metrics.set_disk_utilized(disk_utilized);
 
     info!(
         "{:>17}: batches = {:<3} errors = {} lost = {} disk_files = {:<3} disk_utilized = {} write_memory = {} read_memory = {}",

--- a/uplink/src/base/serializer/mod.rs
+++ b/uplink/src/base/serializer/mod.rs
@@ -593,12 +593,13 @@ fn check_metrics(metrics: &mut SerializerMetrics, storage_handler: &StorageHandl
     metrics.set_disk_files(disk_utilized);
 
     info!(
-        "{:>17}: batches = {:<3} errors = {} lost = {} disk_files = {:<3} write_memory = {} read_memory = {}",
+        "{:>17}: batches = {:<3} errors = {} lost = {} disk_files = {:<3} disk_utilized = {} write_memory = {} read_memory = {}",
         metrics.mode,
         metrics.batches,
         metrics.errors,
         metrics.lost_segments,
         metrics.disk_files,
+        convert(metrics.disk_utilized as f64),
         convert(metrics.write_memory as f64),
         convert(metrics.read_memory as f64),
     );
@@ -661,12 +662,13 @@ fn check_and_flush_metrics(
     while let Some(metrics) = pending.get(0) {
         // Always send pending metrics. They represent state changes
         info!(
-            "{:>17}: batches = {:<3} errors = {} lost = {} disk_files = {:<3} write_memory = {} read_memory = {}",
+            "{:>17}: batches = {:<3} errors = {} lost = {} disk_files = {:<3} disk_utilized = {} write_memory = {} read_memory = {}",
             metrics.mode,
             metrics.batches,
             metrics.errors,
             metrics.lost_segments,
             metrics.disk_files,
+            convert(metrics.disk_utilized as f64),
             convert(metrics.write_memory as f64),
             convert(metrics.read_memory as f64),
         );

--- a/uplink/src/base/serializer/mod.rs
+++ b/uplink/src/base/serializer/mod.rs
@@ -678,12 +678,13 @@ fn check_and_flush_metrics(
 
     if metrics.batches() > 0 {
         info!(
-            "{:>17}: batches = {:<3} errors = {} lost = {} disk_files = {:<3} write_memory = {} read_memory = {}",
+            "{:>17}: batches = {:<3} errors = {} lost = {} disk_files = {:<3} disk_utilized = {} write_memory = {} read_memory = {}",
             metrics.mode,
             metrics.batches,
             metrics.errors,
             metrics.lost_segments,
             metrics.disk_files,
+            convert(metrics.disk_utilized as f64),
             convert(metrics.write_memory as f64),
             convert(metrics.read_memory as f64),
         );


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->

### Why?
<!--Detailed description of why the changes had to be made-->
Currently we only track count of files in disk and not the size of files

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
```
  2023-12-05T13:13:25.332424Z  INFO uplink::base::serializer:           catchup: batches = 4481 errors = 0 lost = 401 disk_files = 1761 disk_utilized = 47.79 MB write_memory = 3.05 MB read_memory = 0 B
```