### PR TITLE
feat: allow stoppage of downloader to free up network

### DIFF
--- a/uplink/src/collector/downloader.rs
+++ b/uplink/src/collector/downloader.rs
@@ -72,7 +72,8 @@ use std::{io::Write, path::PathBuf};
 
 use crate::{base::bridge::BridgeTx, config::DownloaderConfig, Action, ActionResponse, Config};
 
-pub static STOP_DOWNLOAD: AtomicBool = AtomicBool::new(false);
+// Stops from downloading if true
+pub static DOWNLOADER_DISABLED: AtomicBool = AtomicBool::new(false);
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -256,7 +257,8 @@ impl FileDownloader {
             // Download and store to disk by streaming as chunks
             loop {
                 // Checks if downloader is disabled by user or not
-                if STOP_DOWNLOAD.load(Ordering::Acquire) {
+                if DOWNLOADER_DISABLED.load(Ordering::Acquire) {
+                    // async to ensure download can be cancelled during sleep
                     sleep(Duration::from_secs(1)).await;
                 }
                 let Some(item) = stream.next().await else { break };

--- a/uplink/src/collector/downloader.rs
+++ b/uplink/src/collector/downloader.rs
@@ -260,6 +260,7 @@ impl FileDownloader {
                 if DOWNLOADER_DISABLED.load(Ordering::Acquire) {
                     // async to ensure download can be cancelled during sleep
                     sleep(Duration::from_secs(1)).await;
+                    continue;
                 }
                 let Some(item) = stream.next().await else { break };
                 let chunk = match item {

--- a/uplink/src/console.rs
+++ b/uplink/src/console.rs
@@ -58,7 +58,6 @@ async fn shutdown(State(state): State<StateHandle>) -> impl IntoResponse {
 // Stops downloader from downloading even if it was already stopped
 async fn disable_downloader(State(state): State<StateHandle>) -> impl IntoResponse {
     info!("Downloader stopped");
-    // Shouldn't panic as always sets to true
     let mut is_disabled = state.downloader_disable.lock().unwrap();
     if *is_disabled {
         StatusCode::ACCEPTED
@@ -71,7 +70,6 @@ async fn disable_downloader(State(state): State<StateHandle>) -> impl IntoRespon
 // Start downloader back up even if it was already not stopped
 async fn enable_downloader(State(state): State<StateHandle>) -> impl IntoResponse {
     info!("Downloader started");
-    // Shouldn't panic as always sets to true
     let mut is_disabled = state.downloader_disable.lock().unwrap();
     if *state.downloader_disable.lock().unwrap() {
         *is_disabled = false;

--- a/uplink/src/console.rs
+++ b/uplink/src/console.rs
@@ -1,6 +1,12 @@
 use std::sync::atomic::Ordering;
 
-use axum::{extract::State, http::StatusCode, response::IntoResponse, routing::post, Router};
+use axum::{
+    extract::State,
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{post, put},
+    Router,
+};
 use log::info;
 use uplink::{base::CtrlTx, collector::downloader::DOWNLOADER_DISABLED};
 
@@ -20,8 +26,8 @@ pub async fn start(port: u16, reload_handle: ReloadHandle, ctrl_tx: CtrlTx) {
     let app = Router::new()
         .route("/logs", post(reload_loglevel))
         .route("/shutdown", post(shutdown))
-        .route("/disable_downloader", post(disable_downloader))
-        .route("/enable_downloader", post(enable_downloader))
+        .route("/disable_downloader", put(disable_downloader))
+        .route("/enable_downloader", put(enable_downloader))
         .with_state(state);
 
     axum::Server::bind(&address.parse().unwrap()).serve(app.into_make_service()).await.unwrap();

--- a/uplink/src/console.rs
+++ b/uplink/src/console.rs
@@ -59,9 +59,11 @@ async fn shutdown(State(state): State<StateHandle>) -> impl IntoResponse {
 async fn disable_downloader(State(state): State<StateHandle>) -> impl IntoResponse {
     info!("Downloader stopped");
     // Shouldn't panic as always sets to true
-    if *state.downloader_disable.lock().unwrap() {
+    let mut is_disabled = state.downloader_disable.lock().unwrap();
+    if *is_disabled {
         StatusCode::ACCEPTED
     } else {
+        *is_disabled = true;
         StatusCode::OK
     }
 }
@@ -70,7 +72,9 @@ async fn disable_downloader(State(state): State<StateHandle>) -> impl IntoRespon
 async fn enable_downloader(State(state): State<StateHandle>) -> impl IntoResponse {
     info!("Downloader started");
     // Shouldn't panic as always sets to true
+    let mut is_disabled = state.downloader_disable.lock().unwrap();
     if *state.downloader_disable.lock().unwrap() {
+        *is_disabled = false;
         StatusCode::OK
     } else {
         StatusCode::ACCEPTED

--- a/uplink/src/main.rs
+++ b/uplink/src/main.rs
@@ -1,7 +1,7 @@
 mod console;
 
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use anyhow::Error;
@@ -307,7 +307,8 @@ fn main() -> Result<(), Error> {
         _ => None,
     };
 
-    let ctrl_tx = uplink.spawn(bridge)?;
+    let downloader_disable = Arc::new(Mutex::new(false));
+    let ctrl_tx = uplink.spawn(bridge, downloader_disable.clone())?;
 
     if let Some(config) = config.simulator.clone() {
         spawn_named_thread("Simulator", || {
@@ -318,7 +319,9 @@ fn main() -> Result<(), Error> {
     if config.console.enabled {
         let port = config.console.port;
         let ctrl_tx = ctrl_tx.clone();
-        spawn_named_thread("Uplink Console", move || console::start(port, reload_handle, ctrl_tx));
+        spawn_named_thread("Uplink Console", move || {
+            console::start(port, reload_handle, ctrl_tx, downloader_disable)
+        });
     }
 
     let rt = tokio::runtime::Builder::new_current_thread()


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->

### Why?
<!--Detailed description of why the changes had to be made-->
There might be a requirement in the system to disable the downloader in order to prefer other network access events on the system that might otherwise be hindered by large downloads.

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
1. Start uplink
2. Trigger a download action, wait for the download to start on the device
3. Once the download has started, disable downloader with:
```sh
curl -X PUT http://localhost:3333/disable_downloader
```
4. Observe if download continues or if the timeout is short enough, for the action to be timedout.
5. After noticing that download is disabled as expected, enable downloader with:
```sh
curl -X PUT http://localhost:3333/enable_downloader
```
6. Wait for the download to complete as expected.

Observations:
```
  2024-05-03T06:10:17.367319Z TRACE uplink::collector::downloader: Downloading: size = 2 GiB, percentage = 3, elapsed = 13s

  2024-05-03T06:10:17.371487Z TRACE uplink::collector::downloader: Downloading: size = 2 GiB, percentage = 3, elapsed = 13s

  2024-05-03T06:10:17.371670Z TRACE uplink::collector::downloader: Downloading: size = 2 GiB, percentage = 3, elapsed = 13s

  2024-05-03T06:10:17.371776Z TRACE uplink::collector::downloader: Downloading: size = 2 GiB, percentage = 3, elapsed = 13s

  2024-05-03T06:10:17.371832Z  INFO uplink::console: Downloader stopped

  2024-05-03T06:10:17.379613Z TRACE uplink::collector::downloader: Downloading: size = 2 GiB, percentage = 3, elapsed = 13s

  2024-05-03T06:10:24.744384Z  INFO uplink::base::bridge::streams:        action_status: points = 1     batches = 1     latency = 269

  2024-05-03T06:10:24.745014Z DEBUG uplink::base::mqtt: Outgoing = Publish(86)

  2024-05-03T06:10:24.754630Z TRACE uplink::collector::device_shadow: Ping took 10.973ms

  2024-05-03T06:10:24.754845Z TRACE uplink::base::bridge::streams: Initialized stream buffer for device_shadow

  2024-05-03T06:10:24.809573Z DEBUG uplink::base::mqtt: Incoming = PubAck(PubAck { pkid: 86 })

  2024-05-03T06:10:24.914543Z DEBUG uplink::base::mqtt: Outgoing = PingReq

  2024-05-03T06:10:24.968893Z DEBUG uplink::base::mqtt: Incoming = PingResp

  2024-05-03T06:10:24.968965Z  INFO uplink::base::mqtt:                           connected: publishes = 13  pubacks = 13  pingreqs = 1   pingresps = 1   inflight = 0

  2024-05-03T06:10:24.969574Z DEBUG uplink::base::mqtt: Outgoing = Publish(87)

  2024-05-03T06:10:25.020009Z DEBUG uplink::base::mqtt: Incoming = PubAck(PubAck { pkid: 87 })

  2024-05-03T06:10:26.566884Z  INFO uplink::console: Downloader started

  2024-05-03T06:10:27.393013Z TRACE uplink::collector::downloader: Downloading: size = 2 GiB, percentage = 3, elapsed = 23s

  2024-05-03T06:10:27.393574Z TRACE uplink::collector::downloader: Downloading: size = 2 GiB, percentage = 3, elapsed = 23s

  2024-05-03T06:10:27.393873Z TRACE uplink::collector::downloader: Downloading: size = 2 GiB, percentage = 3, elapsed = 23s

  2024-05-03T06:10:27.394200Z TRACE uplink::collector::downloader: Downloading: size = 2 GiB, percentage = 3, elapsed = 23s

  2024-05-03T06:10:27.394501Z TRACE uplink::collector::downloader: Downloading: size = 2 GiB, percentage = 3, elapsed = 23s
```