### PR TITLE
refactor: handle files on disk as `PersistenceFile`

### DIFF
--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -3,8 +3,8 @@ use log::{self, debug, error, info, warn};
 use seahash::hash;
 
 use std::collections::VecDeque;
-use std::fs::{self, File, OpenOptions};
-use std::io::{self, Read, Write};
+use std::fs::{self, OpenOptions};
+use std::io::{self, copy, Write};
 use std::mem;
 use std::path::{Path, PathBuf};
 
@@ -94,22 +94,15 @@ impl Storage {
 
         match &mut self.persistence {
             Some(persistence) => {
-                let hash = hash(&self.current_write_file[..]);
-                let mut next_file = persistence.open_next_write_file()?;
-                info!(
-                    "Flushing data to disk for stoarge: {}; path = {:?}",
-                    self.name, next_file.path
-                );
-
-                next_file.file.write_all(&hash.to_be_bytes())?;
-                next_file.file.write_all(&self.current_write_file[..])?;
-                next_file.file.flush()?;
+                let NextFile { mut file, deleted } = persistence.open_next_write_file()?;
+                info!("Flushing data to disk for stoarge: {}; path = {:?}", self.name, file.path());
+                file.write(&mut self.current_write_file)?;
 
                 // 8 is the number of bytes the hash(u64) occupies
                 persistence.bytes_occupied += 8 + self.current_write_file.len();
-
                 self.current_write_file.clear();
-                Ok(next_file.deleted)
+
+                Ok(deleted)
             }
             None => {
                 // TODO(RT): Make sure that disk files starts with id 1 to represent in memory file
@@ -206,9 +199,91 @@ fn get_file_ids(path: &Path) -> Result<VecDeque<u64>, Error> {
     Ok(file_ids)
 }
 
-struct NextFile {
-    path: PathBuf,
-    file: File,
+pub struct PersistenceFile<'a> {
+    dir: &'a Path,
+    file_id: u64,
+}
+
+impl<'a> PersistenceFile<'a> {
+    pub fn new(dir: &'a Path, file_id: u64) -> Result<Self, Error> {
+        Ok(Self { dir, file_id })
+    }
+
+    /// Path of persistence file when stored on disk
+    pub fn path(&self) -> PathBuf {
+        let file_name = format!("backup@{}", self.file_id);
+        self.dir.join(file_name)
+    }
+
+    // Moves the corrupt persistence file into special directory
+    fn handle_corrupt_file(&self) -> Result<(), Error> {
+        let path_src = self.path();
+        let dest_dir = self.dir.join("corrupted");
+        fs::create_dir_all(&dest_dir)?;
+
+        let file_name = path_src.file_name().unwrap();
+        let path_dest = dest_dir.join(file_name);
+
+        warn!("Moving corrupted file from {path_src:?} to {path_dest:?}");
+        fs::rename(path_src, path_dest)?;
+
+        Ok(())
+    }
+
+    /// Read contents of the persistence file from disk into buffer in memory
+    pub fn read(&mut self, buf: &mut BytesMut) -> Result<(), Error> {
+        let path = self.path();
+        let mut file = OpenOptions::new().read(true).open(&path)?;
+
+        // Initialize buffer and load next read file
+        buf.clear();
+        copy(&mut file, &mut buf.writer())?;
+
+        // Verify with checksum
+        if buf.len() < 8 {
+            self.handle_corrupt_file()?;
+            return Err(Error::CorruptedFile);
+        }
+
+        let expected_hash = buf.get_u64();
+        let actual_hash = hash(&buf[..]);
+        if actual_hash != expected_hash {
+            self.handle_corrupt_file()?;
+            return Err(Error::CorruptedFile);
+        }
+
+        Ok(())
+    }
+
+    /// Write contents of buffer from memory onto the persistence file in disk
+    pub fn write(&mut self, buf: &mut BytesMut) -> Result<(), Error> {
+        let path = self.path();
+        let mut file = OpenOptions::new().write(true).create(true).open(&path)?;
+
+        let hash = hash(&buf[..]);
+        file.write_all(&hash.to_be_bytes())?;
+        file.write_all(&buf[..])?;
+        file.flush()?;
+
+        Ok(())
+    }
+
+    /// Deletes the persistence file from disk
+    pub fn delete(&mut self) -> Result<u64, Error> {
+        let path = self.path();
+
+        // Query the fs to track size of removed persistence file
+        let metadata = fs::metadata(&path)?;
+        let bytes_occupied = metadata.len();
+
+        fs::remove_file(&path)?;
+
+        Ok(bytes_occupied)
+    }
+}
+
+struct NextFile<'a> {
+    file: PersistenceFile<'a>,
     deleted: Option<u64>,
 }
 
@@ -252,53 +327,21 @@ impl Persistence {
         })
     }
 
-    fn path(&self, id: u64) -> Result<PathBuf, Error> {
-        let file_name = format!("backup@{id}");
-        let path = self.path.join(file_name);
-
-        Ok(path)
-    }
-
-    /// Removes a file with provided id
+    /// Removes a persistence file with provided id
     fn remove(&mut self, id: u64) -> Result<PathBuf, Error> {
-        let path = self.path(id)?;
+        let mut file = PersistenceFile::new(&self.path, id)?;
+        let path = file.path();
 
-        // Query the fs to track size of removed persistence file
-        let metadata = fs::metadata(&path)?;
-        self.bytes_occupied -= metadata.len() as usize;
-
-        fs::remove_file(&path)?;
+        self.bytes_occupied -= file.delete()? as usize;
 
         Ok(path)
-    }
-
-    /// Move corrupt file to special directory
-    fn handle_corrupt_file(&self) -> Result<(), Error> {
-        let id = self.current_read_file_id.expect("There is supposed to be a file here");
-        let path_src = self.path(id)?;
-        let dest_dir = self.path.join("corrupted");
-        fs::create_dir_all(&dest_dir)?;
-
-        let file_name = path_src.file_name().expect("The file name should exist");
-        let path_dest = dest_dir.join(file_name);
-
-        warn!("Moving corrupted file from {path_src:?} to {path_dest:?}");
-        fs::rename(path_src, path_dest)?;
-
-        Ok(())
     }
 
     /// Opens file to flush current inmemory write buffer to disk.
     /// Also handles retention of previous files on disk
     fn open_next_write_file(&mut self) -> Result<NextFile, Error> {
         let next_file_id = self.backlog_files.back().map_or(0, |id| id + 1);
-        let file_name = format!("backup@{next_file_id}");
-        let next_file_path = self.path.join(file_name);
-        let next_file = OpenOptions::new().write(true).create(true).open(&next_file_path)?;
-
         self.backlog_files.push_back(next_file_id);
-
-        let mut next = NextFile { path: next_file_path, file: next_file, deleted: None };
         let mut backlog_files_count = self.backlog_files.len();
 
         // File being read is also to be considered
@@ -306,57 +349,37 @@ impl Persistence {
             backlog_files_count += 1
         }
 
-        // Return next file details if backlog is within limits
-        if backlog_files_count <= self.max_file_count {
-            return Ok(next);
-        }
+        // Delete earliest file if backlog limits crossed
+        let deleted = if backlog_files_count > self.max_file_count {
+            // Remove file being read, or first in backlog
+            // NOTE: keeps read buffer unchanged
+            let id = match self.current_read_file_id.take() {
+                Some(id) => id,
+                _ => self.backlog_files.pop_front().unwrap(),
+            };
 
-        // Remove file being read, or first in backlog
-        // NOTE: keeps read buffer unchanged
-        let id = match self.current_read_file_id.take() {
-            Some(id) => id,
-            _ => self.backlog_files.pop_front().unwrap(),
+            if !self.non_destructive_read {
+                let deleted_file = self.remove(id)?;
+                warn!("file limit reached. deleting backup@{}; path = {deleted_file:?}", id);
+            }
+
+            Some(id)
+        } else {
+            None
         };
 
-        next.deleted = Some(id);
-        if !self.non_destructive_read {
-            let deleted_file = self.remove(id)?;
-            warn!("file limit reached. deleting backup@{}; path = {deleted_file:?}", id);
-        }
-
-        Ok(next)
+        Ok(NextFile { file: PersistenceFile::new(&self.path, next_file_id)?, deleted })
     }
 
+    /// Load the next persistence file to be read into memory
     fn load_next_read_file(&mut self, current_read_file: &mut BytesMut) -> Result<(), Error> {
         // Len always > 0 because of above if. Doesn't panic
         let id = self.backlog_files.pop_front().unwrap();
-        let next_file_path = self.path(id)?;
-
-        let mut file = OpenOptions::new().read(true).open(&next_file_path)?;
+        let mut file = PersistenceFile::new(&self.path, id)?;
 
         // Load file into memory and store its id for deleting in the future
-        let metadata = fs::metadata(&next_file_path)?;
-
-        // Initialize next read file with 0s
-        current_read_file.clear();
-        let init = vec![0u8; metadata.len() as usize];
-        current_read_file.put_slice(&init);
-
-        file.read_exact(&mut current_read_file[..])?;
+        file.read(current_read_file)?;
         self.current_read_file_id = Some(id);
-
-        // Verify with checksum
-        if current_read_file.len() < 8 {
-            self.handle_corrupt_file()?;
-            return Err(Error::CorruptedFile);
-        }
-
-        let expected_hash = current_read_file.get_u64();
-        let actual_hash = hash(&current_read_file[..]);
-        if actual_hash != expected_hash {
-            self.handle_corrupt_file()?;
-            return Err(Error::CorruptedFile);
-        }
 
         Ok(())
     }

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -233,7 +233,7 @@ impl<'a> PersistenceFile<'a> {
     /// Read contents of the persistence file from disk into buffer in memory
     pub fn read(&mut self, buf: &mut BytesMut) -> Result<(), Error> {
         let path = self.path();
-        let mut file = OpenOptions::new().read(true).open(&path)?;
+        let mut file = OpenOptions::new().read(true).open(path)?;
 
         // Initialize buffer and load next read file
         buf.clear();
@@ -258,7 +258,7 @@ impl<'a> PersistenceFile<'a> {
     /// Write contents of buffer from memory onto the persistence file in disk
     pub fn write(&mut self, buf: &mut BytesMut) -> Result<(), Error> {
         let path = self.path();
-        let mut file = OpenOptions::new().write(true).create(true).open(&path)?;
+        let mut file = OpenOptions::new().write(true).create(true).open(path)?;
 
         let hash = hash(&buf[..]);
         file.write_all(&hash.to_be_bytes())?;


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->

### Why?
<!--Detailed description of why the changes had to be made-->
Helps us reuse this code in #299 where currently there is a custom implementation of the same

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
Run QA persistence test, turn down the internet, bring it back up. Observed that things work as expected.
```

  2023-12-08T11:05:29.590695Z  WARN storage: file limit reached. deleting backup@9; path = "/var/tmp/persistence/imu/backup@9"

  2023-12-08T11:05:29.590750Z  INFO storage: Flushing data to disk for stoarge: /tenants/demo/devices/1001/events/imu/jsonarray; path = "/var/tmp/persistence/imu/backup@12"

  2023-12-08T11:05:29.590944Z DEBUG uplink::base::serializer: Lost segment = 9

  2023-12-08T11:05:34.441571Z  WARN storage: Persistence disabled for storage: /tenants/demo/devices/1001/events/bms/jsonarray. Deleted in-memory buffer on overflow

  2023-12-08T11:05:34.441645Z DEBUG uplink::base::serializer: Lost segment = 0

  2023-12-08T11:05:36.693653Z  INFO uplink::base::serializer:              slow: batches = 61  errors = 0 lost = 16 disk_files = 3   disk_utilized = 81.2 kB write_memory = 221.2 kB read_memory = 0 B

  2023-12-08T11:05:39.589715Z  WARN storage: file limit reached. deleting backup@10; path = "/var/tmp/persistence/imu/backup@10"

  2023-12-08T11:05:39.589761Z  INFO storage: Flushing data to disk for stoarge: /tenants/demo/devices/1001/events/imu/jsonarray; path = "/var/tmp/persistence/imu/backup@13"

  2023-12-08T11:05:39.589901Z DEBUG uplink::base::serializer: Lost segment = 10

  2023-12-08T11:05:46.693561Z  INFO uplink::base::serializer:              slow: batches = 66  errors = 0 lost = 17 disk_files = 3   disk_utilized = 81.09 kB write_memory = 241.81 kB read_memory = 0 B

  2023-12-08T11:05:49.590523Z  WARN storage: file limit reached. deleting backup@11; path = "/var/tmp/persistence/imu/backup@11"

  2023-12-08T11:05:49.590586Z  INFO storage: Flushing data to disk for stoarge: /tenants/demo/devices/1001/events/imu/jsonarray; path = "/var/tmp/persistence/imu/backup@14"

  2023-12-08T11:05:49.590785Z DEBUG uplink::base::serializer: Lost segment = 11

  2023-12-08T11:05:56.693544Z  INFO uplink::base::serializer:              slow: batches = 69  errors = 0 lost = 18 disk_files = 3   disk_utilized = 81.22 kB write_memory = 244.21 kB read_memory = 0 B

  2023-12-08T11:05:59.441152Z  WARN storage: Persistence disabled for storage: /tenants/demo/devices/1001/events/bms/jsonarray. Deleted in-memory buffer on overflow

  2023-12-08T11:05:59.441209Z DEBUG uplink::base::serializer: Lost segment = 0

  2023-12-08T11:05:59.543834Z  INFO uplink::base::serializer: Switching to catchup mode!!

  2023-12-08T11:05:59.543872Z DEBUG uplink::base::serializer: Reading from: /tenants/demo/devices/1001/events/uplink_network_stats/jsonarray

  2023-12-08T11:05:59.543888Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/uplink_network_stats/jsonarray with size = 473

  2023-12-08T11:05:59.544028Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/uplink_network_stats/jsonarray with size = 474

  2023-12-08T11:05:59.544066Z DEBUG uplink::base::serializer: Completed reading from: /tenants/demo/devices/1001/events/uplink_network_stats/jsonarray

  2023-12-08T11:05:59.544222Z DEBUG uplink::base::serializer: Reading from: /tenants/demo/devices/1001/events/imu/jsonarray

  2023-12-08T11:05:59.544245Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/imu/jsonarray with size = 27015

  2023-12-08T11:05:59.544391Z DEBUG storage: Completed reading a persistence file, deleting it; storage = /tenants/demo/devices/1001/events/imu/jsonarray, path = "/var/tmp/persistence/imu/backup@12"

  2023-12-08T11:05:59.544461Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/imu/jsonarray with size = 26999

  2023-12-08T11:05:59.544555Z DEBUG storage: Completed reading a persistence file, deleting it; storage = /tenants/demo/devices/1001/events/imu/jsonarray, path = "/var/tmp/persistence/imu/backup@13"

  2023-12-08T11:05:59.544619Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/imu/jsonarray with size = 27014

  2023-12-08T11:05:59.544701Z DEBUG storage: Completed reading a persistence file, deleting it; storage = /tenants/demo/devices/1001/events/imu/jsonarray, path = "/var/tmp/persistence/imu/backup@14"

  2023-12-08T11:05:59.544717Z DEBUG uplink::base::serializer: Completed reading from: /tenants/demo/devices/1001/events/imu/jsonarray

  2023-12-08T11:05:59.544726Z DEBUG uplink::base::serializer: Reading from: /tenants/demo/devices/1001/events/uplink_process_stats/jsonarray

  2023-12-08T11:05:59.544740Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/uplink_process_stats/jsonarray with size = 492

  2023-12-08T11:05:59.544757Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/uplink_process_stats/jsonarray with size = 511

  2023-12-08T11:05:59.544772Z DEBUG uplink::base::serializer: Completed reading from: /tenants/demo/devices/1001/events/uplink_process_stats/jsonarray

  2023-12-08T11:05:59.544784Z DEBUG uplink::base::serializer: Reading from: /tenants/demo/devices/1001/events/gps/jsonarray

  2023-12-08T11:05:59.544796Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/gps/jsonarray with size = 24611

  2023-12-08T11:05:59.544818Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/gps/jsonarray with size = 5042

  2023-12-08T11:05:59.544837Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/gps/jsonarray with size = 24589

  2023-12-08T11:05:59.544862Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/gps/jsonarray with size = 24610

  2023-12-08T11:05:59.544907Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/gps/jsonarray with size = 5077

  2023-12-08T11:05:59.544927Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/gps/jsonarray with size = 24594

  2023-12-08T11:05:59.544968Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/gps/jsonarray with size = 24604

  2023-12-08T11:05:59.545007Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/gps/jsonarray with size = 24592

  2023-12-08T11:05:59.545044Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/gps/jsonarray with size = 5109

  2023-12-08T11:05:59.545064Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/gps/jsonarray with size = 24590

  2023-12-08T11:05:59.545088Z DEBUG uplink::base::serializer: Completed reading from: /tenants/demo/devices/1001/events/gps/jsonarray

  2023-12-08T11:05:59.545100Z DEBUG uplink::base::serializer: Reading from: /tenants/demo/devices/1001/events/uplink_processor_stats/jsonarray

  2023-12-08T11:05:59.545113Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/uplink_processor_stats/jsonarray with size = 3102

  2023-12-08T11:05:59.545131Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/uplink_processor_stats/jsonarray with size = 3111

  2023-12-08T11:05:59.545150Z DEBUG uplink::base::serializer: Completed reading from: /tenants/demo/devices/1001/events/uplink_processor_stats/jsonarray

  2023-12-08T11:05:59.545161Z DEBUG uplink::base::serializer: Reading from: /tenants/demo/devices/1001/events/peripheral_state/jsonarray

  2023-12-08T11:05:59.545174Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/peripheral_state/jsonarray with size = 12808

  2023-12-08T11:05:59.545213Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/peripheral_state/jsonarray with size = 12855

  2023-12-08T11:05:59.545246Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/peripheral_state/jsonarray with size = 12908

  2023-12-08T11:05:59.545280Z DEBUG uplink::base::serializer: Completed reading from: /tenants/demo/devices/1001/events/peripheral_state/jsonarray

  2023-12-08T11:05:59.545292Z DEBUG uplink::base::serializer: Reading from: /tenants/demo/devices/1001/events/device_shadow/jsonarray

  2023-12-08T11:05:59.545306Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/device_shadow/jsonarray with size = 1131

  2023-12-08T11:05:59.545325Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/device_shadow/jsonarray with size = 1127

  2023-12-08T11:05:59.545347Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/device_shadow/jsonarray with size = 1209

  2023-12-08T11:05:59.545368Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/device_shadow/jsonarray with size = 1129

  2023-12-08T11:05:59.545386Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/device_shadow/jsonarray with size = 1129

  2023-12-08T11:05:59.545405Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/device_shadow/jsonarray with size = 1125

  2023-12-08T11:05:59.545429Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/device_shadow/jsonarray with size = 1128

  2023-12-08T11:05:59.545447Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/device_shadow/jsonarray with size = 1130

  2023-12-08T11:05:59.545465Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/device_shadow/jsonarray with size = 1129

  2023-12-08T11:05:59.545481Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/device_shadow/jsonarray with size = 1136

  2023-12-08T11:05:59.545502Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/device_shadow/jsonarray with size = 1134

  2023-12-08T11:05:59.545518Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/device_shadow/jsonarray with size = 1135

  2023-12-08T11:05:59.545537Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/device_shadow/jsonarray with size = 1211

  2023-12-08T11:05:59.545578Z  INFO uplink::base::serializer:              slow: batches = 71  errors = 0 lost = 19 disk_files = 3   disk_utilized = 81.22 kB write_memory = 268.86 kB read_memory = 0 B

  2023-12-08T11:05:59.545607Z  INFO uplink::base::serializer:           catchup: batches = 34  errors = 0 lost = 0 disk_files = 0   disk_utilized = 0 B write_memory = 3.38 kB read_memory = 14.46 kB

  2023-12-08T11:05:59.545629Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/device_shadow/jsonarray with size = 1135

  2023-12-08T11:05:59.545653Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/device_shadow/jsonarray with size = 1130

  2023-12-08T11:05:59.545798Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/device_shadow/jsonarray with size = 1136

  2023-12-08T11:05:59.545832Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/device_shadow/jsonarray with size = 1136

  2023-12-08T11:05:59.545864Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/device_shadow/jsonarray with size = 1135

  2023-12-08T11:05:59.545882Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/device_shadow/jsonarray with size = 1137

  2023-12-08T11:05:59.545897Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/device_shadow/jsonarray with size = 1137

  2023-12-08T11:05:59.545924Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/device_shadow/jsonarray with size = 1130

  2023-12-08T11:05:59.545941Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/device_shadow/jsonarray with size = 1134

  2023-12-08T11:05:59.545958Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/device_shadow/jsonarray with size = 1214

  2023-12-08T11:05:59.545982Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/device_shadow/jsonarray with size = 1137

  2023-12-08T11:05:59.545998Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/device_shadow/jsonarray with size = 1131

  2023-12-08T11:05:59.546012Z DEBUG uplink::base::serializer: Completed reading from: /tenants/demo/devices/1001/events/device_shadow/jsonarray

  2023-12-08T11:05:59.546022Z DEBUG uplink::base::serializer: Reading from: /tenants/demo/devices/1001/events/uplink_disk_stats/jsonarray

  2023-12-08T11:05:59.546037Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/uplink_disk_stats/jsonarray with size = 1035

  2023-12-08T11:05:59.546052Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/uplink_disk_stats/jsonarray with size = 1042

  2023-12-08T11:05:59.546069Z DEBUG uplink::base::serializer: Completed reading from: /tenants/demo/devices/1001/events/uplink_disk_stats/jsonarray

  2023-12-08T11:05:59.546079Z DEBUG uplink::base::serializer: Reading from: /tenants/demo/devices/1001/events/uplink_system_stats/jsonarray

  2023-12-08T11:05:59.546092Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/uplink_system_stats/jsonarray with size = 513

  2023-12-08T11:05:59.546112Z DEBUG uplink::base::serializer: publishing on /tenants/demo/devices/1001/events/uplink_system_stats/jsonarray with size = 515

  2023-12-08T11:05:59.546126Z DEBUG uplink::base::serializer: Completed reading from: /tenants/demo/devices/1001/events/uplink_system_stats/jsonarray

  2023-12-08T11:05:59.546139Z  INFO uplink::base::serializer: Switching to normal mode!!

  2023-12-08T11:05:59.547253Z  INFO uplink::base::serializer:            normal: batches = 16  errors = 0 lost = 0 disk_files = 0   disk_utilized = 0 B write_memory = 0 B read_memory = 0 B
```

```
Every 1.0s: tree /var/tmp/persistence                                                                               dfe5d0bd3b94: Fri Dec  8 11:04:18 2023

/var/tmp/persistence
└── imu
    ├── backup@2
    ├── backup@3
    └── backup@4

1 directory, 3 files
```