### PR TITLE
refactor: `CtrlTx` to send control messages to various uplink components

### DIFF
--- a/uplink/src/base/bridge/data_lane.rs
+++ b/uplink/src/base/bridge/data_lane.rs
@@ -42,8 +42,14 @@ impl DataBridge {
         Self { data_tx, data_rx, config, streams, ctrl_rx, ctrl_tx }
     }
 
-    pub fn tx(&self) -> DataBridgeTx {
-        DataBridgeTx { data_tx: self.data_tx.clone(), shutdown_handle: self.ctrl_tx.clone() }
+    /// Handle to send data points from source application
+    pub fn data_tx(&self) -> DataTx {
+        DataTx { inner: self.data_tx.clone() }
+    }
+
+    /// Handle to send data lane control message
+    pub fn ctrl_tx(&self) -> CtrlTx {
+        CtrlTx { inner: self.ctrl_tx.clone() }
     }
 
     pub async fn start(&mut self) -> Result<(), Error> {
@@ -79,23 +85,31 @@ impl DataBridge {
     }
 }
 
+/// Handle for apps to send action status to bridge
 #[derive(Debug, Clone)]
-pub struct DataBridgeTx {
-    // Handle for apps to send action status to bridge
-    pub(crate) data_tx: Sender<Payload>,
-    pub(crate) shutdown_handle: Sender<DataBridgeShutdown>,
+pub struct DataTx {
+    pub(crate) inner: Sender<Payload>,
 }
 
-impl DataBridgeTx {
+impl DataTx {
     pub async fn send_payload(&self, payload: Payload) {
-        self.data_tx.send_async(payload).await.unwrap()
+        self.inner.send_async(payload).await.unwrap()
     }
 
     pub fn send_payload_sync(&self, payload: Payload) {
-        self.data_tx.send(payload).unwrap()
+        self.inner.send(payload).unwrap()
     }
+}
 
+/// Handle to send control messages to data lane
+#[derive(Debug, Clone)]
+pub struct CtrlTx {
+    pub(crate) inner: Sender<DataBridgeShutdown>,
+}
+
+impl CtrlTx {
+    /// Triggers shutdown of `bridge::data_lane`
     pub async fn trigger_shutdown(&self) {
-        self.shutdown_handle.send_async(DataBridgeShutdown).await.unwrap()
+        self.inner.send_async(DataBridgeShutdown).await.unwrap()
     }
 }

--- a/uplink/src/collector/downloader.rs
+++ b/uplink/src/collector/downloader.rs
@@ -414,7 +414,7 @@ mod test {
 
     use super::*;
     use crate::base::{
-        bridge::{ActionsBridgeTx, DataBridgeTx},
+        bridge::{DataTx, StatusTx},
         ActionRoute, DownloaderConfig, MqttConfig,
     };
 
@@ -433,14 +433,12 @@ mod test {
     }
 
     fn create_bridge() -> (BridgeTx, Receiver<ActionResponse>) {
-        let (data_tx, _) = flume::bounded(2);
-        let (status_tx, status_rx) = flume::bounded(2);
-        let (shutdown_handle, _) = bounded(1);
-        let data = DataBridgeTx { data_tx, shutdown_handle };
-        let (shutdown_handle, _) = bounded(1);
-        let actions = ActionsBridgeTx { status_tx, shutdown_handle };
+        let (inner, _) = bounded(2);
+        let data_tx = DataTx { inner };
+        let (inner, status_rx) = bounded(2);
+        let status_tx = StatusTx { inner };
 
-        (BridgeTx { data, actions }, status_rx)
+        (BridgeTx { data_tx, status_tx }, status_rx)
     }
 
     #[test]

--- a/uplink/src/collector/script_runner.rs
+++ b/uplink/src/collector/script_runner.rs
@@ -150,21 +150,19 @@ mod tests {
 
     use super::*;
     use crate::{
-        base::bridge::{ActionsBridgeTx, DataBridgeTx},
+        base::bridge::{DataTx, StatusTx},
         Action,
     };
 
     use flume::bounded;
 
     fn create_bridge() -> (BridgeTx, Receiver<ActionResponse>) {
-        let (data_tx, _) = flume::bounded(2);
-        let (status_tx, status_rx) = flume::bounded(2);
-        let (shutdown_handle, _) = bounded(1);
-        let data = DataBridgeTx { data_tx, shutdown_handle };
-        let (shutdown_handle, _) = bounded(1);
-        let actions = ActionsBridgeTx { status_tx, shutdown_handle };
+        let (inner, _) = flume::bounded(2);
+        let data_tx = DataTx { inner };
+        let (inner, status_rx) = flume::bounded(2);
+        let status_tx = StatusTx { inner };
 
-        (BridgeTx { data, actions }, status_rx)
+        (BridgeTx { data_tx, status_tx }, status_rx)
     }
 
     #[test]

--- a/uplink/src/console.rs
+++ b/uplink/src/console.rs
@@ -1,6 +1,6 @@
 use axum::{extract::State, http::StatusCode, response::IntoResponse, routing::post, Router};
 use log::info;
-use uplink::base::bridge::CtrlTx;
+use uplink::base::CtrlTx;
 
 use crate::ReloadHandle;
 

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -407,7 +407,7 @@ impl Uplink {
     }
 
     pub fn spawn_builtins(&mut self, bridge: &mut Bridge) -> Result<(), Error> {
-        let bridge_tx = bridge.tx();
+        let bridge_tx = bridge.bridge_tx();
 
         let route =
             ActionRoute { name: "launch_shell".to_owned(), timeout: Duration::from_secs(10) };

--- a/uplink/src/main.rs
+++ b/uplink/src/main.rs
@@ -128,7 +128,6 @@ fn main() -> Result<(), Error> {
     uplink.spawn_builtins(&mut bridge)?;
 
     let bridge_tx = bridge.bridge_tx();
-    let ctrl_tx = bridge.ctrl_tx();
 
     let mut tcpapps = vec![];
     for (app, cfg) in config.tcpapps.clone() {
@@ -152,7 +151,7 @@ fn main() -> Result<(), Error> {
         route_rx
     });
 
-    uplink.spawn(bridge)?;
+    let ctrl_tx = uplink.spawn(bridge)?;
 
     if let Some(config) = config.simulator.clone() {
         spawn_named_thread("Simulator", || {


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->

### Why?
<!--Detailed description of why the changes had to be made-->
Will be used to send control messages to the various uplink components, currently this is limited to shutdown only

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->