### PR TITLE
feat: enable simulation on non-demo tenants

### DIFF
--- a/simulator.sh
+++ b/simulator.sh
@@ -83,7 +83,7 @@ download_auth_config() {
     echo "Downloading config: $url"
     mkdir -p devices
     curl --location $url \
-        --header 'x-bytebeam-tenant: demo' \
+        --header "x-bytebeam-tenant: $BYTEBEAM_TENANT_ID" \
         --header "x-bytebeam-api-key: $BYTEBEAM_API_KEY" > devices/device_$id.json
 }
 


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
Fetching tenant ID from env variable - BYTEBEAM_TENANT_ID

### Why?
Need to run simulator on non-demo tenanst for testing purpose

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->