### PR TITLE
fix: delete downloaded file on action timeout

### DIFF
--- a/uplink/src/collector/downloader.rs
+++ b/uplink/src/collector/downloader.rs
@@ -221,7 +221,13 @@ impl FileDownloader {
             // NOTE: if download has timedout don't do anything, else ensure errors are forwarded after three retries
             o = timeout_at(deadline, self.continuous_retry(state)) => match o {
                 Ok(r) => r?,
-                Err(_) => error!("Last download has timedout"),
+                Err(_) => {
+                    // unwrap is safe because download_path is expected to be Some
+                    _ = remove_file(state.current.meta.download_path.as_ref().unwrap());
+                    error!("Last download has timedout; file deleted");
+
+                    return Ok(());
+                },
             }
         }
 

--- a/uplink/src/collector/downloader.rs
+++ b/uplink/src/collector/downloader.rs
@@ -93,6 +93,8 @@ pub enum Error {
     BadSave,
     #[error("Save file doesn't exist")]
     NoSave,
+    #[error("Download timedout")]
+    Timeout,
 }
 
 /// This struct contains the necessary components to download and store file as notified by a download file
@@ -226,7 +228,7 @@ impl FileDownloader {
                     _ = remove_file(state.current.meta.download_path.as_ref().unwrap());
                     error!("Last download has timedout; file deleted");
 
-                    return Ok(());
+                    return Err(Error::Timeout);
                 },
             }
         }


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->

### Why?
<!--Detailed description of why the changes had to be made-->
Partially downloaded files clog up disk

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
Run download action with small timeout in config, but large file contents, use `tree` command to witness the file being created and delted as log line for deletion is also printed by uplink.