### PR TITLE
fix: transition into normal mode only after all storages are emptied

### DIFF
--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -19,7 +19,7 @@ pub enum Error {
 }
 
 pub struct Storage {
-    name: String,
+    pub name: String,
     /// maximum allowed file size
     max_file_size: usize,
     /// current open file


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->

### Why?
<!--Detailed description of why the changes had to be made-->
Currently, if there is any error when reading from a storage, we miss reading the rest of the storages, which is buggy behavior, this is not a problem as long we do checksum verification before loading file from disk, but there is the edge case possibility of corrupt packets written to disk that have valid checksum, in which case we should still complete handling all the storages.

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->