### PR TITLE
fix: ensure that file data is written to disk

### DIFF
--- a/uplink/src/base/serializer/storage.rs
+++ b/uplink/src/base/serializer/storage.rs
@@ -490,7 +490,7 @@ impl<'a> PersistenceFile<'a> {
         let hash = seahash::hash(&buf[..]);
         file.write_all(&hash.to_be_bytes())?;
         file.write_all(&buf[..])?;
-        file.flush()?;
+        file.sync_data()?;
 
         Ok(())
     }


### PR DESCRIPTION
ref: https://doc.rust-lang.org/std/fs/struct.File.html#method.sync_data

As pointed out in https://stackoverflow.com/a/69820437, this could help ensure the OS has also written files to disk before the OS progresses with restarting the service.

Closes #<!--Issue Number-->

<!--Brief description of the purpose behind opening the PR-->

### Changes
<!--Detailed description of changes made-->

### Why?
<!--Detailed description of why the changes had to be made-->

### Trials Performed
<!--Detailed description of testing methodology used to validate behavioral changes and observations made as a result-->