### PR TITLE
fix: calculate network for concerned period

### DIFF
--- a/uplink/src/collector/systemstats.rs
+++ b/uplink/src/collector/systemstats.rs
@@ -141,7 +141,7 @@ impl Network {
     /// Update metrics values for network usage over time
     fn update(&mut self, data: &NetworkData, timestamp: u64, sequence: u32) {
         let update_period = self.timer.elapsed().as_secs_f64();
-        // TODO: check if these calculations are correct
+        self.timer = Instant::now();
         self.incoming_data_rate = data.received() as f64 / update_period;
         self.outgoing_data_rate = data.transmitted() as f64 / update_period;
         self.timestamp = timestamp;
@@ -473,6 +473,7 @@ impl StatCollector {
         let mut sys = sysinfo::System::new();
         sys.refresh_disks_list();
         sys.refresh_networks_list();
+        sys.refresh_networks();
         sys.refresh_memory();
         sys.refresh_cpu();
         sys.refresh_components();
@@ -571,12 +572,12 @@ impl StatCollector {
 
     // Refresh network byte rate stats
     fn update_network_stats(&mut self) -> Result<(), Error> {
-        self.sys.refresh_networks();
         let timestamp = clock() as u64;
         for (net_name, net_data) in self.sys.networks() {
             let payload = self.networks.push(net_name.to_owned(), net_data, timestamp);
             self.bridge_tx.send_payload_sync(payload);
         }
+        self.sys.refresh_networks();
 
         Ok(())
     }

--- a/uplink/src/collector/systemstats.rs
+++ b/uplink/src/collector/systemstats.rs
@@ -142,8 +142,8 @@ impl Network {
     fn update(&mut self, data: &NetworkData, timestamp: u64, sequence: u32) {
         let update_period = self.timer.elapsed().as_secs_f64();
         // TODO: check if these calculations are correct
-        self.incoming_data_rate = data.total_received() as f64 / update_period;
-        self.outgoing_data_rate = data.total_transmitted() as f64 / update_period;
+        self.incoming_data_rate = data.received() as f64 / update_period;
+        self.outgoing_data_rate = data.transmitted() as f64 / update_period;
         self.timestamp = timestamp;
         self.sequence = sequence;
     }


### PR DESCRIPTION
Fixes [comment](https://github.com/bytebeamio/uplink/commit/3a2374c46f4166b307bc801e679c1e1fdb646883#commitcomment-131710329)

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->

### Why?
<!--Detailed description of why the changes had to be made-->
Calculations of network write/read bitrates was the averaged from startup value instead of being associated with only the previous few seconds, which changes with this fix.

1. https://docs.rs/sysinfo/latest/sysinfo/struct.Networks.html#method.refresh_list
2. https://docs.rs/sysinfo/latest/sysinfo/struct.Networks.html#method.refresh
3. https://docs.rs/sysinfo/latest/sysinfo/struct.NetworkData.html#method.total_received
4. https://docs.rs/sysinfo/latest/sysinfo/struct.NetworkData.html#method.received

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->