### PR TITLE
fix: bad file descriptor

### DIFF
--- a/uplink/src/collector/downloader.rs
+++ b/uplink/src/collector/downloader.rs
@@ -450,7 +450,7 @@ impl DownloadState {
         // Calculate deadline based on written time left
         current.action.deadline = current.time_left.map(|t| Instant::now() + t);
 
-        let file = File::open(current.meta.download_path.as_ref().unwrap())?;
+        let file = File::options().append(true).open(current.meta.download_path.as_ref().unwrap())?;
         let bytes_written = file.metadata()?.len() as usize;
 
         remove_file(path)?;


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->

### Why?
<!--Detailed description of why the changes had to be made-->
Download always fails post uplink restart due to lack of write permissions as file is opened read-only

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
1. Start uplink
2. Trigger download action
3. Restart uplink
4. Wait for action to complete (would have immediately failed earlier, but now succeeds)