### PR TITLE
fix: persist contents of read buffer if required

### DIFF
--- a/uplink/src/base/serializer/mod.rs
+++ b/uplink/src/base/serializer/mod.rs
@@ -205,8 +205,7 @@ impl Storage {
         if let Some(mut publish) = self.latest_data.take() {
             publish.pkid = 1;
             if let Err(e) = publish.write(self.inner.writer()) {
-                error!("Failed to fill disk buffer. Error = {e}");
-                return Ok(None);
+                error!("Failed to serialize into write buffer. Error = {e}");
             }
         }
 

--- a/uplink/tests/serializer.rs
+++ b/uplink/tests/serializer.rs
@@ -87,18 +87,18 @@ async fn preferential_send_on_network() {
     one.set_persistence(persistence_path(&config.persistence_path, "one"), 1).unwrap();
     one.write(publish("topic/one".to_string(), 4)).unwrap();
     one.write(publish("topic/one".to_string(), 5)).unwrap();
-    one.flush().unwrap();
+    one.flush();
 
     let mut two = Storage::new("topic/two", 1024 * 1024);
     two.set_persistence(persistence_path(&config.persistence_path, "two"), 1).unwrap();
     two.write(publish("topic/two".to_string(), 3)).unwrap();
-    two.flush().unwrap();
+    two.flush();
 
     let mut top = Storage::new("topic/top", 1024 * 1024);
     top.set_persistence(persistence_path(&config.persistence_path, "top"), 1).unwrap();
     top.write(publish("topic/top".to_string(), 1)).unwrap();
     top.write(publish("topic/top".to_string(), 2)).unwrap();
-    top.flush().unwrap();
+    top.flush();
 
     let config = Arc::new(config);
     let (data_tx, data_rx) = bounded(1);


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->

### Why?
<!--Detailed description of why the changes had to be made-->
Data in the `current_read_file` buffer is lost in a particular edge case, where read buffer has data swapped from write buffer, but flush doesn't care if it came from write buffer or persistence folder, leading to it getting chucked when the service is restarted.

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->
Added a test to verify behavior