### PR TITLE
fix: mark parallel actions as failed on restart

### DIFF
--- a/uplink/src/base/serializer/mod.rs
+++ b/uplink/src/base/serializer/mod.rs
@@ -140,12 +140,15 @@ struct StorageHandler {
 impl StorageHandler {
     fn new(config: Arc<Config>) -> Result<Self, Error> {
         let mut map = BTreeMap::new();
-        for (stream_name, stream_config) in config.streams.iter() {
+        let mut streams = config.streams.clone();
+        // NOTE: persist action_status if not configured otherwise
+        streams.insert("action_status".into(), config.action_status.clone());
+        for (stream_name, stream_config) in streams {
             let mut storage =
                 Storage::new(&stream_config.topic, stream_config.persistence.max_file_size);
             if stream_config.persistence.max_file_count > 0 {
                 let mut path = config.persistence_path.clone();
-                path.push(stream_name);
+                path.push(&stream_name);
 
                 std::fs::create_dir_all(&path).map_err(|_| {
                     Error::Persistence(config.persistence_path.to_string_lossy().to_string())

--- a/uplink/src/main.rs
+++ b/uplink/src/main.rs
@@ -48,6 +48,7 @@ const DEFAULT_CONFIG: &str = r#"
     topic = "/tenants/{tenant_id}/devices/{device_id}/action/status"
     batch_size = 1
     flush_period = 2
+    persistence = { max_file_count = 1 } # Ensures action responses are not lost on restarts
     priority = 255 # highest priority for quick delivery of action status info to platform
 
     [streams.device_shadow]


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Why?
<!--Detailed description of why the changes had to be made-->
- Uplink loses track of all action status when network is down and uplink restarts
- Uplink loses track of parallel actions on a restart

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
Start uplink and trigger a launch_shell, restart uplink before the action reaches 100% progress
![image](https://github.com/bytebeamio/uplink/assets/18750864/c558cb1e-e2fb-4672-9ec5-db33c69e8e27)
