### PR TITLE
feat: restart download post reboot

### DIFF
--- a/uplink/src/base/mod.rs
+++ b/uplink/src/base/mod.rs
@@ -6,6 +6,7 @@ use tokio::join;
 use self::bridge::{ActionsLaneCtrlTx, DataLaneCtrlTx};
 use self::mqtt::CtrlTx as MqttCtrlTx;
 use self::serializer::CtrlTx as SerializerCtrlTx;
+use crate::collector::downloader::CtrlTx as DownloaderCtrlTx;
 
 pub mod actions;
 pub mod bridge;
@@ -26,6 +27,7 @@ pub struct CtrlTx {
     pub data_lane: DataLaneCtrlTx,
     pub mqtt: MqttCtrlTx,
     pub serializer: SerializerCtrlTx,
+    pub downloader: DownloaderCtrlTx,
 }
 
 impl CtrlTx {
@@ -34,7 +36,8 @@ impl CtrlTx {
             self.actions_lane.trigger_shutdown(),
             self.data_lane.trigger_shutdown(),
             self.mqtt.trigger_shutdown(),
-            self.serializer.trigger_shutdown()
+            self.serializer.trigger_shutdown(),
+            self.downloader.trigger_shutdown()
         );
     }
 }

--- a/uplink/src/collector/downloader.rs
+++ b/uplink/src/collector/downloader.rs
@@ -188,7 +188,8 @@ impl FileDownloader {
                 return;
             }
         };
-
+        self.action_id = state.current.action.action_id.clone();
+        
         if let Err(e) = self.download(state).await {
             self.forward_error(e).await;
         }

--- a/uplink/src/collector/downloader.rs
+++ b/uplink/src/collector/downloader.rs
@@ -229,6 +229,15 @@ impl FileDownloader {
             }
         }
 
+        state.current.meta.verify_checksum()?;
+        info!("Firmware downloaded successfully");
+
+        let mut action = state.current.action;
+        action.payload = serde_json::to_string(&state.current.meta)?;
+        let status = ActionResponse::done(&self.action_id, "Downloaded", Some(action))
+            .set_sequence(self.sequence());
+        self.bridge_tx.send_action_response(status).await;
+
         Ok(())
     }
 
@@ -261,15 +270,6 @@ impl FileDownloader {
                 }
             }
         }
-
-        state.current.meta.verify_checksum()?;
-        info!("Firmware downloaded successfully");
-
-        let mut action = state.current.action.clone();
-        action.payload = serde_json::to_string(&state.current.meta)?;
-        let status = ActionResponse::done(&self.action_id, "Downloaded", Some(action))
-            .set_sequence(self.sequence());
-        self.bridge_tx.send_action_response(status).await;
 
         Ok(())
     }


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->
Reorganize the code to allow for handling restart events

### Why?
<!--Detailed description of why the changes had to be made-->
To handle restart events performed between a download action which would otherwise have lead to a download being lost and action being timedout.

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
Kill uplink mid download, restart later, observe logs
![Screenshot from 2024-03-27 13-52-28](https://github.com/bytebeamio/uplink/assets/18750864/461b52f6-12f2-4534-8645-ae8259cfd975)

