### PR TITLE
feat: support json uplink configs

### DIFF
--- a/configs/config.json
+++ b/configs/config.json
@@ -1,0 +1,105 @@
+{
+  "processes": [
+    {
+      "name": "echo",
+      "timeout": 10
+    }
+  ],
+
+  "action_redirections": {
+    "firmware_update": "install_update",
+    "send_file": "load_file",
+    "send_script": "run_script"
+  },
+
+  "persistence_path": "/tmp/uplink/",
+
+  "default_buf_size": 1024,
+
+  "mqtt": {
+    "max_packet_size": 256000,
+    "max_inflight": 100,
+    "keep_alive": 30,
+    "network_timeout": 30
+  },
+
+  "tcpapps": {
+    "1": {
+      "port": 5050,
+      "actions": [
+        {
+          "name": "install_update"
+        },
+        {
+          "name": "load_file"
+        }
+      ]
+    },
+    "2": {
+      "port": 6060,
+      "actions": []
+    }
+  },
+
+  "serializer_metrics": {
+    "enabled": true
+  },
+
+  "stream_metrics": {
+    "enabled": true,
+    "blacklist": ["cancollector_metrics", "candump_metrics", "pinger"]
+  },
+
+  "streams": {
+    "device_shadow": {
+      "topic": "/tenants/{tenant_id}/devices/{device_id}/events/device_shadow/jsonarray",
+      "flush_period": 5,
+      "priority": 75
+    },
+    "imu": {
+      "topic": "/tenants/{tenant_id}/devices/{device_id}/events/imu/jsonarray/lz4",
+      "batch_size": 100,
+      "compression": "Lz4",
+      "priority": 50
+    },
+    "gps": {
+      "topic": "/tenants/{tenant_id}/devices/{device_id}/events/gps/jsonarray",
+      "batch_size": 10,
+      "persistence": { "max_file_size": 1048576, "max_file_count": 10 }
+    },
+    "motor": {
+      "topic": "/tenants/{tenant_id}/devices/{device_id}/events/motor/jsonarray/lz4",
+      "batch_size": 50,
+      "compression": "Lz4",
+      "persistence": { "max_file_count": 3 }
+    }
+  },
+
+  "action_status": {
+    "topic": "/tenants/{tenant_id}/devices/{device_id}/action/status",
+    "flush_period": 2,
+    "priority": 255
+  },
+
+  "downloader": {
+    "actions": [
+      { "name": "update_firmware" },
+      { "name": "send_file", "timeout": 10 },
+      { "name": "send_script" }
+    ],
+    "path": "/var/tmp/ota-file"
+  },
+
+  "system_stats": {
+    "enabled": false,
+    "process_names": ["uplink"],
+    "update_period": 30
+  },
+
+  "console": {
+    "enabled": true,
+    "port": 3333
+  },
+
+  "device_shadow": { "interval": 30 }
+}

--- a/uplink/src/main.rs
+++ b/uplink/src/main.rs
@@ -108,7 +108,17 @@ impl CommandLine {
                     path.display()
                 ))
             })?;
-            config = config.add_source(File::from_str(&read, FileFormat::Toml));
+            let file_format = match path.extension() {
+                Some(e) if e == "json" => FileFormat::Json,
+                Some(e) if e == "toml" => FileFormat::Toml,
+                _ => {
+                    return Err(Error::msg(format!(
+                        "Auth file couldn't be loaded from {:?}; unsupported file extension",
+                        path.display(),
+                    )))
+                }
+            };
+            config = config.add_source(File::from_str(&read, file_format));
         }
 
         let auth = read_to_string(&self.auth).map_err(|e| {

--- a/uplink/src/main.rs
+++ b/uplink/src/main.rs
@@ -113,7 +113,7 @@ impl CommandLine {
                 Some(e) if e == "toml" => FileFormat::Toml,
                 _ => {
                     return Err(Error::msg(format!(
-                        "Auth file couldn't be loaded from {:?}; unsupported file extension",
+                        "Config file couldn't be loaded from {:?}; supported file extensions: [`.json`,`.toml`]",
                         path.display(),
                     )))
                 }


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->

### Why?
<!--Detailed description of why the changes had to be made-->
`update_uplink_config`

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
Started uplink with both toml and json versions of config, both work exactly as expected.
1. Start uplink with config file without/unexpected extension:
```
Error: Auth file couldn't be loaded from "uplink.config"; supported file extensions: [`.json`,`.toml`]
```
2. Start uplink with `config.toml`/`config.json`, observed that behavior is the same no matter JSON or TOML but it works