### PR TITLE
fix: duration in seconds missing fractions

### DIFF
--- a/uplink/src/base/monitor/mod.rs
+++ b/uplink/src/base/monitor/mod.rs
@@ -80,7 +80,9 @@ impl Monitor {
                                 continue;
                             }
                             serializer_stream_metrics.push(o);
+                            dbg!(&serializer_stream_metrics);
                             let v = serde_json::to_string(&serializer_stream_metrics).unwrap();
+                            dbg!(&v);
                             serializer_stream_metrics.clear();
                             self.client.publish(&serializer_stream_metrics_topic, QoS::AtLeastOnce, false, v).await.unwrap();
                         }

--- a/uplink/src/base/serializer/metrics.rs
+++ b/uplink/src/base/serializer/metrics.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use serde::Serialize;
-use serde_with::{serde_as, DurationSeconds};
+use serde_with::{serde_as, DurationSecondsWithFrac};
 
 use crate::base::clock;
 
@@ -113,15 +113,15 @@ pub struct StreamMetrics {
     pub compressed_data_size: usize,
     #[serde(skip)]
     pub serializations: u32,
-    #[serde_as(as = "DurationSeconds<f64>")]
+    #[serde_as(as = "DurationSecondsWithFrac<f64>")]
     pub total_serialization_time: Duration,
-    #[serde_as(as = "DurationSeconds<f64>")]
+    #[serde_as(as = "DurationSecondsWithFrac<f64>")]
     pub avg_serialization_time: Duration,
     #[serde(skip)]
     pub compressions: u32,
-    #[serde_as(as = "DurationSeconds<f64>")]
+    #[serde_as(as = "DurationSecondsWithFrac<f64>")]
     pub total_compression_time: Duration,
-    #[serde_as(as = "DurationSeconds<f64>")]
+    #[serde_as(as = "DurationSecondsWithFrac<f64>")]
     pub avg_compression_time: Duration,
 }
 


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->

### Why?
<!--Detailed description of why the changes had to be made-->
Fractional part of time is missing on serialization

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
JS payload after change:
```js
{
  "timestamp": 1715249644559,
  "sequence": 13,
  "stream": "bms",
  "serialized_data_size": 133510,
  "compressed_data_size": 133510,
  "total_serialization_time": 0.022287279,
  "avg_serialization_time": 0.001714406,
  "total_compression_time": 0.0,
  "avg_compression_time": 0.0
}
```