### PR TITLE
feat: track stream-wise compression stats in serializer

### DIFF
--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -173,7 +173,8 @@ pub struct InstallerConfig {
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct StreamMetricsConfig {
     pub enabled: bool,
-    pub topic: String,
+    pub bridge_topic: String,
+    pub serializer_topic: String,
     pub blacklist: Vec<String>,
     #[serde_as(as = "DurationSeconds<u64>")]
     pub timeout: Duration,

--- a/uplink/src/base/serializer/metrics.rs
+++ b/uplink/src/base/serializer/metrics.rs
@@ -1,4 +1,7 @@
+use std::time::Duration;
+
 use serde::Serialize;
+use serde_with::{serde_as, DurationSeconds};
 
 use crate::base::clock;
 
@@ -100,6 +103,7 @@ impl Metrics {
     }
 }
 
+#[serde_as]
 #[derive(Debug, Serialize, Clone)]
 pub struct StreamMetrics {
     pub timestamp: u128,
@@ -107,6 +111,18 @@ pub struct StreamMetrics {
     pub stream: String,
     pub serialized_data_size: usize,
     pub compressed_data_size: usize,
+    #[serde(skip)]
+    pub serializations: u32,
+    #[serde_as(as = "DurationSeconds<f64>")]
+    pub total_serialization_time: Duration,
+    #[serde_as(as = "DurationSeconds<f64>")]
+    pub avg_serialization_time: Duration,
+    #[serde(skip)]
+    pub compressions: u32,
+    #[serde_as(as = "DurationSeconds<f64>")]
+    pub total_compression_time: Duration,
+    #[serde_as(as = "DurationSeconds<f64>")]
+    pub avg_compression_time: Duration,
 }
 
 impl StreamMetrics {
@@ -117,12 +133,39 @@ impl StreamMetrics {
             sequence: 1,
             serialized_data_size: 0,
             compressed_data_size: 0,
+            serializations: 0,
+            total_serialization_time: Duration::ZERO,
+            avg_serialization_time: Duration::ZERO,
+            compressions: 0,
+            total_compression_time: Duration::ZERO,
+            avg_compression_time: Duration::ZERO,
         }
     }
 
     pub fn add_serialized_sizes(&mut self, data_size: usize, compressed_data_size: Option<usize>) {
         self.serialized_data_size += data_size;
         self.compressed_data_size += compressed_data_size.unwrap_or(data_size);
+    }
+
+    pub fn add_serialization_time(&mut self, serialization_time: Duration) {
+        self.serializations += 1;
+        self.total_serialization_time += serialization_time;
+    }
+
+    pub fn add_compression_time(&mut self, compression_time: Duration) {
+        self.compressions += 1;
+        self.total_compression_time += compression_time;
+    }
+
+    // Should be called before serializing metrics to ensure averages are computed.
+    // Averages aren't calculated for ever `add_*` call to save on costs.
+    pub fn prepare_snapshot(&mut self) {
+        self.avg_serialization_time = self
+            .total_serialization_time
+            .checked_div(self.serializations)
+            .unwrap_or(Duration::ZERO);
+        self.avg_compression_time =
+            self.total_compression_time.checked_div(self.compressions).unwrap_or(Duration::ZERO);
     }
 
     pub fn prepare_next(&mut self) {

--- a/uplink/src/base/serializer/metrics.rs
+++ b/uplink/src/base/serializer/metrics.rs
@@ -177,6 +177,6 @@ impl StreamMetrics {
 }
 
 pub enum SerializerMetrics {
-    Main(Metrics),
-    Stream(StreamMetrics),
+    Main(Box<Metrics>),
+    Stream(Box<StreamMetrics>),
 }

--- a/uplink/src/base/serializer/mod.rs
+++ b/uplink/src/base/serializer/mod.rs
@@ -755,13 +755,13 @@ fn save_and_prepare_next_metrics(
     metrics.set_disk_files(file_count);
     metrics.set_disk_utilized(disk_utilized);
 
-    let m = metrics.clone();
+    let m = Box::new(metrics.clone());
     pending.push_back(SerializerMetrics::Main(m));
     metrics.prepare_next();
 
     for metrics in stream_metrics.values_mut() {
         metrics.prepare_snapshot();
-        let m = metrics.clone();
+        let m = Box::new(metrics.clone());
         pending.push_back(SerializerMetrics::Stream(m));
         metrics.prepare_next();
     }
@@ -841,7 +841,7 @@ fn check_and_flush_metrics(
             convert(metrics.read_memory as f64),
         );
 
-        metrics_tx.try_send(SerializerMetrics::Main(metrics.clone()))?;
+        metrics_tx.try_send(SerializerMetrics::Main(Box::new(metrics.clone())))?;
         metrics.prepare_next();
     }
 

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -112,7 +112,8 @@ pub mod config {
 
     [stream_metrics]
     enabled = false
-    topic = "/tenants/{tenant_id}/devices/{device_id}/events/uplink_stream_metrics/jsonarray"
+    bridge_topic = "/tenants/{tenant_id}/devices/{device_id}/events/uplink_stream_metrics/jsonarray"
+    serializer_topic = "/tenants/{tenant_id}/devices/{device_id}/events/uplink_serializer_stream_metrics/jsonarray"
     blacklist = []
     timeout = 10
 
@@ -172,7 +173,12 @@ pub mod config {
         }
 
         replace_topic_placeholders(&mut config.action_status.topic, tenant_id, device_id);
-        replace_topic_placeholders(&mut config.stream_metrics.topic, tenant_id, device_id);
+        replace_topic_placeholders(&mut config.stream_metrics.bridge_topic, tenant_id, device_id);
+        replace_topic_placeholders(
+            &mut config.stream_metrics.serializer_topic,
+            tenant_id,
+            device_id,
+        );
         replace_topic_placeholders(&mut config.serializer_metrics.topic, tenant_id, device_id);
         replace_topic_placeholders(&mut config.mqtt_metrics.topic, tenant_id, device_id);
 


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->
- Collect and forward stream wise stats about compression sizes(before and after)(on a new stream)
- Configuration of the stream wise stats topic is now with `bridge_topic` and `serializer_topic` as these two modules now do the forwarding of stats on a stream wise basis, instead of being restricted to just the bridge.
- `DEFAULT_CONFIG` updated to reflect this. 

### Why?
<!--Detailed description of why the changes had to be made-->
Allows customers to track data savings through compression. This only tracks data size in bytes, we could also track the time it takes to serialize/compress as that could also provide important information.

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
Tested against simulator with one stream compression turned on:
```
 1-09T19:04:06.379085Z  INFO uplink::base::serializer:               imu: serialized_data_size = 10.84 kB compressed_data_size = 7.96 kB avg_serialization_time = 62us avg_compression_time = 106us

  2024-01-09T19:04:06.379093Z  INFO uplink::base::serializer: uplink_system_stats: serialized_data_size = 0 B compressed_data_size = 0 B avg_serialization_time = 10us avg_compression_time = 0us

  2024-01-09T19:04:06.379102Z  INFO uplink::base::serializer:     device_shadow: serialized_data_size = 1.14 kB compressed_data_size = 1.14 kB avg_serialization_time = 32us avg_compression_time = 0us

  2024-01-09T19:04:06.379110Z  INFO uplink::base::serializer:             motor: serialized_data_size = 24.73 kB compressed_data_size = 24.73 kB avg_serialization_time = 208us avg_compression_time = 0us

  2024-01-09T19:04:06.379117Z  INFO uplink::base::serializer:  peripheral_state: serialized_data_size = 0 B compressed_data_size = 0 B avg_serialization_time = 161us avg_compression_time = 0us

  2024-01-09T19:04:06.379125Z  INFO uplink::base::serializer:               bms: serialized_data_size = 133.51 kB compressed_data_size = 133.51 kB avg_serialization_time = 1396us avg_compression_time = 0us
```