### PR TITLE
fix: unset `clean_session`

### DIFF
--- a/uplink/src/base/mqtt/mod.rs
+++ b/uplink/src/base/mqtt/mod.rs
@@ -297,6 +297,7 @@ fn mqttoptions(config: &Config, device_config: &DeviceConfig) -> MqttOptions {
     mqttoptions.set_max_packet_size(config.mqtt.max_packet_size, config.mqtt.max_packet_size);
     mqttoptions.set_keep_alive(Duration::from_secs(config.mqtt.keep_alive));
     mqttoptions.set_inflight(config.mqtt.max_inflight);
+    mqttoptions.set_clean_session(false);
 
     if let Some(auth) = device_config.authentication.clone() {
         let ca = auth.ca_certificate.into_bytes();


### PR DESCRIPTION
Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->

### Why?
<!--Detailed description of why the changes had to be made-->
To ensure that no data is lost as a result of inflight being unacknowledged during a network failure/restart.

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->