### PR TITLE
fix: ignore corrupted `current_action` file

### DIFF
--- a/uplink/src/base/bridge/actions_lane.rs
+++ b/uplink/src/base/bridge/actions_lane.rs
@@ -153,7 +153,9 @@ impl ActionsBridge {
     pub async fn start(&mut self) -> Result<(), Error> {
         let mut metrics_timeout = interval(self.config.stream_metrics.timeout);
         let mut end: Pin<Box<Sleep>> = Box::pin(time::sleep(Duration::from_secs(u64::MAX)));
-        self.load_saved_action()?;
+        if let Err(e) = self.load_saved_action() {
+            error!("Couldn't load saved action: {e}");
+        }
 
         loop {
             select! {


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->

### Why?
<!--Detailed description of why the changes had to be made-->

### Trials Performed

Restart uplink after corrupting the contents of persistence/current_action.
- Observed previously that the following log would be printed and the errors would be faced when trying to receive actions or send action updates.
```
  [2m2024-10-09T14:47:22.615790Z[0m [31mERROR[0m [1;31muplink[0m[31m: [31mActions lane stopped!! Error = Serde error EOF while parsing a value at line 1 column 0[0m
```
- Observed after change that errors no longer occurred after the updated log saying:
```
  [2m2024-10-09T20:57:62.215291Z[0m [31mERROR[0m [1;31muplink::base::actions_lane[0m[31m: [31mCouldn't load saved action: Serde error EOF while parsing a value at line 1 column 0[0m
```