### PR TITLE
fix: Ignore saved data for different tenant

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ WORKDIR "/usr/share/bytebeam/uplink"
 COPY uplink/ uplink
 COPY storage/ storage
 COPY tools/utils/ tools/utils
-COPY Cargo.* .
+COPY tools/system-stats/ tools/system-stats
+COPY Cargo.* ./
 COPY .git/ .git
 
 RUN mkdir -p /usr/share/bytebeam/uplink/bin

--- a/tools/utils/src/push_data.rs
+++ b/tools/utils/src/push_data.rs
@@ -10,10 +10,15 @@ struct ShadowPayload {
     stream: String,
     sequence: u32,
     timestamp: u64,
-    a: bool,
-    b: bool,
-    c: bool,
-    d: String,
+    can_id: u32,
+    byte1: u8,
+    byte2: u8,
+    byte3: u8,
+    byte4: u8,
+    byte5: u8,
+    byte6: u8,
+    byte7: u8,
+    byte8: u8,
 }
 
 #[tokio::main]
@@ -25,17 +30,21 @@ async fn main() {
         idx += 1;
         // calculate and send consecutive squares
         let data = ShadowPayload {
-            stream: "device_shadow".to_string(),
+            stream: "c2c_can".to_string(),
             sequence: idx,
             timestamp: SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis() as u64,
-            a: idx % 2 == 0,
-            b: idx % 3 == 0,
-            c: idx % 5 == 0,
-            d: idx.to_string(),
+            can_id: idx % 1024,
+            byte1: ((idx + 0) % 256) as u8,
+            byte2: ((idx + 1) % 256) as u8,
+            byte3: ((idx + 2) % 256) as u8,
+            byte4: ((idx + 3) % 256) as u8,
+            byte5: ((idx + 4) % 256) as u8,
+            byte6: ((idx + 5) % 256) as u8,
+            byte7: ((idx + 6) % 256) as u8,
+            byte8: ((idx + 7) % 256) as u8,
         };
         let data_s = serde_json::to_string(&data).unwrap();
-        println!("Sending: {data_s}");
         framed.send(data_s).await.unwrap();
-        sleep(Duration::from_secs(3)).await;
+        sleep(Duration::from_micros(500)).await;
     }
 }

--- a/uplink/src/base/serializer/mod.rs
+++ b/uplink/src/base/serializer/mod.rs
@@ -920,7 +920,7 @@ pub mod tests {
         let (metrics_tx, _metrics_rx) = bounded(1);
         let client = MockClient { net_tx };
 
-        (Serializer::new(config, data_rx, client, metrics_tx).unwrap(), data_tx, net_rx)
+        (Serializer::new(config, String::new(), data_rx, client, metrics_tx).unwrap(), data_tx, net_rx)
     }
 
     #[tokio::test]

--- a/uplink/src/base/serializer/mod.rs
+++ b/uplink/src/base/serializer/mod.rs
@@ -7,7 +7,7 @@ use std::{sync::Arc, time::Duration};
 
 use bytes::Bytes;
 use flume::{bounded, Receiver, RecvError, Sender, TrySendError};
-use log::{debug, error, info, trace};
+use log::{debug, error, info, trace, warn};
 use lz4_flex::frame::FrameEncoder;
 use rumqttc::*;
 use storage::Storage;
@@ -280,6 +280,7 @@ pub struct Serializer<C: MqttClient> {
     /// Control handles
     ctrl_rx: Receiver<SerializerShutdown>,
     ctrl_tx: Sender<SerializerShutdown>,
+    tenant_filter: String,
 }
 
 impl<C: MqttClient> Serializer<C> {
@@ -287,6 +288,7 @@ impl<C: MqttClient> Serializer<C> {
     /// the handle to an MQTT client(This is constructed as such for testing purposes) and a handle to update serailizer metrics.
     pub fn new(
         config: Arc<Config>,
+        tenant_filter: String,
         collector_rx: Receiver<Box<dyn Package>>,
         client: C,
         metrics_tx: Sender<SerializerMetrics>,
@@ -296,6 +298,7 @@ impl<C: MqttClient> Serializer<C> {
 
         Ok(Serializer {
             config,
+            tenant_filter,
             collector_rx,
             client,
             storage_handler,
@@ -447,7 +450,14 @@ impl<C: MqttClient> Serializer<C> {
         // TODO(RT): This can fail when packet sizes > max_payload_size in config are written to disk.
         // This leads to force switching to normal mode. Increasing max_payload_size to bypass this
         let publish = match Packet::read(storage.reader(), max_packet_size) {
-            Ok(Packet::Publish(publish)) => publish,
+            Ok(Packet::Publish(publish)) => {
+                if publish.topic.starts_with(&self.tenant_filter) {
+                    publish
+                } else {
+                    warn!("found data for wrong tenant in persistence!");
+                    return Ok(Status::EventLoopReady);
+                }
+            },
             Ok(packet) => unreachable!("Unexpected packet: {:?}", packet),
             Err(e) => {
                 self.metrics.increment_errors();
@@ -504,7 +514,14 @@ impl<C: MqttClient> Serializer<C> {
                     };
 
                     let publish = match Packet::read(storage.reader(), max_packet_size) {
-                        Ok(Packet::Publish(publish)) => publish,
+                        Ok(Packet::Publish(publish)) => {
+                            if publish.topic.starts_with(&self.tenant_filter) {
+                                publish
+                            } else {
+                                warn!("found data for wrong tenant in persistence!!");
+                                continue;
+                            }
+                        },
                         Ok(packet) => unreachable!("Unexpected packet: {:?}", packet),
                         Err(e) => {
                             error!("Failed to read from storage. Forcing into Normal mode. Error = {e}");

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -153,8 +153,10 @@ impl Uplink {
         let mqtt_client = mqtt.client();
         let ctrl_mqtt = mqtt.ctrl_tx();
 
+        let tenant_filter = format!("/tenants/{}/", device_config.project_id);
         let serializer = Serializer::new(
             self.config.clone(),
+            tenant_filter,
             self.data_rx.clone(),
             mqtt_client.clone(),
             self.serializer_metrics_tx(),

--- a/uplink/tests/serializer.rs
+++ b/uplink/tests/serializer.rs
@@ -105,7 +105,7 @@ async fn preferential_send_on_network() {
     let (net_tx, req_rx) = bounded(1);
     let (metrics_tx, _metrics_rx) = bounded(1);
     let client = MockClient { net_tx };
-    let serializer = Serializer::new(config, data_rx, client, metrics_tx).unwrap();
+    let serializer = Serializer::new(config, String::new(), data_rx, client, metrics_tx).unwrap();
 
     // start serializer in the background
     spawn(async { serializer.start().await.unwrap() });


### PR DESCRIPTION
Closes #<!--Issue Number-->


### Changes
When pushing persisted data to broker, make sure that it is for the right tenant, otherwise drop it.

### Why?
Persisted data can cause problems if device is reprovisioned.

### Trials Performed
* Tests in QA document
* Forced uplink to save data to persistence, stopped uplink, reprovisioned device, and restarted it. Uplink dropped stale data in persistence.