### PR TITLE
fix: need not retry HTTP status errors

### DIFF
--- a/uplink/src/collector/downloader.rs
+++ b/uplink/src/collector/downloader.rs
@@ -185,7 +185,7 @@ impl FileDownloader {
         loop {
             match self.download(req, &mut download).await {
                 Ok(_) => break,
-                Err(Error::Reqwest(e)) => error!("Download failed: {e}"),
+                Err(Error::Reqwest(e)) if !e.is_status() => error!("Download failed: {e}"),
                 Err(e) => return Err(e),
             }
             tokio::time::sleep(Duration::from_secs(1)).await;


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->

### Why?
<!--Detailed description of why the changes had to be made-->

Currently uplink retries all HTTP errors, even 4XX/5XX, with this we are forgoing this and expecting uplink to only retry a download when it fails due to issues like a disconnection

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->