### PR TITLE
feat: Track serialization and compression times in nanos

### DIFF
--- a/uplink/src/base/serializer/metrics.rs
+++ b/uplink/src/base/serializer/metrics.rs
@@ -160,8 +160,12 @@ impl StreamMetrics {
     // Should be called before serializing metrics to ensure averages are computed.
     // Averages aren't calculated for ever `add_*` call to save on costs.
     pub fn prepare_snapshot(&mut self) {
-        self.avg_serialization_time = self.total_serialization_time / self.serializations;
-        self.avg_compression_time = self.total_compression_time / self.compressions;
+        self.avg_serialization_time = self
+            .total_serialization_time
+            .checked_div(self.serializations)
+            .unwrap_or(Duration::ZERO);
+        self.avg_compression_time =
+            self.total_compression_time.checked_div(self.compressions).unwrap_or(Duration::ZERO);
     }
 
     pub fn prepare_next(&mut self) {

--- a/uplink/src/base/serializer/metrics.rs
+++ b/uplink/src/base/serializer/metrics.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use serde::Serialize;
-use serde_with::{serde_as, DurationNanoSeconds};
+use serde_with::{serde_as, DurationSeconds};
 
 use crate::base::clock;
 
@@ -113,15 +113,15 @@ pub struct StreamMetrics {
     pub compressed_data_size: usize,
     #[serde(skip)]
     pub serializations: u32,
-    #[serde_as(as = "DurationNanoSeconds<u64>")]
+    #[serde_as(as = "DurationSeconds<f64>")]
     pub total_serialization_time: Duration,
-    #[serde_as(as = "DurationNanoSeconds<u64>")]
+    #[serde_as(as = "DurationSeconds<f64>")]
     pub avg_serialization_time: Duration,
     #[serde(skip)]
     pub compressions: u32,
-    #[serde_as(as = "DurationNanoSeconds<u64>")]
+    #[serde_as(as = "DurationSeconds<f64>")]
     pub total_compression_time: Duration,
-    #[serde_as(as = "DurationNanoSeconds<u64>")]
+    #[serde_as(as = "DurationSeconds<f64>")]
     pub avg_compression_time: Duration,
 }
 


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->

### Why?
<!--Detailed description of why the changes had to be made-->\
Improves observability into the serialization stage of uplink, helps customers determine if compression is helpful on a particular stream or not when paired along with #320.

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
```
  1-09T19:04:06.379085Z  INFO uplink::base::serializer:               imu: serialized_data_size = 10.84 kB compressed_data_size = 7.96 kB avg_serialization_time = 62us avg_compression_time = 106us

  2024-01-09T19:04:06.379102Z  INFO uplink::base::serializer:     device_shadow: serialized_data_size = 1.14 kB compressed_data_size = 1.14 kB avg_serialization_time = 32us avg_compression_time = 0us

  2024-01-09T19:04:06.379110Z  INFO uplink::base::serializer:             motor: serialized_data_size = 24.73 kB compressed_data_size = 24.73 kB avg_serialization_time = 208us avg_compression_time = 0us

  2024-01-09T19:04:06.379117Z  INFO uplink::base::serializer:  peripheral_state: serialized_data_size = 0 B compressed_data_size = 0 B avg_serialization_time = 161us avg_compression_time = 0us

  2024-01-09T19:04:06.379125Z  INFO uplink::base::serializer:               bms: serialized_data_size = 133.51 kB compressed_data_size = 133.51 kB avg_serialization_time = 1396us avg_compression_time = 0us
```