### PR TITLE
feat: `Serializer` pushes latest data first if configured to do so

### DIFF
--- a/configs/config.toml
+++ b/configs/config.toml
@@ -20,6 +20,11 @@ default_buf_size = 1024 # 1KB
 # Maximum number of data streams that can be accepted by uplink
 max_stream_count = 10
 
+# All streams will first push the latest packet before pushing historical data in
+# FIFO order, defaults to false. This solves the problem of bad networks leading to
+# data being pushed so slow that it is practically impossible to track the device.
+live_data_first = true
+
 # MQTT client configuration
 #
 # Required Parameters

--- a/configs/config.toml
+++ b/configs/config.toml
@@ -23,7 +23,7 @@ max_stream_count = 10
 # All streams will first push the latest packet before pushing historical data in
 # FIFO order, defaults to false. This solves the problem of bad networks leading to
 # data being pushed so slow that it is practically impossible to track the device.
-live_data_first = true
+default_live_data_first = true
 
 # MQTT client configuration
 #
@@ -89,13 +89,19 @@ blacklist = ["cancollector_metrics", "candump_metrics", "pinger"]
 #   used when there is a network/system failure.
 # - priority(optional, u8): Higher prioirity streams get to push their data
 #   onto the network first.
+# - live_data_first(optional, bool): All streams will first push the latest packet
+#   before pushing historical data in FIFO order, defaults to false. This solves the
+#   problem of bad networks leading to data being pushed so slow that it is practically
+#   impossible to track the device.
 #
 # In the following config for the device_shadow stream we set batch_size to 1 and mark
-# it as non-persistent. streams are internally constructed as a map of Name -> Config
+# it as non-persistent, also setting up live_data_first to enable quick delivery of stats.
+# Streams are internally constructed as a map of Name -> Config
 [streams.device_shadow]
 topic = "/tenants/{tenant_id}/devices/{device_id}/events/device_shadow/jsonarray"
 flush_period = 5
 priority = 75
+live_data_first = true
 
 # Example using compression
 [streams.imu]

--- a/uplink/src/base/serializer/mod.rs
+++ b/uplink/src/base/serializer/mod.rs
@@ -233,7 +233,7 @@ impl StorageHandler {
             let mut storage = Storage::new(
                 &stream_config.topic,
                 stream_config.persistence.max_file_size,
-                config.live_data_first,
+                stream_config.live_data_first,
             );
             if stream_config.persistence.max_file_count > 0 {
                 let mut path = config.persistence_path.clone();
@@ -264,7 +264,7 @@ impl StorageHandler {
                 Storage::new(
                     &stream.topic,
                     self.config.default_buf_size,
-                    self.config.live_data_first,
+                    self.config.default_live_data_first,
                 )
             })
             .write(publish)

--- a/uplink/src/base/serializer/mod.rs
+++ b/uplink/src/base/serializer/mod.rs
@@ -183,10 +183,8 @@ impl Storage {
     // ## Panic
     // When any packet other than a publish is deserialized.
     pub fn read(&mut self, max_packet_size: usize) -> Option<Publish> {
-        if self.live_data_first && self.latest_data.is_some() {
-            return self.latest_data.take();
-        } else if self.latest_data.is_some() {
-            warn!("Latest data should be unoccupied if not using the live data first scheme");
+        if let Some(publish) = self.latest_data.take() {
+            return Some(publish);
         }
 
         // TODO(RT): This can fail when packet sizes > max_payload_size in config are written to disk.

--- a/uplink/src/config.rs
+++ b/uplink/src/config.rs
@@ -536,6 +536,8 @@ pub struct Config {
     pub logging: Option<LogcatConfig>,
     pub precondition_checks: Option<PreconditionCheckerConfig>,
     pub bus: Option<BusConfig>,
+    #[serde(default)]
+    pub live_data_first: bool,
 }
 
 impl Config {

--- a/uplink/src/config.rs
+++ b/uplink/src/config.rs
@@ -93,6 +93,8 @@ pub struct StreamConfig {
     pub persistence: Persistence,
     #[serde(default)]
     pub priority: u8,
+    #[serde(default)]
+    pub live_data_first: bool,
 }
 
 impl Default for StreamConfig {
@@ -104,6 +106,7 @@ impl Default for StreamConfig {
             compression: Compression::Disabled,
             persistence: Persistence::default(),
             priority: 0,
+            live_data_first: false,
         }
     }
 }
@@ -537,7 +540,7 @@ pub struct Config {
     pub precondition_checks: Option<PreconditionCheckerConfig>,
     pub bus: Option<BusConfig>,
     #[serde(default)]
-    pub live_data_first: bool,
+    pub default_live_data_first: bool,
 }
 
 impl Config {

--- a/uplink/tests/serializer.rs
+++ b/uplink/tests/serializer.rs
@@ -4,7 +4,7 @@ use bytes::Bytes;
 use flume::bounded;
 use rumqttc::{Publish, QoS, Request};
 use tempdir::TempDir;
-use tokio::{runtime::Runtime, spawn};
+use tokio::{runtime::Runtime, spawn, time::sleep};
 
 use uplink::{
     base::{bridge::Payload, serializer::Serializer},
@@ -83,18 +83,18 @@ async fn preferential_send_on_network() {
     };
 
     // write packets for one, two and top onto disk
-    let mut one = Storage::new("topic/one", 1024 * 1024);
+    let mut one = Storage::new("topic/one", 1024 * 1024, false);
     one.set_persistence(persistence_path(&config.persistence_path, "one"), 1).unwrap();
     one.write(publish("topic/one".to_string(), 4)).unwrap();
     one.write(publish("topic/one".to_string(), 5)).unwrap();
     one.flush().unwrap();
 
-    let mut two = Storage::new("topic/two", 1024 * 1024);
+    let mut two = Storage::new("topic/two", 1024 * 1024, false);
     two.set_persistence(persistence_path(&config.persistence_path, "two"), 1).unwrap();
     two.write(publish("topic/two".to_string(), 3)).unwrap();
     two.flush().unwrap();
 
-    let mut top = Storage::new("topic/top", 1024 * 1024);
+    let mut top = Storage::new("topic/top", 1024 * 1024, false);
     top.set_persistence(persistence_path(&config.persistence_path, "top"), 1).unwrap();
     top.write(publish("topic/top".to_string(), 1)).unwrap();
     top.write(publish("topic/top".to_string(), 2)).unwrap();
@@ -215,4 +215,56 @@ async fn fifo_data_push() {
     };
     assert_eq!(topic, "topic/default");
     assert_eq!(payload, "[{\"sequence\":2,\"timestamp\":0,\"msg\":\"Hello, World!\"}]");
+}
+
+#[tokio::test]
+// Ensures that live data is pushed first if configured to do so
+async fn prefer_live_data() {
+    let mut config = Config::default();
+    config.default_buf_size = 1024 * 1024;
+    config.mqtt.max_packet_size = 1024 * 1024;
+    config.live_data_first = true;
+    let config = Arc::new(config);
+    let (data_tx, data_rx) = bounded(0);
+    let (net_tx, req_rx) = bounded(0);
+    let (metrics_tx, _metrics_rx) = bounded(1);
+    let client = MockClient { net_tx };
+    let serializer = Serializer::new(config, data_rx, client, metrics_tx).unwrap();
+
+    // start serializer in the background
+    thread::spawn(|| _ = Runtime::new().unwrap().block_on(serializer.start()));
+
+    spawn(async {
+        let mut default = MockCollector::new(
+            "default",
+            StreamConfig { topic: "topic/default".to_owned(), batch_size: 1, ..Default::default() },
+            data_tx,
+        );
+        for i in 0.. {
+            default.send(i).await.unwrap();
+            sleep(Duration::from_millis(250)).await;
+        }
+    });
+
+    sleep(Duration::from_millis(750)).await;
+    let Request::Publish(Publish { topic, payload, .. }) = req_rx.recv_async().await.unwrap()
+    else {
+        unreachable!()
+    };
+    assert_eq!(topic, "topic/default");
+    assert_eq!(payload, "[{\"sequence\":0,\"timestamp\":0,\"msg\":\"Hello, World!\"}]");
+
+    let Request::Publish(Publish { topic, payload, .. }) = req_rx.recv_async().await.unwrap()
+    else {
+        unreachable!()
+    };
+    assert_eq!(topic, "topic/default");
+    assert_eq!(payload, "[{\"sequence\":2,\"timestamp\":0,\"msg\":\"Hello, World!\"}]");
+
+    let Request::Publish(Publish { topic, payload, .. }) = req_rx.recv_async().await.unwrap()
+    else {
+        unreachable!()
+    };
+    assert_eq!(topic, "topic/default");
+    assert_eq!(payload, "[{\"sequence\":1,\"timestamp\":0,\"msg\":\"Hello, World!\"}]");
 }

--- a/uplink/tests/serializer.rs
+++ b/uplink/tests/serializer.rs
@@ -223,7 +223,7 @@ async fn prefer_live_data() {
     let mut config = Config::default();
     config.default_buf_size = 1024 * 1024;
     config.mqtt.max_packet_size = 1024 * 1024;
-    config.live_data_first = true;
+    config.default_live_data_first = true;
     let config = Arc::new(config);
     let (data_tx, data_rx) = bounded(0);
     let (net_tx, req_rx) = bounded(0);


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->
[Design doc](https://docs.google.com/document/d/1P5L38mc9UgYeKn0ZyxQSXQGUJQr_OLTZRfq6bntz-mw/edit?usp=sharing)

### Changes
<!--Detailed description of changes made-->
When configured with the following configuration variable, serializer will push latest packet if it hasn't already before pushing older data in FIFO order from storage:
```toml
live_data_first = true
```

### Why?
<!--Detailed description of why the changes had to be made-->
This will ensure that customers aren't frustrated by extremely slow data push, which makes it practically impossible to track the device.

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
Added test to ensure `Serializer` working is as expected.