### PR TITLE
feat: action cancellation

### DIFF
--- a/configs/config.toml
+++ b/configs/config.toml
@@ -9,7 +9,7 @@ action_redirections = { "firmware_update" = "install_update", "send_file" = "loa
 
 # Script runner allows users to trigger an action that will run an already downloaded
 # file as described by the download_path field of the JSON payload of a download action.
-script_runner = [{ name = "run_script" }]
+script_runner = [{ name = "run_script", timeout = 10 }]
 
 # Location on disk for persisted streams to write backlogs into, also used to write
 persistence_path = "/tmp/uplink/"
@@ -141,7 +141,7 @@ priority = 255
 # - actions: List of actions names that can trigger the downloader, with configurable timeouts
 # - path: Location in fs where the files are downloaded into
 [downloader]
-actions = [{ name = "update_firmware" }, { name = "send_file" }, { name = "send_script" }]
+actions = [{ name = "update_firmware" }, { name = "send_file", timeout = 10 }, { name = "send_script" }]
 path = "/var/tmp/ota-file"
 
 # Configurations associated with the system stats module of uplink, if enabled

--- a/uplink/src/base/actions.rs
+++ b/uplink/src/base/actions.rs
@@ -1,5 +1,4 @@
 use serde::{Deserialize, Serialize};
-use tokio::time::Instant;
 
 use crate::{Payload, Point};
 
@@ -17,9 +16,6 @@ pub struct Action {
     pub name: String,
     // action payload. json. can be args/payload. depends on the invoked command
     pub payload: String,
-    // Instant at which action must be timedout
-    #[serde(skip)]
-    pub deadline: Option<Instant>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -115,7 +111,7 @@ impl Point for ActionResponse {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Cancellation {
     pub action_id: String,
     pub name: String,

--- a/uplink/src/base/actions.rs
+++ b/uplink/src/base/actions.rs
@@ -114,3 +114,9 @@ impl Point for ActionResponse {
         self.timestamp
     }
 }
+
+#[derive(Debug, Deserialize)]
+pub struct Cancellation {
+    pub action_id: String,
+    pub name: String,
+}

--- a/uplink/src/base/actions.rs
+++ b/uplink/src/base/actions.rs
@@ -114,5 +114,6 @@ impl Point for ActionResponse {
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Cancellation {
     pub action_id: String,
-    pub name: String,
+    #[serde(rename = "name")]
+    pub action_name: String,
 }

--- a/uplink/src/base/bridge/actions_lane.rs
+++ b/uplink/src/base/bridge/actions_lane.rs
@@ -354,7 +354,12 @@ impl ActionsBridge {
         self.streams.forward(response.clone()).await;
 
         if response.is_completed() || response.is_failed() {
-            self.clear_current_action();
+            if let Some(CurrentAction { cancelled_by: Some(cancel_action), .. }) =
+                self.current_action.take()
+            {
+                let response = ActionResponse::success(&cancel_action.action_id);
+                self.streams.forward(response).await;
+            }
             return;
         }
 

--- a/uplink/src/base/bridge/actions_lane.rs
+++ b/uplink/src/base/bridge/actions_lane.rs
@@ -157,7 +157,7 @@ impl ActionsBridge {
                 action = self.actions_rx.recv_async() => {
                     let action = action?;
 
-                    if action.name == "cancel-action" && self.current_action.is_some() {
+                    if action.name == "cancel_action" && self.current_action.is_some() {
                         self.handle_cancellation(action).await?;
                         continue
                     }
@@ -194,7 +194,7 @@ impl ActionsBridge {
                     let payload = serde_json::to_string(&cancellation)?;
                     let cancel_action = Action {
                         action_id: "timeout".to_owned(), // Describes cause of action cancellation. NOTE: Action handler shouldn't expect an integer.
-                        name: "cancel-action".to_owned(),
+                        name: "cancel_action".to_owned(),
                         payload,
                     };
                     if route.try_send(cancel_action).is_err() {
@@ -486,7 +486,7 @@ struct CurrentAction {
     pub id: String,
     pub action: Action,
     pub timeout: Pin<Box<Sleep>>,
-    // cancel-action request
+    // cancel_action request
     pub cancelled_by: Option<Action>,
 }
 

--- a/uplink/src/base/bridge/actions_lane.rs
+++ b/uplink/src/base/bridge/actions_lane.rs
@@ -540,7 +540,7 @@ impl CtrlTx {
 
 #[cfg(test)]
 mod tests {
-    use tokio::runtime::Runtime;
+    use tokio::{runtime::Runtime, select};
 
     use crate::config::{StreamConfig, StreamMetricsConfig};
 

--- a/uplink/src/base/bridge/actions_lane.rs
+++ b/uplink/src/base/bridge/actions_lane.rs
@@ -397,10 +397,12 @@ impl ActionsBridge {
             }
         };
 
-        if *inflight_action.action.action_id != response.action_id {
+        if !inflight_action.is_executing(&response.action_id)
+            && !inflight_action.is_cancelled_by(&response.action_id)
+        {
             error!(
-                "response id({}) != active action({})",
-                response.action_id, inflight_action.action.action_id
+                "response id({}) != active action({}); response = {:?}",
+                response.action_id, inflight_action.action.action_id, response
             );
             return;
         }
@@ -531,6 +533,14 @@ impl CurrentAction {
             timeout: Box::pin(time::sleep(json.timeout)),
             cancelled_by: None,
         })
+    }
+
+    fn is_executing(&self, action_id: &str) -> bool {
+        self.action.action_id == action_id
+    }
+
+    fn is_cancelled_by(&self, action_id: &str) -> bool {
+        self.cancelled_by.as_ref().is_some_and(|id| id == action_id)
     }
 }
 

--- a/uplink/src/base/bridge/actions_lane.rs
+++ b/uplink/src/base/bridge/actions_lane.rs
@@ -368,6 +368,11 @@ impl ActionsBridge {
     }
 
     async fn forward_action_response(&mut self, mut response: ActionResponse) {
+        // Ignore responses to timeout action
+        if response.action_id == "timeout" {
+            return;
+        }
+
         if self.parallel_actions.contains(&response.action_id) {
             self.forward_parallel_action_response(response).await;
 

--- a/uplink/src/base/bridge/actions_lane.rs
+++ b/uplink/src/base/bridge/actions_lane.rs
@@ -428,7 +428,7 @@ impl ActionsBridge {
             }
 
             match self.redirect_action(&mut action).await {
-                Ok(_) => return,
+                Ok(_) => (),
                 Err(Error::NoRoute(_)) => {
                     // NOTE: send success reponse for actions that don't have redirections configured
                     warn!("Action redirection is not configured for: {:?}", action);

--- a/uplink/src/base/bridge/actions_lane.rs
+++ b/uplink/src/base/bridge/actions_lane.rs
@@ -421,7 +421,7 @@ impl ActionsBridge {
         // Forward actions included in the config to the appropriate forward route, when
         // they have reached 100% progress but haven't been marked as "Completed"/"Finished".
         if response.is_done() {
-            let mut action = inflight_action.action.clone();
+            let mut action = self.current_action.take().unwrap().action;
 
             if let Some(a) = response.done_response.take() {
                 action = a;
@@ -449,12 +449,8 @@ impl ActionsBridge {
                     self.forward_action_error(&action.action_id, Error::Cancelled(cancel_action))
                         .await;
                 }
-                Err(e) => {
-                    self.forward_action_error(&action.action_id, e).await;
-                }
+                Err(e) => self.forward_action_error(&action.action_id, e).await,
             }
-
-            self.clear_current_action();
         }
     }
 

--- a/uplink/src/base/bridge/actions_lane.rs
+++ b/uplink/src/base/bridge/actions_lane.rs
@@ -259,7 +259,7 @@ impl ActionsBridge {
         let error = match self.try_route_action(action.clone()) {
             Ok(_) => {
                 let response = ActionResponse::progress(&action_id, "Received", 0);
-                self.forward_action_response(response).await;
+                self.streams.forward(response).await;
                 return;
             }
             Err(e) => e,
@@ -322,7 +322,7 @@ impl ActionsBridge {
             }
         }
         let response = ActionResponse::progress(&action_id, "Received", 0);
-        self.forward_action_response(response).await;
+        self.streams.forward(response).await;
 
         Ok(())
     }

--- a/uplink/src/base/bridge/actions_lane.rs
+++ b/uplink/src/base/bridge/actions_lane.rs
@@ -285,13 +285,17 @@ impl ActionsBridge {
     /// else marks the current action as cancelled and avoids further redirections
     async fn handle_cancellation(&mut self, action: Action) -> Result<(), Error> {
         let cancellation: Cancellation = serde_json::from_str(&action.payload)?;
-        if cancellation.action_id != self.current_action.as_ref().unwrap().id {
+        let current_action = self
+            .current_action
+            .as_ref()
+            .expect("Actions that are not executing can't be cancelled");
+        if cancellation.action_id != current_action.id {
             warn!("Unexpected cancellation: {cancellation:?}");
             self.forward_action_error(action, Error::UnexpectedCancellation).await;
             return Ok(());
         }
 
-        if cancellation.name != self.current_action.as_ref().unwrap().action.name {
+        if cancellation.name != current_action.action.name {
             warn!("Unexpected cancellation: {cancellation:?}");
             self.forward_action_error(action, Error::CorruptedCancellation).await;
             return Ok(());

--- a/uplink/src/base/bridge/actions_lane.rs
+++ b/uplink/src/base/bridge/actions_lane.rs
@@ -299,7 +299,7 @@ impl ActionsBridge {
 
         let route = self
             .action_routes
-            .get(&action.name)
+            .get(&cancellation.name)
             .expect("Action shouldn't be in execution if it can't be routed!");
 
         // Ensure that action redirections for the action are turned off,

--- a/uplink/src/collector/downloader.rs
+++ b/uplink/src/collector/downloader.rs
@@ -56,7 +56,7 @@ use reqwest::{Certificate, Client, ClientBuilder, Error as ReqwestError, Identit
 use rsa::sha2::{Digest, Sha256};
 use serde::{Deserialize, Serialize};
 use tokio::select;
-use tokio::time::{Instant, sleep};
+use tokio::time::{sleep, Instant};
 
 use std::fs::{metadata, read, remove_dir_all, remove_file, write, File};
 use std::io;
@@ -460,7 +460,8 @@ impl DownloadState {
         let current: CurrentDownload = serde_json::from_slice(&read)?;
 
         // Unwrap is ok here as it is expected to be set for actions once received
-        let file = File::options().append(true).open(current.meta.download_path.as_ref().unwrap())?;
+        let file =
+            File::options().append(true).open(current.meta.download_path.as_ref().unwrap())?;
         let bytes_written = file.metadata()?.len() as usize;
 
         remove_file(path)?;

--- a/uplink/src/collector/downloader.rs
+++ b/uplink/src/collector/downloader.rs
@@ -94,6 +94,8 @@ pub enum Error {
     BadSave,
     #[error("Save file doesn't exist")]
     NoSave,
+    #[error("Download has been cancelled")]
+    Cancelled,
 }
 
 /// This struct contains the necessary components to download and store file as notified by a download file
@@ -222,6 +224,8 @@ impl FileDownloader {
 
                 trace!("Deleting partially downloaded file: {cancellation:?}");
                 state.clean()?;
+
+                return Err(Error::Cancelled);
             },
 
             // NOTE: if download has timedout don't do anything, else ensure errors are forwarded after three retries

--- a/uplink/src/collector/downloader.rs
+++ b/uplink/src/collector/downloader.rs
@@ -210,16 +210,7 @@ impl FileDownloader {
             o = self.continuous_retry(state) => o?,
             // Cancel download on receiving cancel action, e.g. on action timeout
             Ok(action) = self.actions_rx.recv_async() => {
-                if action.name != "cancel-action" {
-                    warn!("Unexpected action: {action:?}");
-                    unreachable!("Only cancel-action should be sent to downloader while it is handling another download!!");
-                }
-
                 let cancellation: Cancellation = serde_json::from_str(&action.payload)?;
-                if cancellation.action_id != self.action_id {
-                    warn!("Unexpected action: {action:?}");
-                    unreachable!("Cancel actions meant for current action only should be sent to downloader!!");
-                }
 
                 trace!("Deleting partially downloaded file: {cancellation:?}");
                 state.clean()?;

--- a/uplink/src/collector/downloader.rs
+++ b/uplink/src/collector/downloader.rs
@@ -594,6 +594,7 @@ mod test {
             actions: vec![ActionRoute {
                 name: "firmware_update".to_owned(),
                 timeout: Duration::from_secs(10),
+                cancellable: true,
             }],
             path,
         };

--- a/uplink/src/collector/process.rs
+++ b/uplink/src/collector/process.rs
@@ -1,5 +1,5 @@
 use flume::{Receiver, RecvError, SendError};
-use log::{debug, error, info, trace, warn};
+use log::{debug, error, info, trace};
 use thiserror::Error;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::{Child, Command};
@@ -82,16 +82,7 @@ impl ProcessHandler {
                 },
                 // Cancel process on receiving cancel action, e.g. on action timeout
                 Ok(action) = self.actions_rx.recv_async() => {
-                    if action.name != "cancel-action" {
-                        warn!("Unexpected action: {action:?}");
-                        unreachable!("Only cancel-actions are acceptable!!");
-                    }
-
                     let cancellation: Cancellation = serde_json::from_str(&action.payload)?;
-                    if cancellation.action_id != action_id {
-                        warn!("Unexpected action: {action:?}");
-                        unreachable!("Cancel actions meant for current action only are acceptable!!");
-                    }
 
                     trace!("Cancelling process: '{}'", cancellation.action_id);
                     let status = ActionResponse::failure(action_id, Error::Cancelled(action.action_id).to_string());

--- a/uplink/src/collector/process.rs
+++ b/uplink/src/collector/process.rs
@@ -1,11 +1,11 @@
 use flume::{Receiver, RecvError, SendError};
-use log::{debug, error, info};
+use log::{debug, error, info, trace, warn};
 use thiserror::Error;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::{Child, Command};
 use tokio::select;
-use tokio::time::timeout_at;
 
+use crate::base::actions::Cancellation;
 use crate::base::bridge::BridgeTx;
 use crate::{Action, ActionResponse, Package};
 
@@ -26,6 +26,8 @@ pub enum Error {
     Busy,
     #[error("No stdout in spawned action")]
     NoStdout,
+    #[error("Process has been cancelled by '{0}'")]
+    Cancelled(String),
 }
 
 /// Process abstracts functions to spawn process and handle their output
@@ -55,24 +57,45 @@ impl ProcessHandler {
     }
 
     /// Capture stdout of the running process in a spawned task
-    pub async fn spawn_and_capture_stdout(&mut self, mut child: Child) -> Result<(), Error> {
+    pub async fn spawn_and_capture_stdout(
+        &mut self,
+        mut child: Child,
+        action_id: &str,
+    ) -> Result<(), Error> {
         let stdout = child.stdout.take().ok_or(Error::NoStdout)?;
         let mut stdout = BufReader::new(stdout).lines();
 
         loop {
             select! {
-                 Ok(Some(line)) = stdout.next_line() => {
+                Ok(Some(line)) = stdout.next_line() => {
                     let status: ActionResponse = match serde_json::from_str(&line) {
                         Ok(status) => status,
-                        Err(e) => ActionResponse::failure("dummy", e.to_string()),
+                        Err(e) => ActionResponse::failure(action_id, e.to_string()),
                     };
 
                     debug!("Action status: {:?}", status);
                     self.bridge_tx.send_action_response(status).await;
-                 }
-                 status = child.wait() => {
+                }
+                status = child.wait() => {
                     info!("Action done!! Status = {:?}", status);
                     return Ok(());
+                },
+                // Cancel process on receiving cancel action, e.g. on action timeout
+                Ok(action) = self.actions_rx.recv_async() => {
+                    if action.name != "cancel-action" {
+                        warn!("Unexpected action: {action:?}");
+                        unreachable!("Only cancel-actions are acceptable!!");
+                    }
+
+                    let cancellation: Cancellation = serde_json::from_str(&action.payload)?;
+                    if cancellation.action_id != action_id {
+                        warn!("Unexpected action: {action:?}");
+                        unreachable!("Cancel actions meant for current action only are acceptable!!");
+                    }
+
+                    trace!("Cancelling process: '{}'", cancellation.action_id);
+                    let status = ActionResponse::failure(action_id, Error::Cancelled(action.action_id).to_string());
+                    self.bridge_tx.send_action_response(status).await;
                 },
             }
         }
@@ -83,21 +106,10 @@ impl ProcessHandler {
         loop {
             let action = self.actions_rx.recv_async().await?;
             let command = format!("tools/{}", action.name);
-            let deadline = match &action.deadline {
-                Some(d) => *d,
-                _ => {
-                    error!("Unconfigured deadline: {}", action.name);
-                    continue;
-                }
-            };
 
             // Spawn the action and capture its stdout, ignore timeouts
             let child = self.run(&action.action_id, &command, &action.payload).await?;
-            if let Ok(o) = timeout_at(deadline, self.spawn_and_capture_stdout(child)).await {
-                o?;
-            } else {
-                error!("Process timedout: {command}; action_id = {}", action.action_id);
-            }
+            self.spawn_and_capture_stdout(child, &action.action_id).await?;
         }
     }
 }

--- a/uplink/src/collector/script_runner.rs
+++ b/uplink/src/collector/script_runner.rs
@@ -90,16 +90,7 @@ impl ScriptRunner {
                 },
                 // Cancel script run on receiving cancel action, e.g. on action timeout
                 Ok(action) = self.actions_rx.recv_async() => {
-                    if action.name != "cancel-action" {
-                        warn!("Unexpected action: {action:?}");
-                        unreachable!("Only cancel-actions are acceptable!!");
-                    }
-
                     let cancellation: Cancellation = serde_json::from_str(&action.payload)?;
-                    if cancellation.action_id != id {
-                        warn!("Unexpected action: {action:?}");
-                        unreachable!("Cancel actions meant for current action only are acceptable!!");
-                    }
 
                     trace!("Cancelling script: '{}'", cancellation.action_id);
                     let status = ActionResponse::failure(id, Error::Cancelled(action.action_id).to_string());

--- a/uplink/src/config.rs
+++ b/uplink/src/config.rs
@@ -215,6 +215,7 @@ pub struct ActionRoute {
     #[serde_as(as = "DurationSeconds<u64>")]
     pub timeout: Duration,
     // Can the action handler cancel actions mid execution?
+    #[serde(default)]
     pub cancellable: bool,
 }
 

--- a/uplink/src/config.rs
+++ b/uplink/src/config.rs
@@ -214,6 +214,8 @@ pub struct ActionRoute {
     #[serde(default = "default_timeout")]
     #[serde_as(as = "DurationSeconds<u64>")]
     pub timeout: Duration,
+    // Can the action handler cancel actions mid execution?
+    pub cancellable: bool,
 }
 
 impl From<&ActionRoute> for ActionRoute {

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -237,8 +237,11 @@ impl Uplink {
     pub fn spawn_builtins(&mut self, bridge: &mut Bridge) -> Result<(), Error> {
         let bridge_tx = bridge.bridge_tx();
 
-        let route =
-            ActionRoute { name: "launch_shell".to_owned(), timeout: Duration::from_secs(10) };
+        let route = ActionRoute {
+            name: "launch_shell".to_owned(),
+            timeout: Duration::from_secs(10),
+            cancellable: false,
+        };
         let actions_rx = bridge.register_action_route(route)?;
         let tunshell_client = TunshellClient::new(actions_rx, bridge_tx.clone());
         spawn_named_thread("Tunshell Client", move || tunshell_client.start());
@@ -258,6 +261,7 @@ impl Uplink {
             let route = ActionRoute {
                 name: "journalctl_config".to_string(),
                 timeout: Duration::from_secs(10),
+                cancellable: false,
             };
             let actions_rx = bridge.register_action_route(route)?;
             let logger = JournalCtl::new(config, actions_rx, bridge_tx.clone());
@@ -273,6 +277,7 @@ impl Uplink {
             let route = ActionRoute {
                 name: "journalctl_config".to_string(),
                 timeout: Duration::from_secs(10),
+                cancellable: false,
             };
             let actions_rx = bridge.register_action_route(route)?;
             let logger = Logcat::new(config, actions_rx, bridge_tx.clone());

--- a/uplink/src/main.rs
+++ b/uplink/src/main.rs
@@ -181,6 +181,21 @@ impl CommandLine {
 
         config.actions_subscription = format!("/tenants/{tenant_id}/devices/{device_id}/actions");
 
+        // downloader actions are cancellable by default
+        for route in config.downloader.actions.iter_mut() {
+            route.cancellable = true;
+        }
+
+        // process actions are cancellable by default
+        for route in config.processes.iter_mut() {
+            route.cancellable = true;
+        }
+
+        // script runner actions are cancellable by default
+        for route in config.script_runner.iter_mut() {
+            route.cancellable = true;
+        }
+
         Ok(config)
     }
 


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->
Action mid execution should be cancellable at one of two places:
1. During execution in a preemptable stage, e.g. while downloading a file(should also delete file created as a result of partial download)
2. At the end of a non-preemptable stage, e.g. at the end of a system-update, but before a restart sequence that would apply the update, this allows the customer to tunshell into the device and make any revertions necessary, but this is just an example and needs more thinking.

As an example of how this can be configured at the application level, downloader is the first built-in to support cancellation, as part of the cancellation procedure, it will also delete a partially downloaded file.

### Why?
<!--Detailed description of why the changes had to be made-->

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
Awaiting backend support for testing